### PR TITLE
feat: OAuth response validation & scope verification (#61, #38)

### DIFF
--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -452,16 +452,12 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
   if (cached) {
     try {
       const jwks: unknown = JSON.parse(cached);
-      try {
-        cachedJWKS = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
-      } catch {
-        throw new OAuthValidationError("Google JWKS (cached) is not a valid JWK Set");
-      }
+      // jose.createLocalJWKSet validates internally; cast is safe here
+      cachedJWKS = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
       jwksCachedAt = Date.now();
       return cachedJWKS;
-    } catch (err) {
+    } catch {
       await kv.delete(kvKey);
-      if (err instanceof OAuthValidationError) throw err;
       // Fall through to fetch fresh JWKS
     }
   }
@@ -484,6 +480,7 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
 
       let keySet: jose.JWTVerifyGetKey;
       try {
+        // jose.createLocalJWKSet validates internally; cast is safe here
         keySet = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
       } catch {
         throw new OAuthValidationError("Google JWKS response is not a valid JWK Set");

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -4,6 +4,15 @@
 import * as jose from "jose";
 import type { Env } from "../types";
 
+// ─── Validation ──────────────────────────────────────────
+
+export class OAuthValidationError extends Error {
+  constructor(context: string) {
+    super(`OAuth validation failed: ${context}`);
+    this.name = "OAuthValidationError";
+  }
+}
+
 // ─── Types ───────────────────────────────────────────────
 
 export type OAuthProvider = "github" | "google" | "discord";
@@ -109,7 +118,7 @@ export function buildAuthorizeUrl(
   }
 }
 
-// ─── Token Exchange ──────────────────────────────────────
+// ─── Assertion Functions ─────────────────────────────────
 
 interface TokenResponse {
   access_token: string;
@@ -119,6 +128,138 @@ interface TokenResponse {
   id_token?: string;
   scope?: string;
 }
+
+function assertTokenResponse(
+  data: unknown,
+): asserts data is TokenResponse & { error?: string; error_description?: string } {
+  if (typeof data !== "object" || data === null) {
+    throw new OAuthValidationError("token response is not an object");
+  }
+  const obj = data as Record<string, unknown>;
+
+  // Check for provider error responses first (GitHub returns 200 with error field)
+  if (typeof obj.error === "string") return;
+
+  if (typeof obj.access_token !== "string" || obj.access_token === "") {
+    throw new OAuthValidationError("token response missing access_token");
+  }
+  if (typeof obj.token_type !== "string" || obj.token_type === "") {
+    throw new OAuthValidationError("token response missing token_type");
+  }
+  if (obj.refresh_token !== undefined && typeof obj.refresh_token !== "string") {
+    throw new OAuthValidationError("token response refresh_token is not a string");
+  }
+  if (obj.expires_in !== undefined && typeof obj.expires_in !== "number") {
+    throw new OAuthValidationError("token response expires_in is not a number");
+  }
+  if (obj.id_token !== undefined && typeof obj.id_token !== "string") {
+    throw new OAuthValidationError("token response id_token is not a string");
+  }
+  if (obj.scope !== undefined && typeof obj.scope !== "string") {
+    throw new OAuthValidationError("token response scope is not a string");
+  }
+}
+
+interface GitHubUser {
+  id: number;
+  login: string;
+}
+
+function assertGitHubUser(data: unknown): asserts data is GitHubUser {
+  if (typeof data !== "object" || data === null) {
+    throw new OAuthValidationError("GitHub /user response is not an object");
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.id !== "number") {
+    throw new OAuthValidationError("GitHub /user id is not a number");
+  }
+  if (typeof obj.login !== "string" || obj.login === "") {
+    throw new OAuthValidationError("GitHub /user login is not a string");
+  }
+}
+
+interface GitHubEmail {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+}
+
+function assertGitHubEmails(data: unknown): asserts data is GitHubEmail[] {
+  if (!Array.isArray(data)) {
+    throw new OAuthValidationError("GitHub /user/emails response is not an array");
+  }
+  for (const item of data) {
+    if (typeof item !== "object" || item === null) {
+      throw new OAuthValidationError("GitHub /user/emails entry is not an object");
+    }
+    const entry = item as Record<string, unknown>;
+    if (typeof entry.email !== "string") {
+      throw new OAuthValidationError("GitHub /user/emails entry missing email");
+    }
+    if (typeof entry.primary !== "boolean") {
+      throw new OAuthValidationError("GitHub /user/emails entry missing primary");
+    }
+    if (typeof entry.verified !== "boolean") {
+      throw new OAuthValidationError("GitHub /user/emails entry missing verified");
+    }
+  }
+}
+
+interface DiscordUser {
+  id: string;
+  username: string;
+  global_name: string | null;
+  email: string | null;
+  verified: boolean;
+}
+
+function assertDiscordUser(data: unknown): asserts data is DiscordUser {
+  if (typeof data !== "object" || data === null) {
+    throw new OAuthValidationError("Discord /users/@me response is not an object");
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.id !== "string" || obj.id === "") {
+    throw new OAuthValidationError("Discord /users/@me id is not a string");
+  }
+  if (typeof obj.username !== "string" || obj.username === "") {
+    throw new OAuthValidationError("Discord /users/@me username is not a string");
+  }
+  if (typeof obj.verified !== "boolean") {
+    throw new OAuthValidationError("Discord /users/@me verified is not a boolean");
+  }
+}
+
+// ─── Scope Verification ─────────────────────────────────
+
+const REQUIRED_SCOPES: Record<OAuthProvider, string[] | null> = {
+  github: ["read:user", "user:email"],
+  discord: ["identify", "email"],
+  google: null, // OpenID Connect: validated via id_token claims
+};
+
+function verifyGrantedScopes(provider: OAuthProvider, scopeField: string | undefined): void {
+  const required = REQUIRED_SCOPES[provider];
+  if (!required) return;
+
+  if (!scopeField) {
+    console.warn(`${provider} token response missing scope field`);
+    return; // downstream fetchUserInfo will detect insufficient permissions
+  }
+
+  // GitHub uses comma-separated, Discord uses space-separated — handle both
+  const granted = new Set(
+    scopeField.split(/[,\s]+/).map((s) => s.trim()).filter(Boolean),
+  );
+  const missing = required.filter((s) => !granted.has(s));
+
+  if (missing.length > 0) {
+    throw new OAuthValidationError(
+      `${provider}: required scopes not granted: ${missing.join(", ")}`,
+    );
+  }
+}
+
+// ─── Token Exchange ──────────────────────────────────────
 
 export async function exchangeCode(
   provider: OAuthProvider,
@@ -149,11 +290,12 @@ export async function exchangeCode(
     ...PROVIDER_FETCH_OPTS,
   });
 
-  const data = (await res.json()) as TokenResponse & { error?: string; error_description?: string };
+  const raw: unknown = await res.json();
+  assertTokenResponse(raw);
 
   // GitHub returns 200 even on errors
-  if (data.error) {
-    console.error(`OAuth token exchange failed for ${provider}: ${data.error}`);
+  if (raw.error) {
+    console.error(`OAuth token exchange failed for ${provider}: ${raw.error}`);
     throw new Error("OAuth token exchange failed");
   }
 
@@ -161,11 +303,9 @@ export async function exchangeCode(
     throw new Error(`OAuth token exchange failed: HTTP ${res.status}`);
   }
 
-  if (!data.access_token || !data.token_type) {
-    throw new Error("OAuth token response missing required fields");
-  }
+  verifyGrantedScopes(provider, raw.scope);
 
-  return data;
+  return raw;
 }
 
 function getTokenEndpoint(
@@ -251,19 +391,11 @@ async function fetchGitHubUser(
   if (!userRes.ok) throw new Error(`GitHub /user failed: ${userRes.status}`);
   if (!emailsRes.ok) throw new Error(`GitHub /user/emails failed: ${emailsRes.status}`);
 
-  const user = (await userRes.json()) as { id: number; login: string };
-  if (!user.id || !user.login) {
-    throw new Error("GitHub API returned unexpected user data");
-  }
+  const user: unknown = await userRes.json();
+  assertGitHubUser(user);
 
-  const emails = (await emailsRes.json()) as Array<{
-    email: string;
-    primary: boolean;
-    verified: boolean;
-  }>;
-  if (!Array.isArray(emails)) {
-    throw new Error("GitHub API returned unexpected emails data");
-  }
+  const emails: unknown = await emailsRes.json();
+  assertGitHubEmails(emails);
 
   const primaryEmail = emails.find((e) => e.primary && e.verified);
 
@@ -302,8 +434,8 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
   const cached = await kv.get(kvKey);
   if (cached) {
     try {
-      const jwks = JSON.parse(cached) as jose.JSONWebKeySet;
-      cachedJWKS = jose.createLocalJWKSet(jwks);
+      const jwks: unknown = JSON.parse(cached);
+      cachedJWKS = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
       jwksCachedAt = Date.now();
       return cachedJWKS;
     } catch {
@@ -326,11 +458,18 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
     try {
       const res = await fetch("https://www.googleapis.com/oauth2/v3/certs", PROVIDER_FETCH_OPTS);
       if (!res.ok) throw new Error(`Failed to fetch Google JWKS: ${res.status}`);
-      const jwks = (await res.json()) as jose.JSONWebKeySet;
+      const jwks: unknown = await res.json();
+
+      let keySet: jose.JWTVerifyGetKey;
+      try {
+        keySet = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
+      } catch {
+        throw new OAuthValidationError("Google JWKS response is not a valid JWK Set");
+      }
 
       // Cache in KV (10 min TTL)
       await kv.put(kvKey, JSON.stringify(jwks), { expirationTtl: 600 });
-      cachedJWKS = jose.createLocalJWKSet(jwks);
+      cachedJWKS = keySet;
       jwksCachedAt = Date.now();
       return cachedJWKS;
     } catch (err) {
@@ -460,16 +599,8 @@ async function fetchDiscordUser(
 
   if (!res.ok) throw new Error(`Discord /users/@me failed: ${res.status}`);
 
-  const user = (await res.json()) as {
-    id: string;
-    username: string;
-    global_name: string | null;
-    email: string | null;
-    verified: boolean;
-  };
-  if (!user.id || !user.username) {
-    throw new Error("Discord API returned unexpected user data");
-  }
+  const user: unknown = await res.json();
+  assertDiscordUser(user);
 
   return {
     providerUserId: user.id,

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -129,9 +129,16 @@ interface TokenResponse {
   scope?: string;
 }
 
-function assertTokenResponse(
+interface TokenErrorResponse {
+  error: string;
+  error_description?: string;
+}
+
+type TokenExchangeResult = TokenResponse | TokenErrorResponse;
+
+function assertTokenExchangeResult(
   data: unknown,
-): asserts data is TokenResponse & { error?: string; error_description?: string } {
+): asserts data is TokenExchangeResult {
   if (typeof data !== "object" || data === null) {
     throw new OAuthValidationError("token response is not an object");
   }
@@ -158,6 +165,10 @@ function assertTokenResponse(
   if (obj.scope !== undefined && typeof obj.scope !== "string") {
     throw new OAuthValidationError("token response scope is not a string");
   }
+}
+
+function isTokenError(result: TokenExchangeResult): result is TokenErrorResponse {
+  return "error" in result;
 }
 
 interface GitHubUser {
@@ -227,6 +238,12 @@ function assertDiscordUser(data: unknown): asserts data is DiscordUser {
   if (typeof obj.verified !== "boolean") {
     throw new OAuthValidationError("Discord /users/@me verified is not a boolean");
   }
+  if (obj.global_name !== null && typeof obj.global_name !== "string") {
+    throw new OAuthValidationError("Discord /users/@me global_name is not a string or null");
+  }
+  if (obj.email !== null && typeof obj.email !== "string") {
+    throw new OAuthValidationError("Discord /users/@me email is not a string or null");
+  }
 }
 
 // ─── Scope Verification ─────────────────────────────────
@@ -291,10 +308,10 @@ export async function exchangeCode(
   });
 
   const raw: unknown = await res.json();
-  assertTokenResponse(raw);
+  assertTokenExchangeResult(raw);
 
   // GitHub returns 200 even on errors
-  if (raw.error) {
+  if (isTokenError(raw)) {
     console.error(`OAuth token exchange failed for ${provider}: ${raw.error}`);
     throw new Error("OAuth token exchange failed");
   }
@@ -435,11 +452,16 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
   if (cached) {
     try {
       const jwks: unknown = JSON.parse(cached);
-      cachedJWKS = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
+      try {
+        cachedJWKS = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
+      } catch {
+        throw new OAuthValidationError("Google JWKS (cached) is not a valid JWK Set");
+      }
       jwksCachedAt = Date.now();
       return cachedJWKS;
-    } catch {
+    } catch (err) {
       await kv.delete(kvKey);
+      if (err instanceof OAuthValidationError) throw err;
       // Fall through to fetch fresh JWKS
     }
   }

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -145,7 +145,12 @@ function assertTokenExchangeResult(
   const obj = data as Record<string, unknown>;
 
   // Check for provider error responses first (GitHub returns 200 with error field)
-  if (typeof obj.error === "string") return;
+  if (typeof obj.error === "string") {
+    if (obj.error_description !== undefined && typeof obj.error_description !== "string") {
+      throw new OAuthValidationError("token error response error_description is not a string");
+    }
+    return;
+  }
 
   if (typeof obj.access_token !== "string" || obj.access_token === "") {
     throw new OAuthValidationError("token response missing access_token");
@@ -312,7 +317,8 @@ export async function exchangeCode(
 
   // GitHub returns 200 even on errors
   if (isTokenError(raw)) {
-    console.error(`OAuth token exchange failed for ${provider}: ${raw.error}`);
+    const desc = raw.error_description ? `: ${raw.error_description}` : "";
+    console.error(`OAuth token exchange failed for ${provider}: ${raw.error}${desc}`);
     throw new Error("OAuth token exchange failed");
   }
 
@@ -482,8 +488,10 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
       try {
         // jose.createLocalJWKSet validates internally; cast is safe here
         keySet = jose.createLocalJWKSet(jwks as jose.JSONWebKeySet);
-      } catch {
-        throw new OAuthValidationError("Google JWKS response is not a valid JWK Set");
+      } catch (jwksErr) {
+        throw new OAuthValidationError(
+          `Google JWKS response is not a valid JWK Set: ${jwksErr instanceof Error ? jwksErr.message : jwksErr}`,
+        );
       }
 
       // Cache in KV (10 min TTL)


### PR DESCRIPTION
## Summary
- Replace all `as` type casts on OAuth provider responses with `asserts data is T` assertion functions that validate at runtime
- Add `verifyGrantedScopes()` to check that token exchange responses include all required scopes (GitHub: `read:user`, `user:email`; Discord: `identify`, `email`; Google: skipped — uses id_token claims)
- Wrap Google JWKS `createLocalJWKSet()` with error handling for invalid JWK Set responses
- Zero new dependencies — all validation is hand-written (~130 lines)

### Assertion functions added
| Function | Validates |
|----------|-----------|
| `assertTokenExchangeResult` | Token exchange response shape — discriminated union: success (access_token, token_type, optional fields) or error (error field + optional error_description) |
| `assertGitHubUser` | GitHub `/user` response (id: number, login: string) |
| `assertGitHubEmails` | GitHub `/user/emails` response (array with email/primary/verified per entry) |
| `assertDiscordUser` | Discord `/users/@me` response (id, username, verified, global_name, email) |

### Scope verification behavior
- **GitHub**: comma-separated scopes — validates `read:user` and `user:email`
- **Discord**: space-separated scopes — validates `identify` and `email`
- **Google**: skipped (OpenID Connect scopes are URL-form; id_token claim validation is sufficient)
- Missing `scope` field: warn and continue (downstream API calls will fail with 403 if scopes are insufficient)

### JWKS cache error handling
- Cached JWKS (KV): if `createLocalJWKSet` fails, deletes the corrupt entry and falls through to fresh fetch (self-healing)
- Fresh JWKS (Google endpoint): if `createLocalJWKSet` fails, throws `OAuthValidationError` with the original jose error message (hard failure — Google returned bad data)

### Review follow-up (4d5ca62)
- `assertTokenExchangeResult` error branch now validates `error_description` type when present
- Token exchange error logging now includes `error_description` for better diagnostics
- JWKS fresh-fetch `OAuthValidationError` now includes the original jose error message

Closes #61, closes #38

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify assertion functions reject malformed data (code review: each function checks typeof for all required fields)
- [ ] Verify `assertTokenExchangeResult` passes through error responses (allows GitHub 200+error pattern)
- [ ] Verify `verifyGrantedScopes` handles both comma and space delimiters
- [ ] Verify corrupt cached JWKS self-heals by falling through to fresh fetch
- [ ] End-to-end OAuth login flow with each provider after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)