### PR TITLE
Restrict CORS origin to APP_URL for session auth

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,18 @@ import { aggregateHeartbeats } from "./cron/aggregate";
 
 const app = new Hono<{ Bindings: Env }>();
 
+// CORS configuration for browser-based clients.
+// NOTE: CORS is a browser-only protection — curl/Postman/server-side requests
+// ignore CORS headers entirely. Actual access control is enforced by authMiddleware
+// (API key) and session validation, not by CORS.
+// NOTE: Hono's CORS middleware sends `Access-Control-Allow-Credentials: true`
+// even when the origin function returns null (rejecting the origin). Browsers
+// still block the response because `Access-Control-Allow-Origin` is omitted,
+// so this is not exploitable, but security scanners may flag it.
+// Assumes same-origin deployment (frontend and API share APP_URL origin).
+// Session cookies use SameSite=Lax which prevents cross-origin fetch from
+// sending cookies — only top-level navigation GETs include them. If a
+// cross-origin frontend is needed, SameSite=None must be considered.
 app.use(
   "/*",
   cors({
@@ -27,7 +39,7 @@ app.use(
       }
     },
     credentials: true,
-    allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allowMethods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
     allowHeaders: ["Content-Type", "Authorization"],
     maxAge: 86400,
   }),


### PR DESCRIPTION
## Summary
- Replace wildcard `cors()` with origin-restricted configuration
- When `APP_URL` is set: only allow requests from that origin (compared by `URL.origin`)
- When `APP_URL` is unset: fail closed in production, reflect any origin only in `ENVIRONMENT=development`
- Enable `credentials: true` so browsers send session cookies
- Explicitly list allowed methods (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`)
- Explicitly list allowed headers (`Content-Type`, `Authorization`)
- Set preflight cache (`maxAge`) to 24h to reduce OPTIONS requests

## Design assumptions
- **Same-origin deployment**: Frontend and API share the same `APP_URL` origin. Session cookies use `SameSite=Lax`, which prevents cross-origin `fetch()` from sending cookies (only top-level navigation GETs include them). If a cross-origin frontend is needed in the future, `SameSite=None; Secure` must be considered.
- **CORS is browser-only**: `curl`/Postman/server-side requests ignore CORS headers entirely. Actual access control is enforced by `authMiddleware` (API key) and session validation.
- **No OpenAPI spec changes needed**: CORS policy is a runtime concern, not an API contract.

## Known Hono behavior
Hono's CORS middleware sends `Access-Control-Allow-Credentials: true` even when the origin function returns `null`. Browsers still block the response because `Access-Control-Allow-Origin` is omitted, so this is not exploitable, but security scanners may flag it. Documented in code comments.

Closes #51

## Review feedback addressed
- **[Critical]** Origin reflection with `credentials: true` when `APP_URL` unset — fixed: fail closed unless `ENVIRONMENT=development`
- **[Critical]** Documented Hono's `Allow-Credentials: true` on rejected origins behavior
- **[Medium]** Documented same-origin assumption (`SameSite=Lax` + cross-origin mismatch)
- **[Medium]** Documented that CORS is not server-side access control
- **[Low]** Added `PATCH` to `allowMethods` (needed for `/users/current/profile`)
- **[Low]** Removed redundant `OPTIONS` from `allowMethods` (Hono handles preflight automatically)
- **[Low]** Added `HEAD` to `allowMethods`

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] With `APP_URL` set: only matching origin gets CORS headers
- [ ] With `APP_URL` unset + `ENVIRONMENT=development`: any origin is reflected
- [ ] With `APP_URL` unset + no `ENVIRONMENT`: CORS blocked (fail closed)
- [ ] `Access-Control-Allow-Credentials: true` is present in response
- [ ] API key auth (Basic/Bearer) continues to work unchanged
- [ ] PATCH and HEAD requests pass preflight

🤖 Generated with [Claude Code](https://claude.com/claude-code)