### PR TITLE
Implement stats route handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import type { Env } from "./types";
 import heartbeats from "./routes/heartbeats";
 import summaries from "./routes/summaries";
+import stats from "./routes/stats";
 import { aggregateHeartbeats } from "./cron/aggregate";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -17,6 +18,9 @@ app.route("/api/v1/users/current", heartbeats);
 
 // Summary routes (mounted at /users/current, sub-app defines /summaries)
 app.route("/api/v1/users/current", summaries);
+
+// Stats routes (mounted at /users/current, sub-app defines /stats, /status_bar, /all_time_since_today, /durations)
+app.route("/api/v1/users/current", stats);
 
 // Cron trigger handler for periodic aggregation
 export default {

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,305 @@
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { formatDigital, formatHumanReadable } from "../utils/time-format";
+import { resolveStatsRange } from "../utils/stats-range";
+import { buildSummary, aggregateDimension, DIMENSIONS, DIMENSION_TO_KEY, type SummaryRow } from "../utils/summary-builder";
+
+type Stats = components["schemas"]["Stats"];
+type AllTime = components["schemas"]["AllTime"];
+type Duration = components["schemas"]["Duration"];
+type Summary = components["schemas"]["Summary"];
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const stats = new Hono<AuthEnv>();
+
+stats.use("/*", authMiddleware);
+
+// ─── Helpers ──────────────────────────────────────────────
+
+async function checkUpToDate(db: D1Database): Promise<boolean> {
+  const row = await db
+    .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
+    .first<{ value: string }>();
+  const lastAggregatedAt = row ? Number(row.value) : 0;
+  return (Date.now() / 1000 - lastAggregatedAt) < 7200;
+}
+
+// ─── GET /stats/:range ───────────────────────────────────
+
+stats.get("/stats/:range", async (c) => {
+  const rangeParam = c.req.param("range");
+  const resolved = resolveStatsRange(rangeParam);
+  if (!resolved) {
+    return c.json({ error: "Invalid range. Use: last_7_days, last_30_days, last_6_months, last_year, all_time, YYYY, or YYYY-MM" }, 400);
+  }
+
+  const userId = c.get("userId");
+
+  const sql = `SELECT date, project, language, editor, operating_system, category, branch, machine, total_seconds
+    FROM summaries WHERE user_id = ? AND date >= ? AND date <= ?`;
+  const { results } = await c.env.DB.prepare(sql)
+    .bind(userId, resolved.start, resolved.end)
+    .all<SummaryRow>();
+
+  // Total seconds
+  let totalSeconds = 0;
+  for (const row of results) {
+    totalSeconds += row.total_seconds;
+  }
+
+  // Days in range
+  const startMs = new Date(resolved.start + "T00:00:00Z").getTime();
+  const endMs = new Date(resolved.end + "T00:00:00Z").getTime();
+  const daysInRange = Math.max(1, Math.floor((endMs - startMs) / 86400000) + 1);
+  const dailyAverage = totalSeconds / daysInRange;
+
+  // Dimension breakdowns (across all dates)
+  const dimensionItems: Record<string, ReturnType<typeof aggregateDimension>> = {};
+  for (const dim of DIMENSIONS) {
+    dimensionItems[DIMENSION_TO_KEY[dim]] = aggregateDimension(results, dim, totalSeconds);
+  }
+
+  // Best day
+  const dailyTotals = new Map<string, number>();
+  for (const row of results) {
+    dailyTotals.set(row.date, (dailyTotals.get(row.date) ?? 0) + row.total_seconds);
+  }
+
+  let bestDay: { date?: string; total_seconds?: number; text?: string } | undefined;
+  let bestDaySeconds = 0;
+  for (const [date, seconds] of dailyTotals) {
+    if (seconds > bestDaySeconds) {
+      bestDaySeconds = seconds;
+      bestDay = { date, total_seconds: seconds, text: formatHumanReadable(seconds) };
+    }
+  }
+
+  const isUpToDate = await checkUpToDate(c.env.DB);
+
+  const data: Stats = {
+    total_seconds: totalSeconds,
+    total_seconds_including_other_language: totalSeconds,
+    daily_average: dailyAverage,
+    daily_average_including_other_language: dailyAverage,
+    human_readable_total: formatHumanReadable(totalSeconds),
+    human_readable_total_including_other_language: formatHumanReadable(totalSeconds),
+    human_readable_daily_average: formatHumanReadable(dailyAverage),
+    human_readable_daily_average_including_other_language: formatHumanReadable(dailyAverage),
+    ...dimensionItems,
+    dependencies: [],
+    best_day: bestDay,
+    range: {
+      start: `${resolved.start}T00:00:00Z`,
+      end: `${resolved.end}T23:59:59Z`,
+      text: resolved.text,
+      timezone: "UTC",
+    },
+    status: isUpToDate ? "ok" : "pending_update",
+    is_already_updating: false,
+    is_up_to_date: isUpToDate,
+  };
+
+  return c.json({ data }, isUpToDate ? 200 : 202);
+});
+
+// ─── GET /status_bar/today ───────────────────────────────
+
+stats.get("/status_bar/today", async (c) => {
+  const userId = c.get("userId");
+  const cacheKey = `statusbar:${userId}`;
+
+  // Check KV cache
+  const cached = await c.env.KV.get(cacheKey, "json") as { data: Summary; cached_at: string } | null;
+  if (cached) {
+    return c.json(cached);
+  }
+
+  // Query today's summaries
+  const today = new Date().toISOString().slice(0, 10);
+  const sql = `SELECT date, project, language, editor, operating_system, category, branch, machine, total_seconds
+    FROM summaries WHERE user_id = ? AND date = ?`;
+  const { results } = await c.env.DB.prepare(sql)
+    .bind(userId, today)
+    .all<SummaryRow>();
+
+  const summary = buildSummary(today, results);
+  const response = { data: summary, cached_at: new Date().toISOString() };
+
+  await c.env.KV.put(cacheKey, JSON.stringify(response), { expirationTtl: 60 });
+
+  return c.json(response);
+});
+
+// ─── GET /all_time_since_today ───────────────────────────
+
+stats.get("/all_time_since_today", async (c) => {
+  const userId = c.get("userId");
+  const project = c.req.query("project");
+
+  let sql = "SELECT COALESCE(SUM(total_seconds), 0) as total_seconds, MIN(date) as first_date FROM summaries WHERE user_id = ?";
+  const params: (string | number)[] = [userId];
+
+  if (project) {
+    sql += " AND project = ?";
+    params.push(project);
+  }
+
+  const row = await c.env.DB.prepare(sql)
+    .bind(...params)
+    .first<{ total_seconds: number; first_date: string | null }>();
+
+  const totalSeconds = row?.total_seconds ?? 0;
+  const today = new Date().toISOString().slice(0, 10);
+  const firstDate = row?.first_date ?? today;
+  const isUpToDate = await checkUpToDate(c.env.DB);
+
+  const data: AllTime = {
+    total_seconds: totalSeconds,
+    text: formatHumanReadable(totalSeconds),
+    digital: formatDigital(totalSeconds),
+    is_up_to_date: isUpToDate,
+    range: {
+      start: `${firstDate}T00:00:00Z`,
+      end: `${today}T23:59:59Z`,
+      text: "All Time",
+      timezone: "UTC",
+    },
+    ...(project ? { project } : {}),
+  };
+
+  return c.json({ data });
+});
+
+// ─── GET /durations ──────────────────────────────────────
+
+type HeartbeatRow = {
+  time: number;
+  entity: string;
+  project: string | null;
+  language: string | null;
+  branch: string | null;
+  category: string | null;
+  machine: string | null;
+  editor: string | null;
+  operating_system: string | null;
+  is_write: number;
+};
+
+stats.get("/durations", async (c) => {
+  const date = c.req.query("date");
+  if (!date || !DATE_RE.test(date)) {
+    return c.json({ error: "Valid date parameter (YYYY-MM-DD) is required" }, 400);
+  }
+
+  const userId = c.get("userId");
+  const project = c.req.query("project");
+  const branchesParam = c.req.query("branches");
+  const sliceBy = c.req.query("slice_by") ?? "project";
+
+  // Convert date to UNIX epoch range
+  const dayStart = Date.UTC(
+    parseInt(date.slice(0, 4)),
+    parseInt(date.slice(5, 7)) - 1,
+    parseInt(date.slice(8, 10)),
+  ) / 1000;
+  const dayEnd = dayStart + 86400;
+
+  // Build query
+  let sql = `SELECT time, entity, project, language, branch, category, machine, editor, operating_system, is_write
+    FROM heartbeats WHERE user_id = ? AND time >= ? AND time < ?`;
+  const params: (string | number)[] = [userId, dayStart, dayEnd];
+
+  if (project) {
+    sql += " AND project = ?";
+    params.push(project);
+  }
+
+  if (branchesParam) {
+    const branchList = branchesParam.split(",").map((b) => b.trim()).filter(Boolean);
+    if (branchList.length > 0) {
+      sql += ` AND branch IN (${branchList.map(() => "?").join(", ")})`;
+      params.push(...branchList);
+    }
+  }
+
+  sql += " ORDER BY time ASC";
+
+  // Fetch heartbeats and user timeout in parallel
+  const [heartbeatsResult, userRow] = await Promise.all([
+    c.env.DB.prepare(sql).bind(...params).all<HeartbeatRow>(),
+    c.env.DB.prepare("SELECT timeout FROM users WHERE id = ?").bind(userId).first<{ timeout: number }>(),
+  ]);
+
+  const heartbeats = heartbeatsResult.results;
+  const timeout = (userRow?.timeout ?? 15) * 60; // minutes to seconds
+
+  // Build duration segments
+  const durations: Duration[] = [];
+  const branchSet = new Set<string>();
+
+  if (heartbeats.length > 0) {
+    let segStart = heartbeats[0];
+    let segDuration = 0;
+
+    for (let i = 1; i < heartbeats.length; i++) {
+      const curr = heartbeats[i];
+      const gap = curr.time - heartbeats[i - 1].time;
+      const sliceChanged = getSliceValue(curr, sliceBy) !== getSliceValue(segStart, sliceBy);
+
+      if (gap > timeout || sliceChanged) {
+        // Emit previous segment
+        durations.push(buildDuration(segStart, segDuration));
+        segStart = curr;
+        segDuration = 0;
+      } else {
+        segDuration += gap;
+      }
+
+      if (curr.branch) branchSet.add(curr.branch);
+    }
+
+    // Emit final segment
+    durations.push(buildDuration(segStart, segDuration));
+    if (segStart.branch) branchSet.add(segStart.branch);
+  }
+
+  return c.json({
+    data: durations,
+    branches: Array.from(branchSet).sort(),
+    start: date,
+    end: date,
+    timezone: "UTC",
+  });
+});
+
+function getSliceValue(hb: HeartbeatRow, sliceBy: string): string {
+  switch (sliceBy) {
+    case "entity": return hb.entity ?? "";
+    case "language": return hb.language ?? "";
+    case "dependencies": return "";
+    case "operating_system": return hb.operating_system ?? "";
+    case "editor": return hb.editor ?? "";
+    case "category": return hb.category ?? "";
+    case "machine": return hb.machine ?? "";
+    case "project":
+    default: return hb.project ?? "";
+  }
+}
+
+function buildDuration(hb: HeartbeatRow, duration: number): Duration {
+  return {
+    project: hb.project ?? "Unknown",
+    time: hb.time,
+    duration,
+    entity: hb.entity,
+    language: hb.language ?? undefined,
+    branch: hb.branch ?? undefined,
+    category: (hb.category as Duration["category"]) ?? undefined,
+    machine: hb.machine ?? undefined,
+  };
+}
+
+export default stats;

--- a/src/routes/summaries.ts
+++ b/src/routes/summaries.ts
@@ -3,37 +3,11 @@ import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
 import { resolveDateRange, formatDigital, formatHumanReadable } from "../utils/time-format";
+import { buildSummary, type SummaryRow } from "../utils/summary-builder";
 
 type Summary = components["schemas"]["Summary"];
-type SummaryItem = components["schemas"]["SummaryItem"];
-type GrandTotal = components["schemas"]["GrandTotal"];
 type CumulativeTotal = components["schemas"]["CumulativeTotal"];
 type DailyAverage = components["schemas"]["DailyAverage"];
-
-type SummaryRow = {
-  date: string;
-  project: string | null;
-  language: string | null;
-  editor: string | null;
-  operating_system: string | null;
-  category: string | null;
-  branch: string | null;
-  machine: string | null;
-  total_seconds: number;
-};
-
-const DIMENSIONS = ["project", "language", "editor", "operating_system", "category", "branch", "machine"] as const;
-type Dimension = (typeof DIMENSIONS)[number];
-
-const DIMENSION_TO_KEY: Record<Dimension, string> = {
-  project: "projects",
-  language: "languages",
-  editor: "editors",
-  operating_system: "operating_systems",
-  category: "categories",
-  branch: "branches",
-  machine: "machines",
-};
 
 const MAX_BRANCHES = 25;
 const MAX_DAYS = 366;
@@ -129,66 +103,6 @@ summaries.get("/summaries", async (c) => {
     return c.json({ error: "Internal server error" }, 500);
   }
 });
-
-function buildSummary(date: string, rows: SummaryRow[]): Summary {
-  // Grand total = sum of all rows' total_seconds for this date
-  let grandTotalSeconds = 0;
-  for (const row of rows) {
-    grandTotalSeconds += row.total_seconds;
-  }
-
-  const grand_total: GrandTotal = {
-    total_seconds: grandTotalSeconds,
-    digital: formatDigital(grandTotalSeconds),
-    text: formatHumanReadable(grandTotalSeconds),
-    hours: Math.floor(grandTotalSeconds / 3600),
-    minutes: Math.floor((grandTotalSeconds % 3600) / 60),
-  };
-
-  // Aggregate each dimension
-  const dimensionItems: Record<string, SummaryItem[]> = {};
-  for (const dim of DIMENSIONS) {
-    dimensionItems[DIMENSION_TO_KEY[dim]] = aggregateDimension(rows, dim, grandTotalSeconds);
-  }
-
-  return {
-    grand_total,
-    range: {
-      date,
-      start: `${date}T00:00:00Z`,
-      end: `${date}T23:59:59Z`,
-      text: date,
-      timezone: "UTC",
-    },
-    ...dimensionItems,
-    entities: [],
-    dependencies: [],
-  };
-}
-
-function aggregateDimension(rows: SummaryRow[], dimension: Dimension, grandTotal: number): SummaryItem[] {
-  const totals = new Map<string, number>();
-  for (const row of rows) {
-    const name = row[dimension] || "Unknown";
-    totals.set(name, (totals.get(name) ?? 0) + row.total_seconds);
-  }
-
-  // Sort descending by total_seconds
-  const items = Array.from(totals.entries())
-    .sort((a, b) => b[1] - a[1])
-    .map(([name, total_seconds]): SummaryItem => ({
-      name,
-      total_seconds,
-      percent: grandTotal > 0 ? Math.round((total_seconds / grandTotal) * 10000) / 100 : 0,
-      digital: formatDigital(total_seconds),
-      text: formatHumanReadable(total_seconds),
-      hours: Math.floor(total_seconds / 3600),
-      minutes: Math.floor((total_seconds % 3600) / 60),
-      seconds: Math.floor(total_seconds % 60),
-    }));
-
-  return items;
-}
 
 function generateDateRange(start: string, end: string): string[] {
   const dates: string[] = [];

--- a/src/utils/stats-range.ts
+++ b/src/utils/stats-range.ts
@@ -1,0 +1,53 @@
+import { formatDate, addDays } from "./time-format";
+
+export function resolveStatsRange(range: string): { start: string; end: string; text: string } | null {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+  switch (range) {
+    case "last_7_days":
+      return { start: formatDate(addDays(today, -6)), end: formatDate(today), text: "last 7 days" };
+
+    case "last_30_days":
+      return { start: formatDate(addDays(today, -29)), end: formatDate(today), text: "last 30 days" };
+
+    case "last_6_months": {
+      const sixMonthsAgo = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 6, today.getUTCDate()));
+      return { start: formatDate(sixMonthsAgo), end: formatDate(today), text: "last 6 months" };
+    }
+
+    case "last_year": {
+      const oneYearAgo = new Date(Date.UTC(today.getUTCFullYear() - 1, today.getUTCMonth(), today.getUTCDate()));
+      return { start: formatDate(oneYearAgo), end: formatDate(today), text: "last year" };
+    }
+
+    case "all_time":
+      return { start: "1970-01-01", end: formatDate(today), text: "all time" };
+
+    default:
+      break;
+  }
+
+  // YYYY format (full year)
+  if (/^\d{4}$/.test(range)) {
+    const year = parseInt(range, 10);
+    return {
+      start: `${range}-01-01`,
+      end: `${range}-12-31`,
+      text: String(year),
+    };
+  }
+
+  // YYYY-MM format (specific month)
+  if (/^\d{4}-\d{2}$/.test(range)) {
+    const [y, m] = range.split("-").map(Number);
+    const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate();
+    return {
+      start: `${range}-01`,
+      end: `${range}-${String(lastDay).padStart(2, "0")}`,
+      text: range,
+    };
+  }
+
+  return null;
+}

--- a/src/utils/summary-builder.ts
+++ b/src/utils/summary-builder.ts
@@ -1,0 +1,86 @@
+import type { components } from "../types/generated";
+import { formatDigital, formatHumanReadable } from "./time-format";
+
+type Summary = components["schemas"]["Summary"];
+type SummaryItem = components["schemas"]["SummaryItem"];
+type GrandTotal = components["schemas"]["GrandTotal"];
+
+export type SummaryRow = {
+  date: string;
+  project: string | null;
+  language: string | null;
+  editor: string | null;
+  operating_system: string | null;
+  category: string | null;
+  branch: string | null;
+  machine: string | null;
+  total_seconds: number;
+};
+
+export const DIMENSIONS = ["project", "language", "editor", "operating_system", "category", "branch", "machine"] as const;
+export type Dimension = (typeof DIMENSIONS)[number];
+
+export const DIMENSION_TO_KEY: Record<Dimension, string> = {
+  project: "projects",
+  language: "languages",
+  editor: "editors",
+  operating_system: "operating_systems",
+  category: "categories",
+  branch: "branches",
+  machine: "machines",
+};
+
+export function buildSummary(date: string, rows: SummaryRow[]): Summary {
+  let grandTotalSeconds = 0;
+  for (const row of rows) {
+    grandTotalSeconds += row.total_seconds;
+  }
+
+  const grand_total: GrandTotal = {
+    total_seconds: grandTotalSeconds,
+    digital: formatDigital(grandTotalSeconds),
+    text: formatHumanReadable(grandTotalSeconds),
+    hours: Math.floor(grandTotalSeconds / 3600),
+    minutes: Math.floor((grandTotalSeconds % 3600) / 60),
+  };
+
+  const dimensionItems: Record<string, SummaryItem[]> = {};
+  for (const dim of DIMENSIONS) {
+    dimensionItems[DIMENSION_TO_KEY[dim]] = aggregateDimension(rows, dim, grandTotalSeconds);
+  }
+
+  return {
+    grand_total,
+    range: {
+      date,
+      start: `${date}T00:00:00Z`,
+      end: `${date}T23:59:59Z`,
+      text: date,
+      timezone: "UTC",
+    },
+    ...dimensionItems,
+    entities: [],
+    dependencies: [],
+  };
+}
+
+export function aggregateDimension(rows: SummaryRow[], dimension: Dimension, grandTotal: number): SummaryItem[] {
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const name = row[dimension] || "Unknown";
+    totals.set(name, (totals.get(name) ?? 0) + row.total_seconds);
+  }
+
+  return Array.from(totals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, total_seconds]): SummaryItem => ({
+      name,
+      total_seconds,
+      percent: grandTotal > 0 ? Math.round((total_seconds / grandTotal) * 10000) / 100 : 0,
+      digital: formatDigital(total_seconds),
+      text: formatHumanReadable(total_seconds),
+      hours: Math.floor(total_seconds / 3600),
+      minutes: Math.floor((total_seconds % 3600) / 60),
+      seconds: Math.floor(total_seconds % 60),
+    }));
+}

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -39,12 +39,12 @@ function parseDate(date: string): Date | null {
 }
 
 /** Format a Date as YYYY-MM-DD in UTC */
-function formatDate(d: Date): string {
+export function formatDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
 /** Add days to a Date (returns new Date) */
-function addDays(d: Date, days: number): Date {
+export function addDays(d: Date, days: number): Date {
   return new Date(d.getTime() + days * 86400000);
 }
 


### PR DESCRIPTION
## Summary
- Add four new endpoints: `GET /stats/:range`, `GET /status_bar/today`, `GET /all_time_since_today`, `GET /durations`
- Extract `buildSummary`/`aggregateDimension` into shared `src/utils/summary-builder.ts` for reuse across summaries and stats handlers
- Add `src/utils/stats-range.ts` to resolve stats-specific range strings (`last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `all_time`, `YYYY`, `YYYY-MM`)

## Endpoints

| Endpoint | Data source | Description |
|----------|-------------|-------------|
| `GET /stats/:range` | summaries table | Aggregated stats with dimension breakdowns, best_day, daily_average, is_up_to_date |
| `GET /status_bar/today` | summaries + KV | Today's summary for IDE status bars (KV cached, 60s TTL) |
| `GET /all_time_since_today` | summaries table | Total coding time with optional `?project=` filter |
| `GET /durations` | heartbeats table | Duration segments using timeout algorithm with `slice_by` support |

## Test plan
- [ ] `GET /stats/last_7_days` returns Stats with dimension breakdowns
- [ ] `GET /stats/2026-03` returns Stats for March 2026
- [ ] `GET /status_bar/today` returns today's Summary; second call returns cached_at
- [ ] `GET /all_time_since_today` returns total seconds across all time
- [ ] `GET /all_time_since_today?project=foo` returns total filtered by project
- [ ] `GET /durations?date=2026-03-09` returns Duration segments for the day
- [ ] All endpoints return 401 without auth
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)