### PR TITLE
Split schema: core activity domain

### DIFF
--- a/schemas/components/schemas/AllTime.yaml
+++ b/schemas/components/schemas/AllTime.yaml
@@ -1,0 +1,21 @@
+type: object
+required:
+  - total_seconds
+  - text
+  - digital
+  - is_up_to_date
+properties:
+  total_seconds:
+    type: number
+    format: double
+  text:
+    type: string
+    description: Human readable (e.g., '1,250 hrs 30 mins')
+  digital:
+    type: string
+  is_up_to_date:
+    type: boolean
+  range:
+    $ref: ./TimeRange.yaml
+  project:
+    type: string

--- a/schemas/components/schemas/Category.yaml
+++ b/schemas/components/schemas/Category.yaml
@@ -1,0 +1,18 @@
+type: string
+enum:
+  - coding
+  - building
+  - indexing
+  - debugging
+  - browsing
+  - running tests
+  - writing tests
+  - manual testing
+  - writing docs
+  - communicating
+  - code reviewing
+  - notes
+  - researching
+  - learning
+  - designing
+  - ai coding

--- a/schemas/components/schemas/CumulativeTotal.yaml
+++ b/schemas/components/schemas/CumulativeTotal.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  seconds:
+    type: number
+    format: double
+  text:
+    type: string
+  digital:
+    type: string

--- a/schemas/components/schemas/DailyAverage.yaml
+++ b/schemas/components/schemas/DailyAverage.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  seconds:
+    type: number
+    format: double
+  text:
+    type: string

--- a/schemas/components/schemas/Duration.yaml
+++ b/schemas/components/schemas/Duration.yaml
@@ -1,0 +1,28 @@
+type: object
+required:
+  - project
+  - time
+  - duration
+properties:
+  project:
+    type: string
+  time:
+    type: number
+    format: double
+    description: Start time as UNIX epoch
+  duration:
+    type: number
+    format: double
+    description: Duration in seconds
+  color:
+    type: string
+  entity:
+    type: string
+  language:
+    type: string
+  branch:
+    type: string
+  category:
+    $ref: ./Category.yaml
+  machine:
+    type: string

--- a/schemas/components/schemas/Heartbeat.yaml
+++ b/schemas/components/schemas/Heartbeat.yaml
@@ -1,0 +1,19 @@
+allOf:
+  - $ref: ./HeartbeatInput.yaml
+  - type: object
+    required:
+      - id
+      - user_id
+      - created_at
+    properties:
+      id:
+        type: string
+      user_id:
+        type: string
+      machine:
+        type: string
+      user_agent_id:
+        type: string
+      created_at:
+        type: string
+        format: date-time

--- a/schemas/components/schemas/HeartbeatInput.yaml
+++ b/schemas/components/schemas/HeartbeatInput.yaml
@@ -1,0 +1,48 @@
+type: object
+required:
+  - entity
+  - type
+  - time
+properties:
+  entity:
+    type: string
+    description: File path, app name, or domain
+  type:
+    type: string
+    enum:
+      - file
+      - app
+      - domain
+  time:
+    type: number
+    format: double
+    description: UNIX epoch timestamp
+  category:
+    $ref: ./Category.yaml
+  project:
+    type: string
+  project_root_count:
+    type: integer
+  branch:
+    type: string
+  language:
+    type: string
+  dependencies:
+    type: string
+    description: Comma-separated dependency names
+  lines:
+    type: integer
+  ai_line_changes:
+    type: integer
+  human_line_changes:
+    type: integer
+  lineno:
+    type: integer
+  cursorpos:
+    type: integer
+  is_write:
+    type: boolean
+  editor:
+    type: string
+  operating_system:
+    type: string

--- a/schemas/components/schemas/Stats.yaml
+++ b/schemas/components/schemas/Stats.yaml
@@ -1,0 +1,72 @@
+type: object
+properties:
+  total_seconds:
+    type: number
+    format: double
+  total_seconds_including_other_language:
+    type: number
+    format: double
+  daily_average:
+    type: number
+    format: double
+  daily_average_including_other_language:
+    type: number
+    format: double
+  human_readable_total:
+    type: string
+  human_readable_total_including_other_language:
+    type: string
+  human_readable_daily_average:
+    type: string
+  human_readable_daily_average_including_other_language:
+    type: string
+  categories:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  projects:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  languages:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  editors:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  operating_systems:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  dependencies:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  machines:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  best_day:
+    type: object
+    properties:
+      date:
+        type: string
+        format: date
+      total_seconds:
+        type: number
+        format: double
+      text:
+        type: string
+  range:
+    $ref: ./TimeRange.yaml
+  status:
+    type: string
+    enum:
+      - ok
+      - pending_update
+  is_already_updating:
+    type: boolean
+  is_up_to_date:
+    type: boolean

--- a/schemas/components/schemas/Summary.yaml
+++ b/schemas/components/schemas/Summary.yaml
@@ -1,0 +1,45 @@
+type: object
+required:
+  - grand_total
+  - range
+properties:
+  grand_total:
+    $ref: ./GrandTotal.yaml
+  categories:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  projects:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  languages:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  editors:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  operating_systems:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  dependencies:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  machines:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  branches:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  entities:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+  range:
+    $ref: ./TimeRange.yaml

--- a/schemas/components/schemas/SummaryRange.yaml
+++ b/schemas/components/schemas/SummaryRange.yaml
@@ -1,0 +1,12 @@
+type: string
+enum:
+  - Today
+  - Yesterday
+  - Last 7 Days
+  - Last 7 Days from Yesterday
+  - Last 14 Days
+  - Last 30 Days
+  - This Week
+  - Last Week
+  - This Month
+  - Last Month

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -87,6 +87,26 @@ paths:
   /users/current/data_dumps:
     $ref: paths/users/data-dumps.yaml
 
+  # --- heartbeats ---
+  /users/current/heartbeats:
+    $ref: paths/heartbeats/heartbeats.yaml
+  /users/current/heartbeats.bulk:
+    $ref: paths/heartbeats/heartbeats-bulk.yaml
+
+  # --- summaries ---
+  /users/current/summaries:
+    $ref: paths/summaries/summaries.yaml
+
+  # --- stats & durations ---
+  /users/current/stats/{range}:
+    $ref: paths/stats/stats.yaml
+  /users/current/status_bar/today:
+    $ref: paths/stats/status-bar.yaml
+  /users/current/all_time_since_today:
+    $ref: paths/stats/all-time.yaml
+  /users/current/durations:
+    $ref: paths/stats/durations.yaml
+
   # --- meta ---
   /health:
     $ref: paths/meta/health.yaml

--- a/schemas/paths/heartbeats/heartbeats-bulk.yaml
+++ b/schemas/paths/heartbeats/heartbeats-bulk.yaml
@@ -1,0 +1,61 @@
+post:
+  operationId: createHeartbeatsBulk
+  tags:
+    - heartbeats
+  summary: Create up to 25 heartbeats at once
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: ../../components/schemas/HeartbeatInput.yaml
+          maxItems: 25
+  responses:
+    '202':
+      description: Heartbeats accepted
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - responses
+            properties:
+              responses:
+                type: array
+                items:
+                  type: array
+                  prefixItems:
+                    - $ref: ../../components/schemas/Heartbeat.yaml
+                    - type: integer
+                      description: HTTP status code
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+delete:
+  operationId: deleteHeartbeatsBulk
+  tags:
+    - heartbeats
+  summary: Delete heartbeats
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - date
+            - ids
+          properties:
+            date:
+              type: string
+              format: date
+            ids:
+              type: array
+              items:
+                type: string
+  responses:
+    '204':
+      description: Heartbeats deleted
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/heartbeats/heartbeats.yaml
+++ b/schemas/paths/heartbeats/heartbeats.yaml
@@ -1,0 +1,54 @@
+get:
+  operationId: getHeartbeats
+  tags:
+    - heartbeats
+  summary: List heartbeats for a given day
+  parameters:
+    - name: date
+      in: query
+      required: true
+      schema:
+        type: string
+        format: date
+        example: '2026-03-09'
+  responses:
+    '200':
+      description: List of heartbeats
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../components/schemas/Heartbeat.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+post:
+  operationId: createHeartbeat
+  tags:
+    - heartbeats
+  summary: Create a single heartbeat
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/HeartbeatInput.yaml
+  responses:
+    '201':
+      description: Heartbeat created
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Heartbeat.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/stats/all-time.yaml
+++ b/schemas/paths/stats/all-time.yaml
@@ -1,0 +1,24 @@
+get:
+  operationId: getAllTimeSinceToday
+  tags:
+    - all_time
+  summary: Total coding time since account creation
+  parameters:
+    - name: project
+      in: query
+      schema:
+        type: string
+  responses:
+    '200':
+      description: All time data
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/AllTime.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/stats/durations.yaml
+++ b/schemas/paths/stats/durations.yaml
@@ -1,0 +1,73 @@
+get:
+  operationId: getDurations
+  tags:
+    - durations
+  summary: Coding durations for a day (heartbeats joined by timeout)
+  parameters:
+    - name: date
+      in: query
+      required: true
+      schema:
+        type: string
+        format: date
+    - name: project
+      in: query
+      schema:
+        type: string
+    - name: branches
+      in: query
+      schema:
+        type: string
+    - name: timeout
+      in: query
+      schema:
+        type: integer
+    - name: writes_only
+      in: query
+      schema:
+        type: boolean
+    - name: timezone
+      in: query
+      schema:
+        type: string
+    - name: slice_by
+      in: query
+      schema:
+        type: string
+        enum:
+          - project
+          - entity
+          - language
+          - dependencies
+          - operating_system
+          - editor
+          - category
+          - machine
+  responses:
+    '200':
+      description: List of durations
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../components/schemas/Duration.yaml
+              branches:
+                type: array
+                items:
+                  type: string
+              start:
+                type: string
+                format: date
+              end:
+                type: string
+                format: date
+              timezone:
+                type: string
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/stats/stats.yaml
+++ b/schemas/paths/stats/stats.yaml
@@ -1,0 +1,47 @@
+get:
+  operationId: getStats
+  tags:
+    - stats
+  summary: Coding statistics for a time range
+  parameters:
+    - name: range
+      in: path
+      required: true
+      schema:
+        type: string
+        description: >-
+          last_7_days, last_30_days, last_6_months, last_year, all_time, or YYYY
+          / YYYY-MM
+    - name: timeout
+      in: query
+      schema:
+        type: integer
+    - name: writes_only
+      in: query
+      schema:
+        type: boolean
+  responses:
+    '200':
+      description: Statistics
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Stats.yaml
+    '202':
+      description: Stats are still being calculated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: ../../components/schemas/Stats.yaml
+              message:
+                type: string
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/stats/status-bar.yaml
+++ b/schemas/paths/stats/status-bar.yaml
@@ -1,0 +1,25 @@
+get:
+  operationId: getStatusBarToday
+  tags:
+    - status_bar
+  summary: Today's coding activity for IDE status bars
+  description: >-
+    Cached version of summaries for today. Returns empty summary while cache
+    updates.
+  responses:
+    '200':
+      description: Today's status bar data
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Summary.yaml
+              cached_at:
+                type: string
+                format: date-time
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/summaries/summaries.yaml
+++ b/schemas/paths/summaries/summaries.yaml
@@ -1,0 +1,73 @@
+get:
+  operationId: getSummaries
+  tags:
+    - summaries
+  summary: Coding activity summaries for a date range
+  parameters:
+    - name: start
+      in: query
+      description: Required if range is not provided. Use with end.
+      schema:
+        type: string
+        format: date
+    - name: end
+      in: query
+      description: Required if range is not provided. Use with start.
+      schema:
+        type: string
+        format: date
+    - name: range
+      in: query
+      description: >-
+        Predefined range (alternative to start/end). One of start+end or range
+        is required.
+      schema:
+        $ref: ../../components/schemas/SummaryRange.yaml
+    - name: project
+      in: query
+      schema:
+        type: string
+    - name: branches
+      in: query
+      description: Comma-separated branch names
+      schema:
+        type: string
+    - name: timeout
+      in: query
+      description: Keystroke timeout in minutes
+      schema:
+        type: integer
+    - name: writes_only
+      in: query
+      schema:
+        type: boolean
+    - name: timezone
+      in: query
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Daily summaries
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../components/schemas/Summary.yaml
+              start:
+                type: string
+                format: date
+              end:
+                type: string
+                format: date
+              cumulative_total:
+                $ref: ../../components/schemas/CumulativeTotal.yaml
+              daily_average:
+                $ref: ../../components/schemas/DailyAverage.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml


### PR DESCRIPTION
## Summary
- Add heartbeat ingestion endpoints (single and bulk)
- Add daily coding summaries endpoint
- Add coding statistics, status bar, all-time totals, and duration endpoints
- Add component schemas: Category, HeartbeatInput, Heartbeat, Summary, SummaryRange, CumulativeTotal, DailyAverage, Duration, Stats, AllTime

## Files
- 2 path files in `schemas/paths/heartbeats/`
- 1 path file in `schemas/paths/summaries/`
- 4 path files in `schemas/paths/stats/`
- 10 component schemas in `schemas/components/schemas/`

## Test plan
- [x] `npm run lint:api` passes
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)