### PR TITLE
docs: restore active development warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # cloudtime
 
+> [!WARNING]
+> This project is under active development and is not yet ready for use. APIs may change without notice and core features are still being implemented.
+
 A self-hosted, WakaTime-compatible coding time tracker built on Cloudflare Workers + D1.
 
 Designed for **individual developers** who want full control over their coding metrics. Each person deploys their own instance.


### PR DESCRIPTION
## Summary

- Restore the `[!WARNING]` block that was accidentally removed in PR #40
- Notifies users that the project is under active development and not yet production-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)