### PR TITLE
Extract shared checkUpToDate helper

### DIFF
--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -5,6 +5,7 @@ import { EDITORS } from "../data/editors";
 import { LANGUAGES } from "../data/languages";
 import { resolveStatsRange } from "../utils/stats-range";
 import { formatDigital, formatHumanReadable } from "../utils/time-format";
+import { checkUpToDate } from "../utils/aggregation-status";
 
 type GlobalStats = components["schemas"]["GlobalStats"];
 type SummaryItem = components["schemas"]["SummaryItem"];
@@ -12,16 +13,6 @@ type SummaryItem = components["schemas"]["SummaryItem"];
 declare const __APP_VERSION__: string;
 
 const meta = new Hono<{ Bindings: Env }>();
-
-// ─── Helpers ──────────────────────────────────────────────
-
-async function checkUpToDate(db: D1Database): Promise<boolean> {
-  const row = await db
-    .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
-    .first<{ value: string }>();
-  const lastAggregatedAt = row ? Number(row.value) : 0;
-  return (Date.now() / 1000 - lastAggregatedAt) < 7200;
-}
 
 // ─── GET /meta ────────────────────────────────────────────
 

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -5,6 +5,7 @@ import { authMiddleware } from "../middleware/auth";
 import { formatDigital, formatHumanReadable } from "../utils/time-format";
 import { resolveStatsRange } from "../utils/stats-range";
 import { buildSummary, aggregateDimension, DIMENSIONS, DIMENSION_TO_KEY, type SummaryRow } from "../utils/summary-builder";
+import { checkUpToDate } from "../utils/aggregation-status";
 
 type Stats = components["schemas"]["Stats"];
 type AllTime = components["schemas"]["AllTime"];
@@ -16,16 +17,6 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const stats = new Hono<AuthEnv>();
 
 stats.use("/*", authMiddleware);
-
-// ─── Helpers ──────────────────────────────────────────────
-
-async function checkUpToDate(db: D1Database): Promise<boolean> {
-  const row = await db
-    .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
-    .first<{ value: string }>();
-  const lastAggregatedAt = row ? Number(row.value) : 0;
-  return (Date.now() / 1000 - lastAggregatedAt) < 7200;
-}
 
 // ─── GET /stats/:range ───────────────────────────────────
 

--- a/src/utils/aggregation-status.ts
+++ b/src/utils/aggregation-status.ts
@@ -1,0 +1,10 @@
+/**
+ * Check if heartbeat aggregation is recent (within 2 hours).
+ */
+export async function checkUpToDate(db: D1Database): Promise<boolean> {
+  const row = await db
+    .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
+    .first<{ value: string }>();
+  const lastAggregatedAt = row ? Number(row.value) : 0;
+  return (Date.now() / 1000 - lastAggregatedAt) < 7200;
+}


### PR DESCRIPTION
## Summary
- Extract duplicated `checkUpToDate` function from `stats.ts` and `meta.ts` into a shared `src/utils/aggregation-status.ts` module
- Both route files now import from the shared utility instead of defining their own copy
- Pure refactoring — no logic, API, or schema changes

Closes #22

## Test plan
- [x] `npx tsc --noEmit` passes with no type errors
- [x] No local `checkUpToDate` definitions remain in `src/routes/`
- [x] Single definition exists in `src/utils/aggregation-status.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)