### PR TITLE
fix: revoke provider OAuth tokens on unlink (#35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3129 @@
+{
+  "name": "cloudtime",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cloudtime",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "hono": "^4.12.5",
+        "jose": "^6.2.1"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250309.0",
+        "@redocly/cli": "^2.20.4",
+        "openapi-typescript": "^7.6.1",
+        "typescript": "^5.7.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260301.1.tgz",
+      "integrity": "sha512-Q0wMJ4kcujXILwQKQFc1jaYamVsNvjuECzvRrTI8OxGFMx2yq9aOsswViE4X1gaS2YQQ5u0JGwuGi5WdT1Lt7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260307.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260307.1.tgz",
+      "integrity": "sha512-0PvWLVVD6Q64V/XhollYtc8H35Vxm2rZi8bkZbEr3lK+mNgd2FBBVhlZ6A3saAUq3giRF4US/UfU/3a8i1PEcg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
+      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz",
+      "integrity": "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.202.0.tgz",
+      "integrity": "sha512-/hKE8DaFCJuaQqE1IxpgkcjOolUIwgi3TgHElPVKGdGRBSmJMTmN/cr6vWa55pCJIXPyhKvcMrbrya7DZ3VmzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-exporter-base": "0.202.0",
+        "@opentelemetry/otlp-transformer": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.202.0.tgz",
+      "integrity": "sha512-nMEOzel+pUFYuBJg2znGmHJWbmvMbdX5/RhoKNKowguMbURhz0fwik5tUKplLcUtl8wKPL1y9zPnPxeBn65N0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/otlp-transformer": "0.202.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
+      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-logs": "0.202.0",
+        "@opentelemetry/sdk-metrics": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
+      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
+      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
+      "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.1.tgz",
+      "integrity": "sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.0.1",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
+      "integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.20.4.tgz",
+      "integrity": "sha512-ahZmcTfEvw2ghWBm418A3anN3XS88Izbqn+HyH6fm/iJ/x04vFwW2KSv/V2K2JZON5ImpTCQBHPQd9bSmmZw9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/sdk-trace-node": "2.0.1",
+        "@opentelemetry/semantic-conventions": "1.34.0",
+        "@redocly/openapi-core": "2.20.4",
+        "@redocly/respect-core": "2.20.4",
+        "abort-controller": "^3.0.0",
+        "ajv": "npm:@redocly/ajv@8.18.0",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "cookie": "^0.7.2",
+        "dotenv": "16.4.7",
+        "glob": "^13.0.5",
+        "handlebars": "^4.7.6",
+        "https-proxy-agent": "^7.0.5",
+        "mobx": "^6.0.4",
+        "picomatch": "^4.0.3",
+        "pluralize": "^8.0.0",
+        "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
+        "react-dom": "^17.0.0 || ^18.2.0 || ^19.2.1",
+        "redoc": "2.5.1",
+        "semver": "^7.5.2",
+        "set-cookie-parser": "^2.3.5",
+        "simple-websocket": "^9.0.0",
+        "styled-components": "6.3.9",
+        "ulid": "^3.0.1",
+        "undici": "^6.23.0",
+        "yargs": "17.0.1"
+      },
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/@redocly/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/@redocly/config": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.44.0.tgz",
+      "integrity": "sha512-UHKkWcCNZrGiKBbrQ1CE08ElrOUGm5H97Zn8+wkp80Uu2AT/go5In1sbqvhHxViPYtu1MLdy7qKiifSyOL3W/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/@redocly/openapi-core": {
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.20.4.tgz",
+      "integrity": "sha512-3WZh8dPF6MrxLDbTG4GXtV81EOqHrpMWlOhELWBIICRieMMt/LKcGFuOBRdLEp/KMU2ypwQLKYHrKYCeUNwO3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/config": "^0.44.0",
+        "ajv": "npm:@redocly/ajv@8.18.0",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "picomatch": "^4.0.3",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.10",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
+      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.20.4.tgz",
+      "integrity": "sha512-kOM1cCDQtTwZkD58Lx3IIUPcFuRD8bnlkCFUvi0iigy6JJKfpRwgXuzkzFf6FHVO9Z5LwJuYgIP58q3TftWrqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": "^7.6.0",
+        "@noble/hashes": "^1.8.0",
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/openapi-core": "2.20.4",
+        "ajv": "npm:@redocly/ajv@8.18.0",
+        "better-ajv-errors": "^1.2.0",
+        "colorette": "^2.0.20",
+        "json-pointer": "^0.6.2",
+        "jsonpath-rfc9535": "1.3.0",
+        "openapi-sampler": "^1.7.1",
+        "outdent": "^0.8.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/config": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.44.0.tgz",
+      "integrity": "sha512-UHKkWcCNZrGiKBbrQ1CE08ElrOUGm5H97Zn8+wkp80Uu2AT/go5In1sbqvhHxViPYtu1MLdy7qKiifSyOL3W/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core": {
+      "version": "2.20.4",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.20.4.tgz",
+      "integrity": "sha512-3WZh8dPF6MrxLDbTG4GXtV81EOqHrpMWlOhELWBIICRieMMt/LKcGFuOBRdLEp/KMU2ypwQLKYHrKYCeUNwO3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/config": "^0.44.0",
+        "ajv": "npm:@redocly/ajv@8.18.0",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "picomatch": "^4.0.3",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/openapi-core/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
+      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/better-ajv-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
+      "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
+        "chalk": "^4.1.2",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
+      "dev": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@types/json-schema": "^7.0.9",
+        "ts-algebra": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpath-rfc9535": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-rfc9535/-/jsonpath-rfc9535-1.3.0.tgz",
+      "integrity": "sha512-3jFHya7oZ45aDxIIdx+/zQARahHXxFSMWBkcBUldfXpLS9VCXDJyTKt35kQfEXLqh0K3Ixw/9xFnvcDStaxh7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260301.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260301.1.tgz",
+      "integrity": "sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260301.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mobx": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
+      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.0.tgz",
+      "integrity": "sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.1.tgz",
+      "integrity": "sha512-pKFRROcYyxRt9GIn0NmS+GkWPS19l0CLQRYAnHk4m1Qp+G43ssVNcfRMs1sLkGrVMuFWO4P4F6YMXeXnfyFGuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^5.3.8",
+        "json-pointer": "0.6.2"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+      "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-tabs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
+      "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redoc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.1.tgz",
+      "integrity": "sha512-LmqA+4A3CmhTllGG197F0arUpmChukAj9klfSdxNRemT9Hr07xXr7OGKu4PHzBs359sgrJ+4JwmOlM7nxLPGMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.4.0",
+        "classnames": "^2.3.2",
+        "decko": "^1.2.0",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.1",
+        "json-pointer": "^0.6.2",
+        "lunr": "^2.3.9",
+        "mark.js": "^8.11.1",
+        "marked": "^4.3.0",
+        "mobx-react": "9.2.0",
+        "openapi-sampler": "^1.5.0",
+        "path-browserify": "^1.0.1",
+        "perfect-scrollbar": "^1.5.5",
+        "polished": "^4.2.2",
+        "prismjs": "^1.29.0",
+        "prop-types": "^15.8.1",
+        "react-tabs": "^6.0.2",
+        "slugify": "~1.4.7",
+        "stickyfill": "^1.1.1",
+        "swagger2openapi": "^7.0.8",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=6.9",
+        "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.1.4",
+        "mobx": "^6.0.4",
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      }
+    },
+    "node_modules/simple-websocket/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/styled-components": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz",
+      "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workerd": {
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260301.1.tgz",
+      "integrity": "sha512-oterQ1IFd3h7PjCfT4znSFOkJCvNQ6YMOyZ40YsnO3nrSpgB4TbJVYWFOnyJAw71/RQuupfVqZZWKvsy8GO3fw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260301.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260301.1",
+        "@cloudflare/workerd-linux-64": "1.20260301.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260301.1",
+        "@cloudflare/workerd-windows-64": "1.20260301.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.71.0.tgz",
+      "integrity": "sha512-j6pSGAncOLNQDRzqtp0EqzYj52CldDP7uz/C9cxVrIgqa5p+cc0b4pIwnapZZAGv9E1Loa3tmPD0aXonH7KTkw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260301.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260226.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import type { Env } from "./types";
+import { matchOrigin } from "./utils/origin";
 import meta from "./routes/meta";
 import auth from "./routes/auth";
 import heartbeats from "./routes/heartbeats";
@@ -16,12 +17,7 @@ app.use("/*", secureHeaders());
 app.use(
   "/*",
   cors({
-    origin: (origin, c) => {
-      const appUrl = (c.env as Env).APP_URL?.replace(/\/+$/, "");
-      if (appUrl) return origin === appUrl ? origin : "";
-      // Development: reflect origin (allow all)
-      return origin;
-    },
+    origin: (origin, c) => matchOrigin(origin, (c.env as Env).APP_URL),
     credentials: true,
   }),
 );
@@ -61,10 +57,9 @@ export default {
           ).all<{ token_hash: string }>(),
         ]);
 
-        // Delete expired records from D1
+        // Delete expired records from D1 (same condition as SELECT to avoid orphaned KV entries)
         await env.DB.batch([
-          env.DB.prepare("DELETE FROM sessions WHERE expires_at < datetime('now')"),
-          env.DB.prepare("DELETE FROM sessions WHERE last_active_at < datetime('now', '-1 day')"),
+          env.DB.prepare("DELETE FROM sessions WHERE expires_at < datetime('now') OR last_active_at < datetime('now', '-1 day')"),
           env.DB.prepare("DELETE FROM pending_links WHERE expires_at < datetime('now')"),
         ]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
 import type { Env } from "./types";
 import meta from "./routes/meta";
 import auth from "./routes/auth";
@@ -11,7 +12,19 @@ import { aggregateHeartbeats } from "./cron/aggregate";
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.use("/*", cors());
+app.use("/*", secureHeaders());
+app.use(
+  "/*",
+  cors({
+    origin: (origin, c) => {
+      const appUrl = (c.env as Env).APP_URL?.replace(/\/+$/, "");
+      if (appUrl) return origin === appUrl ? origin : "";
+      // Development: reflect origin (allow all)
+      return origin;
+    },
+    credentials: true,
+  }),
+);
 
 // Health check
 app.get("/api/v1/health", (c) => c.json({ status: "ok" }));
@@ -39,15 +52,29 @@ export default {
   fetch: app.fetch,
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(
-      Promise.all([
-        aggregateHeartbeats(env.DB),
-        // Cleanup expired and idle sessions, and expired pending links
-        env.DB.batch([
+      (async () => {
+        // Query expired sessions first (before deletion) for KV cache cleanup
+        const [, expiredSessions] = await Promise.all([
+          aggregateHeartbeats(env.DB),
+          env.DB.prepare(
+            "SELECT token_hash FROM sessions WHERE expires_at < datetime('now') OR last_active_at < datetime('now', '-1 day')",
+          ).all<{ token_hash: string }>(),
+        ]);
+
+        // Delete expired records from D1
+        await env.DB.batch([
           env.DB.prepare("DELETE FROM sessions WHERE expires_at < datetime('now')"),
           env.DB.prepare("DELETE FROM sessions WHERE last_active_at < datetime('now', '-1 day')"),
           env.DB.prepare("DELETE FROM pending_links WHERE expires_at < datetime('now')"),
-        ]),
-      ]),
+        ]);
+
+        // Clean up KV cache for deleted sessions
+        if (expiredSessions.results.length > 0) {
+          await Promise.all(
+            expiredSessions.results.map((r) => env.KV.delete(`session:${r.token_hash}`)),
+          );
+        }
+      })(),
     );
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,10 @@ export default {
     ctx.waitUntil(
       Promise.all([
         aggregateHeartbeats(env.DB),
-        // Cleanup expired sessions and pending links
+        // Cleanup expired and idle sessions, and expired pending links
         env.DB.batch([
           env.DB.prepare("DELETE FROM sessions WHERE expires_at < datetime('now')"),
+          env.DB.prepare("DELETE FROM sessions WHERE last_active_at < datetime('now', '-1 day')"),
           env.DB.prepare("DELETE FROM pending_links WHERE expires_at < datetime('now')"),
         ]),
       ]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Env } from "./types";
 import meta from "./routes/meta";
+import auth from "./routes/auth";
 import heartbeats from "./routes/heartbeats";
 import summaries from "./routes/summaries";
 import stats from "./routes/stats";
@@ -18,6 +19,9 @@ app.get("/api/v1/health", (c) => c.json({ status: "ok" }));
 // Meta routes (public, no auth — /meta, /editors, /program_languages, /stats/:range)
 app.route("/api/v1", meta);
 
+// Auth routes (OAuth, sessions, providers — before other authenticated routes)
+app.route("/api/v1/auth", auth);
+
 // Heartbeat routes (mounted at /users/current, sub-app defines /heartbeats and /heartbeats.bulk)
 app.route("/api/v1/users/current", heartbeats);
 
@@ -30,10 +34,19 @@ app.route("/api/v1/users/current", stats);
 // User routes (mounted at /users/current, sub-app defines /, /profile, /projects)
 app.route("/api/v1/users/current", users);
 
-// Cron trigger handler for periodic aggregation
+// Cron trigger handler for periodic aggregation + session cleanup
 export default {
   fetch: app.fetch,
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
-    ctx.waitUntil(aggregateHeartbeats(env.DB));
+    ctx.waitUntil(
+      Promise.all([
+        aggregateHeartbeats(env.DB),
+        // Cleanup expired sessions and pending links
+        env.DB.batch([
+          env.DB.prepare("DELETE FROM sessions WHERE expires_at < datetime('now')"),
+          env.DB.prepare("DELETE FROM pending_links WHERE expires_at < datetime('now')"),
+        ]),
+      ]),
+    );
   },
 };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,18 +1,30 @@
 import { createMiddleware } from "hono/factory";
 import type { AuthEnv } from "../types";
 import { getApiKey, getUserId } from "../utils/auth";
+import { sha256Hex } from "../utils/crypto";
+import { getSessionTokenFromCookie, validateSession } from "../utils/session";
 
 export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
+  // 1. Try API key auth
   const apiKey = getApiKey(c.req);
-  if (!apiKey) {
-    return c.json({ error: "Unauthorized" }, 401);
+  if (apiKey) {
+    const userId = await getUserId(apiKey, c.env);
+    if (userId) {
+      c.set("userId", userId);
+      return next();
+    }
   }
 
-  const userId = await getUserId(apiKey, c.env);
-  if (!userId) {
-    return c.json({ error: "Unauthorized" }, 401);
+  // 2. Fallback to session cookie
+  const sessionToken = getSessionTokenFromCookie(c, c.env);
+  if (sessionToken) {
+    const tokenHash = await sha256Hex(sessionToken);
+    const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
+    if (session) {
+      c.set("userId", session.userId);
+      return next();
+    }
   }
 
-  c.set("userId", userId);
-  await next();
+  return c.json({ error: "Unauthorized" }, 401);
 });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -5,17 +5,16 @@ import { sha256Hex } from "../utils/crypto";
 import { getSessionTokenFromCookie, validateSession } from "../utils/session";
 
 export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
-  // 1. Try API key auth
+  // 1. Try API key auth — if a key is present but invalid, reject immediately
   const apiKey = getApiKey(c.req);
   if (apiKey) {
     const userId = await getUserId(apiKey, c.env);
-    if (userId) {
-      c.set("userId", userId);
-      return next();
-    }
+    if (!userId) return c.json({ error: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    return next();
   }
 
-  // 2. Fallback to session cookie
+  // 2. No API key — try session cookie
   const sessionToken = getSessionTokenFromCookie(c, c.env);
   if (sessionToken) {
     const tokenHash = await sha256Hex(sessionToken);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -24,6 +24,7 @@ import {
   fetchUserInfo,
   revokeProviderToken,
   type OAuthProvider,
+  type ProviderUserInfo,
 } from "../utils/oauth";
 import {
   createSession,
@@ -127,6 +128,45 @@ type ProviderRow = {
   email_verified: number;
   created_at: string;
 };
+
+async function encryptProviderTokens(
+  userInfo: ProviderUserInfo,
+  encryptionKey: string,
+  userId: string,
+  provider: OAuthProvider,
+): Promise<{ accessTokenEnc: string; refreshTokenEnc: string | null }> {
+  const encCtx = `${userId}:${provider}`;
+  const accessTokenEnc = await encryptToken(userInfo.accessToken, encryptionKey, encCtx);
+  const refreshTokenEnc = userInfo.refreshToken
+    ? await encryptToken(userInfo.refreshToken, encryptionKey, encCtx)
+    : null;
+  return { accessTokenEnc, refreshTokenEnc };
+}
+
+async function updateOAuthAccount(
+  db: D1Database,
+  provider: OAuthProvider,
+  userInfo: ProviderUserInfo,
+  accessTokenEnc: string,
+  refreshTokenEnc: string | null,
+): Promise<void> {
+  await db.prepare(
+    `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+     access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+     WHERE provider = ? AND provider_user_id = ?`,
+  )
+    .bind(
+      userInfo.providerUsername,
+      userInfo.providerEmail,
+      userInfo.emailVerified ? 1 : 0,
+      accessTokenEnc,
+      refreshTokenEnc,
+      userInfo.tokenExpiresAt,
+      provider,
+      userInfo.providerUserId,
+    )
+    .run();
+}
 
 // ─── Session-authenticated routes (static paths first) ───
 
@@ -265,21 +305,24 @@ auth.delete("/providers/:provider", sessionMw, async (c) => {
   }
 
   // Ensure user keeps at least one other auth method
-  const [{ results: linked }, userRow] = await Promise.all([
+  const [otherProviderCount, userRow, targetRow] = await Promise.all([
     c.env.DB.prepare(
-      "SELECT provider, access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ?",
+      "SELECT COUNT(*) as count FROM oauth_accounts WHERE user_id = ? AND provider != ?",
     )
-      .bind(userId)
-      .all<{ provider: string; access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
+      .bind(userId, provider)
+      .first<{ count: number }>(),
     c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
       .bind(userId)
       .first<{ api_key_hash: string | null }>(),
+    c.env.DB.prepare(
+      "SELECT access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ? AND provider = ?",
+    )
+      .bind(userId, provider)
+      .first<{ access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
   ]);
 
   const hasApiKey = !!userRow?.api_key_hash;
-  const targetRow = linked.find((p) => p.provider === provider);
-  const otherProviders = linked.filter((p) => p.provider !== provider).length;
-  if (otherProviders === 0 && !hasApiKey) {
+  if ((otherProviderCount?.count ?? 0) === 0 && !hasApiKey) {
     return c.json({ error: "Cannot unlink the only authentication method" }, 400);
   }
 
@@ -490,34 +533,16 @@ auth.get("/link/:provider/callback", async (c) => {
     .first<{ user_id: string }>();
 
   if (existingLink && existingLink.user_id !== stateData.linkUserId) {
-    return c.json({ error: "This provider account is already linked to another user" }, 409);
+    return c.json({ error: "This provider account is already linked to another user" }, 409, securityHeaders());
   }
 
   // Encrypt tokens with AAD context (binds ciphertext to this user+provider)
-  const encCtx = `${stateData.linkUserId}:${provider}`;
-  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-  const refreshTokenEnc = userInfo.refreshToken
-    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-    : null;
+  const { accessTokenEnc, refreshTokenEnc } = await encryptProviderTokens(
+    userInfo, c.env.ENCRYPTION_KEY, stateData.linkUserId, provider,
+  );
 
   if (existingLink) {
-    // Update existing link
-    await c.env.DB.prepare(
-      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-       WHERE provider = ? AND provider_user_id = ?`,
-    )
-      .bind(
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-        provider,
-        userInfo.providerUserId,
-      )
-      .run();
+    await updateOAuthAccount(c.env.DB, provider, userInfo, accessTokenEnc, refreshTokenEnc);
   } else {
     // Create new link
     await c.env.DB.prepare(
@@ -607,7 +632,11 @@ auth.get("/:provider/callback", async (c) => {
 
   // 4. Email verification gate
   if (!userInfo.emailVerified) {
-    return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
+    return c.json(
+      { error: "Email not verified with provider. Please verify your email first." },
+      400,
+      securityHeaders(),
+    );
   }
 
   // 5. Account matching — check for existing OAuth link
@@ -619,29 +648,10 @@ auth.get("/:provider/callback", async (c) => {
 
   if (existingOAuth) {
     // ─── Existing user login ─────────────────────
-    const encCtx = `${existingOAuth.user_id}:${provider}`;
-    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-    const refreshTokenEnc = userInfo.refreshToken
-      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-      : null;
-
-    // Update provider tokens
-    await c.env.DB.prepare(
-      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-       WHERE provider = ? AND provider_user_id = ?`,
-    )
-      .bind(
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-        provider,
-        userInfo.providerUserId,
-      )
-      .run();
+    const { accessTokenEnc, refreshTokenEnc } = await encryptProviderTokens(
+      userInfo, c.env.ENCRYPTION_KEY, existingOAuth.user_id, provider,
+    );
+    await updateOAuthAccount(c.env.DB, provider, userInfo, accessTokenEnc, refreshTokenEnc);
 
     // Create session
     const sessionToken = generateSessionToken();
@@ -663,9 +673,10 @@ auth.get("/:provider/callback", async (c) => {
   }
 
   // No existing OAuth link — check if email matches an existing user
-  if (userInfo.providerEmail) {
+  const providerEmail = userInfo.providerEmail;
+  if (providerEmail) {
     const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
-      .bind(userInfo.providerEmail)
+      .bind(providerEmail)
       .first<{ id: string; username: string }>();
 
     if (emailMatch) {
@@ -680,11 +691,9 @@ auth.get("/:provider/callback", async (c) => {
       }
 
       // Encrypt tokens with AAD context
-      const encCtx = `${emailMatch.id}:${provider}`;
-      const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-      const refreshTokenEnc = userInfo.refreshToken
-        ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-        : null;
+      const { accessTokenEnc, refreshTokenEnc } = await encryptProviderTokens(
+        userInfo, c.env.ENCRYPTION_KEY, emailMatch.id, provider,
+      );
 
       // Create pending link for manual approval
       const pendingId = crypto.randomUUID();
@@ -720,7 +729,7 @@ auth.get("/:provider/callback", async (c) => {
               id: pendingId,
               provider: provider as OAuthProvider,
               provider_username: userInfo.providerUsername,
-              provider_email: userInfo.providerEmail!,
+              provider_email: providerEmail,
               expires_at: normalizeDateTime(pendingExpiry),
             },
           },
@@ -747,11 +756,9 @@ auth.get("/:provider/callback", async (c) => {
   }
 
   // Encrypt tokens with AAD context
-  const encCtx = `${userId}:${provider}`;
-  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-  const refreshTokenEnc = userInfo.refreshToken
-    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-    : null;
+  const { accessTokenEnc, refreshTokenEnc } = await encryptProviderTokens(
+    userInfo, c.env.ENCRYPTION_KEY, userId, provider,
+  );
 
   const oauthAccountId = crypto.randomUUID();
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,712 @@
+/**
+ * OAuth authentication routes — 13 endpoints across 4 flows.
+ */
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import type { Env, SessionAuthEnv } from "../types";
+import {
+  sha256Hex,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+  generateNonce,
+  generateSessionToken,
+  generateApiKey,
+  encryptToken,
+  timingSafeEqual,
+} from "../utils/crypto";
+import {
+  isValidProvider,
+  buildAuthorizeUrl,
+  exchangeCode,
+  fetchUserInfo,
+  type OAuthProvider,
+} from "../utils/oauth";
+import {
+  createSession,
+  validateSession,
+  invalidateSession,
+  invalidateOtherSessions,
+  invalidateAllUserSessions,
+  setSessionCookie,
+  clearSessionCookie,
+  getSessionTokenFromCookie,
+  storeOAuthState,
+  consumeOAuthState,
+  setStateCookie,
+  getStateCookie,
+  clearStateCookie,
+} from "../utils/session";
+import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../utils/user";
+
+const auth = new Hono<{ Bindings: Env }>();
+
+// ─── Session Middleware ──────────────────────────────────
+
+const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
+  const token = getSessionTokenFromCookie(c, c.env);
+  if (!token) return c.json({ error: "Unauthorized" }, 401);
+
+  const tokenHash = await sha256Hex(token);
+  const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
+  if (!session) return c.json({ error: "Unauthorized" }, 401);
+
+  c.set("userId", session.userId);
+  c.set("sessionId", session.sessionId);
+  c.set("sessionTokenHash", tokenHash);
+  await next();
+});
+
+// ─── Helpers ─────────────────────────────────────────────
+
+function getRedirectUri(c: { req: { url: string } }, provider: string, isLink = false): string {
+  const origin = new URL(c.req.url).origin;
+  return isLink
+    ? `${origin}/api/v1/auth/link/${provider}/callback`
+    : `${origin}/api/v1/auth/${provider}/callback`;
+}
+
+function securityHeaders(): Record<string, string> {
+  return {
+    "Referrer-Policy": "no-referrer",
+    "Cache-Control": "no-store",
+    Pragma: "no-cache",
+  };
+}
+
+// ─── Session-authenticated routes (static paths first) ───
+
+// GET /session
+auth.get("/session", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const [userRow, providers] = await Promise.all([
+    c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+      .bind(userId)
+      .first<UserRow>(),
+    c.env.DB.prepare(
+      "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
+    )
+      .bind(userId)
+      .all<{
+        provider: string;
+        provider_user_id: string;
+        provider_username: string;
+        provider_email: string | null;
+        email_verified: number;
+        created_at: string;
+      }>(),
+  ]);
+
+  if (!userRow) return c.json({ error: "Unauthorized" }, 401);
+
+  return c.json(
+    {
+      data: {
+        user: rowToUser(userRow),
+        providers: providers.results.map((p) => ({
+          provider: p.provider as OAuthProvider,
+          provider_user_id: p.provider_user_id,
+          provider_username: p.provider_username,
+          provider_email: p.provider_email ?? undefined,
+          email_verified: p.email_verified === 1,
+          created_at: normalizeDateTime(p.created_at),
+        })),
+      },
+    },
+    200,
+    { "Cache-Control": "no-store" },
+  );
+});
+
+// DELETE /session (logout)
+auth.delete("/session", sessionMw, async (c) => {
+  const tokenHash = c.get("sessionTokenHash");
+  await invalidateSession(c.env.DB, c.env.KV, tokenHash);
+  clearSessionCookie(c, c.env);
+  return c.body(null, 204);
+});
+
+// GET /sessions (list all active sessions)
+auth.get("/sessions", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const currentSessionId = c.get("sessionId");
+
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, ip, country, city, user_agent, created_at, expires_at, last_active_at
+     FROM sessions WHERE user_id = ? AND expires_at > datetime('now')
+     ORDER BY last_active_at DESC`,
+  )
+    .bind(userId)
+    .all<{
+      id: string;
+      ip: string | null;
+      country: string | null;
+      city: string | null;
+      user_agent: string | null;
+      created_at: string;
+      expires_at: string;
+      last_active_at: string;
+    }>();
+
+  return c.json(
+    {
+      data: results.map((s) => ({
+        id: s.id,
+        ip: s.ip ?? undefined,
+        country: s.country ?? undefined,
+        city: s.city ?? undefined,
+        user_agent: s.user_agent ?? undefined,
+        created_at: normalizeDateTime(s.created_at),
+        last_active_at: normalizeDateTime(s.last_active_at),
+        expires_at: normalizeDateTime(s.expires_at),
+        is_current: s.id === currentSessionId,
+      })),
+    },
+    200,
+    { "Cache-Control": "no-store" },
+  );
+});
+
+// DELETE /sessions (revoke all other sessions)
+auth.delete("/sessions", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const currentTokenHash = c.get("sessionTokenHash");
+  await invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash);
+  return c.body(null, 204);
+});
+
+// DELETE /sessions/:session_id
+auth.delete("/sessions/:session_id", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const targetSessionId = c.req.param("session_id");
+  const currentSessionId = c.get("sessionId");
+
+  // Find the target session (must belong to current user)
+  const target = await c.env.DB.prepare(
+    "SELECT token_hash FROM sessions WHERE id = ? AND user_id = ?",
+  )
+    .bind(targetSessionId, userId)
+    .first<{ token_hash: string }>();
+
+  if (!target) return c.json({ error: "Not found" }, 404);
+
+  await invalidateSession(c.env.DB, c.env.KV, target.token_hash);
+
+  // If revoking own session, clear cookie
+  if (targetSessionId === currentSessionId) {
+    clearSessionCookie(c, c.env);
+  }
+
+  return c.body(null, 204);
+});
+
+// GET /providers (list linked providers)
+auth.get("/providers", sessionMw, async (c) => {
+  const userId = c.get("userId");
+
+  const { results } = await c.env.DB.prepare(
+    "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
+  )
+    .bind(userId)
+    .all<{
+      provider: string;
+      provider_user_id: string;
+      provider_username: string;
+      provider_email: string | null;
+      email_verified: number;
+      created_at: string;
+    }>();
+
+  return c.json({
+    data: results.map((p) => ({
+      provider: p.provider as OAuthProvider,
+      provider_user_id: p.provider_user_id,
+      provider_username: p.provider_username,
+      provider_email: p.provider_email ?? undefined,
+      email_verified: p.email_verified === 1,
+      created_at: normalizeDateTime(p.created_at),
+    })),
+  });
+});
+
+// DELETE /providers/:provider (unlink)
+auth.delete("/providers/:provider", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const provider = c.req.param("provider");
+
+  if (!isValidProvider(provider)) {
+    return c.json({ error: "Invalid provider" }, 400);
+  }
+
+  // Ensure user has at least one other auth method (another provider or API key)
+  const { results: linked } = await c.env.DB.prepare(
+    "SELECT provider FROM oauth_accounts WHERE user_id = ?",
+  )
+    .bind(userId)
+    .all<{ provider: string }>();
+
+  if (linked.length <= 1) {
+    return c.json({ error: "Cannot unlink the only authentication provider" }, 400);
+  }
+
+  await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
+    .bind(userId, provider)
+    .run();
+
+  return c.body(null, 204);
+});
+
+// POST /api-key (regenerate)
+auth.post("/api-key", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const currentTokenHash = c.get("sessionTokenHash");
+
+  // Get current api_key_hash to clear KV cache
+  const user = await c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+    .bind(userId)
+    .first<{ api_key_hash: string }>();
+
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const { plaintext, hash } = await generateApiKey();
+
+  // Batch: update key + delete old KV cache
+  await c.env.DB.prepare("UPDATE users SET api_key_hash = ?, modified_at = datetime('now') WHERE id = ?")
+    .bind(hash, userId)
+    .run();
+
+  await Promise.all([
+    c.env.KV.delete(`apikey:${user.api_key_hash}`),
+    invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash),
+  ]);
+
+  return c.json(
+    { data: { api_key: plaintext } },
+    200,
+    { "Cache-Control": "no-store" },
+  );
+});
+
+// POST /link/approve/:pending_link_id
+auth.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
+  const userId = c.get("userId");
+  const pendingLinkId = c.req.param("pending_link_id");
+
+  const pending = await c.env.DB.prepare(
+    "SELECT * FROM pending_links WHERE id = ? AND existing_user_id = ?",
+  )
+    .bind(pendingLinkId, userId)
+    .first<{
+      id: string;
+      existing_user_id: string;
+      provider: string;
+      provider_user_id: string;
+      provider_username: string | null;
+      provider_email: string | null;
+      email_verified: number;
+      access_token_encrypted: string | null;
+      refresh_token_encrypted: string | null;
+      token_expires_at: string | null;
+      expires_at: string;
+    }>();
+
+  if (!pending) return c.json({ error: "Not found" }, 404);
+
+  // Check expiry
+  const expiresAt = new Date(pending.expires_at.replace(" ", "T") + "Z");
+  if (new Date() > expiresAt) {
+    await c.env.DB.prepare("DELETE FROM pending_links WHERE id = ?").bind(pendingLinkId).run();
+    return c.json({ error: "Pending link expired" }, 410);
+  }
+
+  const oauthId = crypto.randomUUID();
+
+  // Create oauth_account + delete pending_link in batch
+  await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      oauthId,
+      userId,
+      pending.provider,
+      pending.provider_user_id,
+      pending.provider_username,
+      pending.provider_email,
+      pending.email_verified,
+      pending.access_token_encrypted,
+      pending.refresh_token_encrypted,
+      pending.token_expires_at,
+    ),
+    c.env.DB.prepare("DELETE FROM pending_links WHERE id = ?").bind(pendingLinkId),
+  ]);
+
+  const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+    .bind(userId)
+    .first<UserRow>();
+
+  if (!userRow) return c.json({ error: "Unauthorized" }, 401);
+
+  return c.json({ data: { user: rowToUser(userRow) } });
+});
+
+// POST /link/:provider (initiate linking)
+auth.post("/link/:provider", sessionMw, async (c) => {
+  const provider = c.req.param("provider");
+  if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
+
+  const userId = c.get("userId");
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateState();
+  const nonce = provider === "google" ? generateNonce() : undefined;
+
+  const redirectUri = getRedirectUri(c, provider, true);
+  const authorizeUrl = buildAuthorizeUrl(provider, c.env, redirectUri, codeChallenge, state, nonce);
+
+  await storeOAuthState(c.env.KV, state, { codeVerifier, nonce, linkUserId: userId });
+  setStateCookie(c, state, c.env);
+
+  return c.redirect(authorizeUrl, 302);
+});
+
+// GET /link/:provider/callback (link callback — read session from cookie manually)
+auth.get("/link/:provider/callback", async (c) => {
+  const provider = c.req.param("provider");
+  if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
+
+  // Validate state (double-submit)
+  const stateParam = c.req.query("state");
+  const code = c.req.query("code");
+  const stateCookie = getStateCookie(c);
+  clearStateCookie(c);
+
+  if (!stateParam || !code || !stateCookie) {
+    return c.json({ error: "Missing state or code" }, 400);
+  }
+
+  if (!(await timingSafeEqual(stateParam, stateCookie))) {
+    return c.json({ error: "State mismatch" }, 400);
+  }
+
+  const stateData = await consumeOAuthState(c.env.KV, stateParam);
+  if (!stateData || !stateData.linkUserId) {
+    return c.json({ error: "Invalid or expired state" }, 400);
+  }
+
+  // Validate session from cookie
+  const token = getSessionTokenFromCookie(c, c.env);
+  if (!token) return c.json({ error: "Unauthorized" }, 401);
+  const tokenHash = await sha256Hex(token);
+  const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
+  if (!session || session.userId !== stateData.linkUserId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const redirectUri = getRedirectUri(c, provider, true);
+  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+
+  // Check if this provider account is already linked to a different user
+  const existingLink = await c.env.DB.prepare(
+    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
+  )
+    .bind(provider, userInfo.providerUserId)
+    .first<{ user_id: string }>();
+
+  if (existingLink && existingLink.user_id !== stateData.linkUserId) {
+    return c.json({ error: "This provider account is already linked to another user" }, 409);
+  }
+
+  // Encrypt tokens
+  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
+  const refreshTokenEnc = userInfo.refreshToken
+    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
+    : null;
+
+  if (existingLink) {
+    // Update existing link
+    await c.env.DB.prepare(
+      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+       WHERE provider = ? AND provider_user_id = ?`,
+    )
+      .bind(
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+        provider,
+        userInfo.providerUserId,
+      )
+      .run();
+  } else {
+    // Create new link
+    await c.env.DB.prepare(
+      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        stateData.linkUserId,
+        provider,
+        userInfo.providerUserId,
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+      )
+      .run();
+  }
+
+  return c.json(
+    { data: { provider, provider_username: userInfo.providerUsername } },
+    200,
+    securityHeaders(),
+  );
+});
+
+// ─── Public routes (parameterized, last) ─────────────────
+
+// GET /:provider (initiate OAuth login)
+auth.get("/:provider", async (c) => {
+  const provider = c.req.param("provider");
+  if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateState();
+  const nonce = provider === "google" ? generateNonce() : undefined;
+
+  const redirectUri = getRedirectUri(c, provider);
+  const authorizeUrl = buildAuthorizeUrl(provider, c.env, redirectUri, codeChallenge, state, nonce);
+
+  await storeOAuthState(c.env.KV, state, { codeVerifier, nonce });
+  setStateCookie(c, state, c.env);
+
+  return c.redirect(authorizeUrl, 302);
+});
+
+// GET /:provider/callback (OAuth callback — most complex)
+auth.get("/:provider/callback", async (c) => {
+  const provider = c.req.param("provider");
+  if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
+
+  // 1. Validate state (double-submit)
+  const stateParam = c.req.query("state");
+  const code = c.req.query("code");
+  const stateCookie = getStateCookie(c);
+  clearStateCookie(c);
+
+  if (!stateParam || !code || !stateCookie) {
+    return c.json({ error: "Missing state or code" }, 400);
+  }
+
+  if (!(await timingSafeEqual(stateParam, stateCookie))) {
+    return c.json({ error: "State mismatch" }, 400);
+  }
+
+  const stateData = await consumeOAuthState(c.env.KV, stateParam);
+  if (!stateData) {
+    return c.json({ error: "Invalid or expired state" }, 400);
+  }
+
+  // 2. Exchange code for tokens
+  const redirectUri = getRedirectUri(c, provider);
+  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+
+  // 3. Fetch/validate user info
+  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+
+  // 4. Email verification gate
+  if (!userInfo.emailVerified) {
+    return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
+  }
+
+  // 5. Account matching
+  // Encrypt tokens for storage
+  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
+  const refreshTokenEnc = userInfo.refreshToken
+    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
+    : null;
+
+  // Check for existing OAuth link
+  const existingOAuth = await c.env.DB.prepare(
+    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
+  )
+    .bind(provider, userInfo.providerUserId)
+    .first<{ user_id: string }>();
+
+  if (existingOAuth) {
+    // ─── Existing user login ─────────────────────
+    // Update provider tokens
+    await c.env.DB.prepare(
+      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+       WHERE provider = ? AND provider_user_id = ?`,
+    )
+      .bind(
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+        provider,
+        userInfo.providerUserId,
+      )
+      .run();
+
+    // Create session
+    const sessionToken = generateSessionToken();
+    const sessionTokenHash = await sha256Hex(sessionToken);
+    await createSession(c.env.DB, existingOAuth.user_id, sessionTokenHash, c.req.raw);
+    setSessionCookie(c, sessionToken, c.env);
+
+    const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+      .bind(existingOAuth.user_id)
+      .first<UserRow>();
+
+    if (!userRow) return c.json({ error: "User not found" }, 500);
+
+    return c.json(
+      { data: { user: rowToUser(userRow), is_new_user: false } },
+      200,
+      securityHeaders(),
+    );
+  }
+
+  // No existing OAuth link — check if email matches an existing user
+  if (userInfo.providerEmail) {
+    const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
+      .bind(userInfo.providerEmail)
+      .first<{ id: string; username: string }>();
+
+    if (emailMatch) {
+      // Create pending link for manual approval
+      const pendingId = crypto.randomUUID();
+      const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
+        .toISOString()
+        .replace("T", " ")
+        .replace("Z", "");
+
+      await c.env.DB.prepare(
+        `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          pendingId,
+          emailMatch.id,
+          provider,
+          userInfo.providerUserId,
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+          pendingExpiry,
+        )
+        .run();
+
+      // Return pending link info (no session — user needs to log in with existing account)
+      return c.json(
+        {
+          data: {
+            user: rowToUser(
+              (await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+                .bind(emailMatch.id)
+                .first<UserRow>())!,
+            ),
+            pending_link: {
+              id: pendingId,
+              provider: provider as OAuthProvider,
+              provider_username: userInfo.providerUsername,
+              provider_email: userInfo.providerEmail!,
+              existing_username: emailMatch.username,
+              expires_at: normalizeDateTime(pendingExpiry),
+            },
+          },
+        },
+        200,
+        securityHeaders(),
+      );
+    }
+  }
+
+  // No existing account — new user creation
+  const isSingleUser = c.env.INSTANCE_MODE !== "multi";
+
+  if (isSingleUser) {
+    // Check if any users exist
+    const userCount = await c.env.DB.prepare("SELECT COUNT(*) as count FROM users")
+      .first<{ count: number }>();
+
+    if (userCount && userCount.count > 0) {
+      return c.json(
+        { error: "Registration closed. This instance only allows one user." },
+        403,
+      );
+    }
+  }
+
+  // Create user
+  const userId = crypto.randomUUID();
+  const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
+
+  const username = userInfo.providerUsername.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64) || `user_${userId.slice(0, 8)}`;
+
+  await c.env.DB.prepare(
+    `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+     VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+  )
+    .bind(userId, username, userInfo.providerEmail, apiKeyHash)
+    .run();
+
+  // Create OAuth account link
+  await c.env.DB.prepare(
+    `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      userId,
+      provider,
+      userInfo.providerUserId,
+      userInfo.providerUsername,
+      userInfo.providerEmail,
+      userInfo.emailVerified ? 1 : 0,
+      accessTokenEnc,
+      refreshTokenEnc,
+      userInfo.tokenExpiresAt,
+    )
+    .run();
+
+  // Create session
+  const sessionToken = generateSessionToken();
+  const sessionTokenHash = await sha256Hex(sessionToken);
+  await createSession(c.env.DB, userId, sessionTokenHash, c.req.raw);
+  setSessionCookie(c, sessionToken, c.env);
+
+  const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+    .bind(userId)
+    .first<UserRow>();
+
+  return c.json(
+    {
+      data: {
+        user: rowToUser(userRow!),
+        api_key: apiKeyPlaintext,
+        is_new_user: true,
+      },
+    },
+    200,
+    securityHeaders(),
+  );
+});
+
+export default auth;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -58,8 +58,8 @@ const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
 
 // ─── Helpers ─────────────────────────────────────────────
 
-function getRedirectUri(c: { req: { url: string } }, provider: string, isLink = false): string {
-  const origin = new URL(c.req.url).origin;
+function getRedirectUri(c: { req: { url: string }; env: Env }, provider: string, isLink = false): string {
+  const origin = c.env.APP_URL?.replace(/\/+$/, "") ?? new URL(c.req.url).origin;
   return isLink
     ? `${origin}/api/v1/auth/link/${provider}/callback`
     : `${origin}/api/v1/auth/${provider}/callback`;
@@ -379,6 +379,12 @@ auth.get("/link/:provider/callback", async (c) => {
   const provider = c.req.param("provider");
   if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
 
+  // Handle OAuth error (e.g., user denied access)
+  const oauthError = c.req.query("error");
+  if (oauthError) {
+    return c.json({ error: `OAuth error: ${oauthError}` }, 400);
+  }
+
   // Validate state (double-submit)
   const stateParam = c.req.query("state");
   const code = c.req.query("code");
@@ -389,7 +395,7 @@ auth.get("/link/:provider/callback", async (c) => {
     return c.json({ error: "Missing state or code" }, 400);
   }
 
-  if (!(await timingSafeEqual(stateParam, stateCookie))) {
+  if (!timingSafeEqual(stateParam, stateCookie)) {
     return c.json({ error: "State mismatch" }, 400);
   }
 
@@ -504,6 +510,12 @@ auth.get("/:provider/callback", async (c) => {
   const provider = c.req.param("provider");
   if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400);
 
+  // Handle OAuth error (e.g., user denied access)
+  const oauthError = c.req.query("error");
+  if (oauthError) {
+    return c.json({ error: `OAuth error: ${oauthError}` }, 400);
+  }
+
   // 1. Validate state (double-submit)
   const stateParam = c.req.query("state");
   const code = c.req.query("code");
@@ -514,7 +526,7 @@ auth.get("/:provider/callback", async (c) => {
     return c.json({ error: "Missing state or code" }, 400);
   }
 
-  if (!(await timingSafeEqual(stateParam, stateCookie))) {
+  if (!timingSafeEqual(stateParam, stateCookie)) {
     return c.json({ error: "State mismatch" }, 400);
   }
 
@@ -622,21 +634,15 @@ auth.get("/:provider/callback", async (c) => {
           )
           .run();
 
-        // Return pending link info (no session — user needs to log in with existing account)
+        // Return minimal pending link info (no full user profile — unauthenticated response)
         return c.json(
           {
             data: {
-              user: rowToUser(
-                (await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-                  .bind(emailMatch.id)
-                  .first<UserRow>())!,
-              ),
               pending_link: {
                 id: pendingId,
                 provider: provider as OAuthProvider,
                 provider_username: userInfo.providerUsername,
                 provider_email: userInfo.providerEmail!,
-                existing_username: emailMatch.username,
                 expires_at: normalizeDateTime(pendingExpiry),
               },
             },
@@ -677,19 +683,16 @@ auth.get("/:provider/callback", async (c) => {
       username = `${username.slice(0, 55)}_${userId.slice(0, 8)}`;
     }
 
-    await c.env.DB.prepare(
-      `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
-    )
-      .bind(userId, username, userInfo.providerEmail, apiKeyHash)
-      .run();
-
-    // Create OAuth account link
-    await c.env.DB.prepare(
-      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-      .bind(
+    // Atomic: create user + OAuth account in single batch
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
+      c.env.DB.prepare(
+        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
         crypto.randomUUID(),
         userId,
         provider,
@@ -700,8 +703,8 @@ auth.get("/:provider/callback", async (c) => {
         accessTokenEnc,
         refreshTokenEnc,
         userInfo.tokenExpiresAt,
-      )
-      .run();
+      ),
+    ]);
 
     // Create session
     const sessionToken = generateSessionToken();

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -3,6 +3,7 @@
  */
 import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
+import { csrf } from "hono/csrf";
 import type { Env, SessionAuthEnv } from "../types";
 import {
   sha256Hex,
@@ -40,6 +41,9 @@ import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../uti
 
 const auth = new Hono<{ Bindings: Env }>();
 
+// CSRF protection — validates Origin header for non-safe methods (POST, DELETE)
+auth.use("/*", csrf());
+
 // ─── Session Middleware ──────────────────────────────────
 
 const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
@@ -59,7 +63,14 @@ const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
 // ─── Helpers ─────────────────────────────────────────────
 
 function getRedirectUri(c: { req: { url: string }; env: Env }, provider: string, isLink = false): string {
-  const origin = c.env.APP_URL?.replace(/\/+$/, "") ?? new URL(c.req.url).origin;
+  let origin = c.env.APP_URL?.replace(/\/+$/, "");
+  if (!origin) {
+    if (c.env.ENVIRONMENT === "development" || c.env.ENVIRONMENT === undefined) {
+      origin = new URL(c.req.url).origin;
+    } else {
+      throw new Error("APP_URL environment variable is required in production");
+    }
+  }
   return isLink
     ? `${origin}/api/v1/auth/link/${provider}/callback`
     : `${origin}/api/v1/auth/${provider}/callback`;
@@ -395,7 +406,7 @@ auth.get("/link/:provider/callback", async (c) => {
     return c.json({ error: "Missing state or code" }, 400);
   }
 
-  if (!timingSafeEqual(stateParam, stateCookie)) {
+  if (!(await timingSafeEqual(stateParam, stateCookie))) {
     return c.json({ error: "State mismatch" }, 400);
   }
 
@@ -429,10 +440,11 @@ auth.get("/link/:provider/callback", async (c) => {
       return c.json({ error: "This provider account is already linked to another user" }, 409);
     }
 
-    // Encrypt tokens
-    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
+    // Encrypt tokens with AAD context (binds ciphertext to this user+provider)
+    const encCtx = `${stateData.linkUserId}:${provider}`;
+    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
     const refreshTokenEnc = userInfo.refreshToken
-      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
+      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
       : null;
 
     if (existingLink) {
@@ -526,7 +538,7 @@ auth.get("/:provider/callback", async (c) => {
     return c.json({ error: "Missing state or code" }, 400);
   }
 
-  if (!timingSafeEqual(stateParam, stateCookie)) {
+  if (!(await timingSafeEqual(stateParam, stateCookie))) {
     return c.json({ error: "State mismatch" }, 400);
   }
 
@@ -548,14 +560,7 @@ auth.get("/:provider/callback", async (c) => {
       return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
     }
 
-    // 5. Account matching
-    // Encrypt tokens for storage
-    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
-    const refreshTokenEnc = userInfo.refreshToken
-      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
-      : null;
-
-    // Check for existing OAuth link
+    // 5. Account matching — check for existing OAuth link
     const existingOAuth = await c.env.DB.prepare(
       "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
     )
@@ -564,6 +569,12 @@ auth.get("/:provider/callback", async (c) => {
 
     if (existingOAuth) {
       // ─── Existing user login ─────────────────────
+      const encCtx = `${existingOAuth.user_id}:${provider}`;
+      const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+      const refreshTokenEnc = userInfo.refreshToken
+        ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+        : null;
+
       // Update provider tokens
       await c.env.DB.prepare(
         `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
@@ -608,6 +619,23 @@ auth.get("/:provider/callback", async (c) => {
         .first<{ id: string; username: string }>();
 
       if (emailMatch) {
+        // Limit active pending links per user
+        const activeLinkCount = await c.env.DB.prepare(
+          "SELECT COUNT(*) as count FROM pending_links WHERE existing_user_id = ? AND expires_at > datetime('now')",
+        )
+          .bind(emailMatch.id)
+          .first<{ count: number }>();
+        if (activeLinkCount && activeLinkCount.count >= 3) {
+          return c.json({ error: "Too many pending link requests" }, 429);
+        }
+
+        // Encrypt tokens with AAD context
+        const encCtx = `${emailMatch.id}:${provider}`;
+        const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+        const refreshTokenEnc = userInfo.refreshToken
+          ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+          : null;
+
         // Create pending link for manual approval
         const pendingId = crypto.randomUUID();
         const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
@@ -655,21 +683,6 @@ auth.get("/:provider/callback", async (c) => {
 
     // No existing account — new user creation
     const isSingleUser = c.env.INSTANCE_MODE !== "multi";
-
-    if (isSingleUser) {
-      // Check if any users exist
-      const userCount = await c.env.DB.prepare("SELECT COUNT(*) as count FROM users")
-        .first<{ count: number }>();
-
-      if (userCount && userCount.count > 0) {
-        return c.json(
-          { error: "Registration closed. This instance only allows one user." },
-          403,
-        );
-      }
-    }
-
-    // Create user
     const userId = crypto.randomUUID();
     const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
 
@@ -683,28 +696,72 @@ auth.get("/:provider/callback", async (c) => {
       username = `${username.slice(0, 55)}_${userId.slice(0, 8)}`;
     }
 
-    // Atomic: create user + OAuth account in single batch
-    await c.env.DB.batch([
-      c.env.DB.prepare(
-        `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
-      ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
-      c.env.DB.prepare(
-        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ).bind(
-        crypto.randomUUID(),
-        userId,
-        provider,
-        userInfo.providerUserId,
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-      ),
-    ]);
+    // Encrypt tokens with AAD context
+    const encCtx = `${userId}:${provider}`;
+    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+    const refreshTokenEnc = userInfo.refreshToken
+      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+      : null;
+
+    const oauthAccountId = crypto.randomUUID();
+
+    if (isSingleUser) {
+      // Atomic: create user only if no users exist (prevents TOCTOU race)
+      const batchResult = await c.env.DB.batch([
+        c.env.DB.prepare(
+          `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+           SELECT ?, ?, ?, ?, datetime('now'), datetime('now')
+           WHERE (SELECT COUNT(*) FROM users) = 0`,
+        ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
+        c.env.DB.prepare(
+          `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+           SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+           WHERE EXISTS (SELECT 1 FROM users WHERE id = ?)`,
+        ).bind(
+          oauthAccountId,
+          userId,
+          provider,
+          userInfo.providerUserId,
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+          userId,
+        ),
+      ]);
+
+      if (batchResult[0].meta.changes === 0) {
+        return c.json(
+          { error: "Registration closed. This instance only allows one user." },
+          403,
+        );
+      }
+    } else {
+      // Multi-user mode: unconditional insert
+      await c.env.DB.batch([
+        c.env.DB.prepare(
+          `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+           VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+        ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
+        c.env.DB.prepare(
+          `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).bind(
+          oauthAccountId,
+          userId,
+          provider,
+          userInfo.providerUserId,
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+        ),
+      ]);
+    }
 
     // Create session
     const sessionToken = generateSessionToken();

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -27,7 +27,6 @@ import {
   validateSession,
   invalidateSession,
   invalidateOtherSessions,
-  invalidateAllUserSessions,
   setSessionCookie,
   clearSessionCookie,
   getSessionTokenFromCookie,
@@ -238,15 +237,20 @@ auth.delete("/providers/:provider", sessionMw, async (c) => {
     return c.json({ error: "Invalid provider" }, 400);
   }
 
-  // Ensure user has at least one other auth method (another provider or API key)
-  const { results: linked } = await c.env.DB.prepare(
-    "SELECT provider FROM oauth_accounts WHERE user_id = ?",
-  )
-    .bind(userId)
-    .all<{ provider: string }>();
+  // Ensure user keeps at least one other auth method
+  const [{ results: linked }, userRow] = await Promise.all([
+    c.env.DB.prepare("SELECT provider FROM oauth_accounts WHERE user_id = ?")
+      .bind(userId)
+      .all<{ provider: string }>(),
+    c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+      .bind(userId)
+      .first<{ api_key_hash: string | null }>(),
+  ]);
 
-  if (linked.length <= 1) {
-    return c.json({ error: "Cannot unlink the only authentication provider" }, 400);
+  const hasApiKey = !!userRow?.api_key_hash;
+  const otherProviders = linked.filter((p) => p.provider !== provider).length;
+  if (otherProviders === 0 && !hasApiKey) {
+    return c.json({ error: "Cannot unlink the only authentication method" }, 400);
   }
 
   await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
@@ -403,71 +407,75 @@ auth.get("/link/:provider/callback", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const redirectUri = getRedirectUri(c, provider, true);
-  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
-  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+  try {
+    const redirectUri = getRedirectUri(c, provider, true);
+    const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+    const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
 
-  // Check if this provider account is already linked to a different user
-  const existingLink = await c.env.DB.prepare(
-    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
-  )
-    .bind(provider, userInfo.providerUserId)
-    .first<{ user_id: string }>();
-
-  if (existingLink && existingLink.user_id !== stateData.linkUserId) {
-    return c.json({ error: "This provider account is already linked to another user" }, 409);
-  }
-
-  // Encrypt tokens
-  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
-  const refreshTokenEnc = userInfo.refreshToken
-    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
-    : null;
-
-  if (existingLink) {
-    // Update existing link
-    await c.env.DB.prepare(
-      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-       WHERE provider = ? AND provider_user_id = ?`,
+    // Check if this provider account is already linked to a different user
+    const existingLink = await c.env.DB.prepare(
+      "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
     )
-      .bind(
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-        provider,
-        userInfo.providerUserId,
-      )
-      .run();
-  } else {
-    // Create new link
-    await c.env.DB.prepare(
-      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-      .bind(
-        crypto.randomUUID(),
-        stateData.linkUserId,
-        provider,
-        userInfo.providerUserId,
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-      )
-      .run();
-  }
+      .bind(provider, userInfo.providerUserId)
+      .first<{ user_id: string }>();
 
-  return c.json(
-    { data: { provider, provider_username: userInfo.providerUsername } },
-    200,
-    securityHeaders(),
-  );
+    if (existingLink && existingLink.user_id !== stateData.linkUserId) {
+      return c.json({ error: "This provider account is already linked to another user" }, 409);
+    }
+
+    // Encrypt tokens
+    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
+    const refreshTokenEnc = userInfo.refreshToken
+      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
+      : null;
+
+    if (existingLink) {
+      // Update existing link
+      await c.env.DB.prepare(
+        `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+         access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+         WHERE provider = ? AND provider_user_id = ?`,
+      )
+        .bind(
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+          provider,
+          userInfo.providerUserId,
+        )
+        .run();
+    } else {
+      // Create new link
+      await c.env.DB.prepare(
+        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          crypto.randomUUID(),
+          stateData.linkUserId,
+          provider,
+          userInfo.providerUserId,
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+        )
+        .run();
+    }
+
+    return c.json(
+      { data: { provider, provider_username: userInfo.providerUsername } },
+      200,
+      securityHeaders(),
+    );
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 // ─── Public routes (parameterized, last) ─────────────────
@@ -515,198 +523,210 @@ auth.get("/:provider/callback", async (c) => {
     return c.json({ error: "Invalid or expired state" }, 400);
   }
 
-  // 2. Exchange code for tokens
-  const redirectUri = getRedirectUri(c, provider);
-  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+  try {
+    // 2. Exchange code for tokens
+    const redirectUri = getRedirectUri(c, provider);
+    const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
 
-  // 3. Fetch/validate user info
-  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+    // 3. Fetch/validate user info
+    const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
 
-  // 4. Email verification gate
-  if (!userInfo.emailVerified) {
-    return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
-  }
+    // 4. Email verification gate
+    if (!userInfo.emailVerified) {
+      return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
+    }
 
-  // 5. Account matching
-  // Encrypt tokens for storage
-  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
-  const refreshTokenEnc = userInfo.refreshToken
-    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
-    : null;
+    // 5. Account matching
+    // Encrypt tokens for storage
+    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY);
+    const refreshTokenEnc = userInfo.refreshToken
+      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY)
+      : null;
 
-  // Check for existing OAuth link
-  const existingOAuth = await c.env.DB.prepare(
-    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
-  )
-    .bind(provider, userInfo.providerUserId)
-    .first<{ user_id: string }>();
-
-  if (existingOAuth) {
-    // ─── Existing user login ─────────────────────
-    // Update provider tokens
-    await c.env.DB.prepare(
-      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-       WHERE provider = ? AND provider_user_id = ?`,
+    // Check for existing OAuth link
+    const existingOAuth = await c.env.DB.prepare(
+      "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
     )
-      .bind(
-        userInfo.providerUsername,
-        userInfo.providerEmail,
-        userInfo.emailVerified ? 1 : 0,
-        accessTokenEnc,
-        refreshTokenEnc,
-        userInfo.tokenExpiresAt,
-        provider,
-        userInfo.providerUserId,
-      )
-      .run();
+      .bind(provider, userInfo.providerUserId)
+      .first<{ user_id: string }>();
 
-    // Create session
-    const sessionToken = generateSessionToken();
-    const sessionTokenHash = await sha256Hex(sessionToken);
-    await createSession(c.env.DB, existingOAuth.user_id, sessionTokenHash, c.req.raw);
-    setSessionCookie(c, sessionToken, c.env);
-
-    const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-      .bind(existingOAuth.user_id)
-      .first<UserRow>();
-
-    if (!userRow) return c.json({ error: "User not found" }, 500);
-
-    return c.json(
-      { data: { user: rowToUser(userRow), is_new_user: false } },
-      200,
-      securityHeaders(),
-    );
-  }
-
-  // No existing OAuth link — check if email matches an existing user
-  if (userInfo.providerEmail) {
-    const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
-      .bind(userInfo.providerEmail)
-      .first<{ id: string; username: string }>();
-
-    if (emailMatch) {
-      // Create pending link for manual approval
-      const pendingId = crypto.randomUUID();
-      const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
-        .toISOString()
-        .replace("T", " ")
-        .replace("Z", "");
-
+    if (existingOAuth) {
+      // ─── Existing user login ─────────────────────
+      // Update provider tokens
       await c.env.DB.prepare(
-        `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+         access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+         WHERE provider = ? AND provider_user_id = ?`,
       )
         .bind(
-          pendingId,
-          emailMatch.id,
-          provider,
-          userInfo.providerUserId,
           userInfo.providerUsername,
           userInfo.providerEmail,
           userInfo.emailVerified ? 1 : 0,
           accessTokenEnc,
           refreshTokenEnc,
           userInfo.tokenExpiresAt,
-          pendingExpiry,
+          provider,
+          userInfo.providerUserId,
         )
         .run();
 
-      // Return pending link info (no session — user needs to log in with existing account)
+      // Create session
+      const sessionToken = generateSessionToken();
+      const sessionTokenHash = await sha256Hex(sessionToken);
+      await createSession(c.env.DB, existingOAuth.user_id, sessionTokenHash, c.req.raw);
+      setSessionCookie(c, sessionToken, c.env);
+
+      const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+        .bind(existingOAuth.user_id)
+        .first<UserRow>();
+
+      if (!userRow) return c.json({ error: "User not found" }, 500);
+
       return c.json(
-        {
-          data: {
-            user: rowToUser(
-              (await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-                .bind(emailMatch.id)
-                .first<UserRow>())!,
-            ),
-            pending_link: {
-              id: pendingId,
-              provider: provider as OAuthProvider,
-              provider_username: userInfo.providerUsername,
-              provider_email: userInfo.providerEmail!,
-              existing_username: emailMatch.username,
-              expires_at: normalizeDateTime(pendingExpiry),
-            },
-          },
-        },
+        { data: { user: rowToUser(userRow), is_new_user: false } },
         200,
         securityHeaders(),
       );
     }
-  }
 
-  // No existing account — new user creation
-  const isSingleUser = c.env.INSTANCE_MODE !== "multi";
+    // No existing OAuth link — check if email matches an existing user
+    if (userInfo.providerEmail) {
+      const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
+        .bind(userInfo.providerEmail)
+        .first<{ id: string; username: string }>();
 
-  if (isSingleUser) {
-    // Check if any users exist
-    const userCount = await c.env.DB.prepare("SELECT COUNT(*) as count FROM users")
-      .first<{ count: number }>();
+      if (emailMatch) {
+        // Create pending link for manual approval
+        const pendingId = crypto.randomUUID();
+        const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
+          .toISOString()
+          .replace("T", " ")
+          .replace("Z", "");
 
-    if (userCount && userCount.count > 0) {
-      return c.json(
-        { error: "Registration closed. This instance only allows one user." },
-        403,
-      );
+        await c.env.DB.prepare(
+          `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+          .bind(
+            pendingId,
+            emailMatch.id,
+            provider,
+            userInfo.providerUserId,
+            userInfo.providerUsername,
+            userInfo.providerEmail,
+            userInfo.emailVerified ? 1 : 0,
+            accessTokenEnc,
+            refreshTokenEnc,
+            userInfo.tokenExpiresAt,
+            pendingExpiry,
+          )
+          .run();
+
+        // Return pending link info (no session — user needs to log in with existing account)
+        return c.json(
+          {
+            data: {
+              user: rowToUser(
+                (await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+                  .bind(emailMatch.id)
+                  .first<UserRow>())!,
+              ),
+              pending_link: {
+                id: pendingId,
+                provider: provider as OAuthProvider,
+                provider_username: userInfo.providerUsername,
+                provider_email: userInfo.providerEmail!,
+                existing_username: emailMatch.username,
+                expires_at: normalizeDateTime(pendingExpiry),
+              },
+            },
+          },
+          200,
+          securityHeaders(),
+        );
+      }
     }
-  }
 
-  // Create user
-  const userId = crypto.randomUUID();
-  const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
+    // No existing account — new user creation
+    const isSingleUser = c.env.INSTANCE_MODE !== "multi";
 
-  const username = userInfo.providerUsername.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64) || `user_${userId.slice(0, 8)}`;
+    if (isSingleUser) {
+      // Check if any users exist
+      const userCount = await c.env.DB.prepare("SELECT COUNT(*) as count FROM users")
+        .first<{ count: number }>();
 
-  await c.env.DB.prepare(
-    `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-     VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
-  )
-    .bind(userId, username, userInfo.providerEmail, apiKeyHash)
-    .run();
+      if (userCount && userCount.count > 0) {
+        return c.json(
+          { error: "Registration closed. This instance only allows one user." },
+          403,
+        );
+      }
+    }
 
-  // Create OAuth account link
-  await c.env.DB.prepare(
-    `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  )
-    .bind(
-      crypto.randomUUID(),
-      userId,
-      provider,
-      userInfo.providerUserId,
-      userInfo.providerUsername,
-      userInfo.providerEmail,
-      userInfo.emailVerified ? 1 : 0,
-      accessTokenEnc,
-      refreshTokenEnc,
-      userInfo.tokenExpiresAt,
+    // Create user
+    const userId = crypto.randomUUID();
+    const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
+
+    let username = userInfo.providerUsername.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64) || `user_${userId.slice(0, 8)}`;
+
+    // Handle username collision by appending random suffix
+    const existingUsername = await c.env.DB.prepare("SELECT 1 FROM users WHERE username = ?")
+      .bind(username)
+      .first();
+    if (existingUsername) {
+      username = `${username.slice(0, 55)}_${userId.slice(0, 8)}`;
+    }
+
+    await c.env.DB.prepare(
+      `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
     )
-    .run();
+      .bind(userId, username, userInfo.providerEmail, apiKeyHash)
+      .run();
 
-  // Create session
-  const sessionToken = generateSessionToken();
-  const sessionTokenHash = await sha256Hex(sessionToken);
-  await createSession(c.env.DB, userId, sessionTokenHash, c.req.raw);
-  setSessionCookie(c, sessionToken, c.env);
+    // Create OAuth account link
+    await c.env.DB.prepare(
+      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        userId,
+        provider,
+        userInfo.providerUserId,
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+      )
+      .run();
 
-  const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-    .bind(userId)
-    .first<UserRow>();
+    // Create session
+    const sessionToken = generateSessionToken();
+    const sessionTokenHash = await sha256Hex(sessionToken);
+    await createSession(c.env.DB, userId, sessionTokenHash, c.req.raw);
+    setSessionCookie(c, sessionToken, c.env);
 
-  return c.json(
-    {
-      data: {
-        user: rowToUser(userRow!),
-        api_key: apiKeyPlaintext,
-        is_new_user: true,
+    const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+      .bind(userId)
+      .first<UserRow>();
+
+    return c.json(
+      {
+        data: {
+          user: rowToUser(userRow!),
+          api_key: apiKeyPlaintext,
+          is_new_user: true,
+        },
       },
-    },
-    200,
-    securityHeaders(),
-  );
+      200,
+      securityHeaders(),
+    );
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 export default auth;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -378,8 +378,8 @@ auth.get("/link/:provider/callback", async (c) => {
   // Validate state (double-submit)
   const stateParam = c.req.query("state");
   const code = c.req.query("code");
-  const stateCookie = getStateCookie(c);
-  clearStateCookie(c);
+  const stateCookie = getStateCookie(c, c.env);
+  clearStateCookie(c, c.env);
 
   if (!stateParam || !code || !stateCookie) {
     return c.json({ error: "Missing state or code" }, 400);
@@ -499,8 +499,8 @@ auth.get("/:provider/callback", async (c) => {
   // 1. Validate state (double-submit)
   const stateParam = c.req.query("state");
   const code = c.req.query("code");
-  const stateCookie = getStateCookie(c);
-  clearStateCookie(c);
+  const stateCookie = getStateCookie(c, c.env);
+  clearStateCookie(c, c.env);
 
   if (!stateParam || !code || !stateCookie) {
     return c.json({ error: "Missing state or code" }, 400);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -14,6 +14,7 @@ import {
   generateSessionToken,
   generateApiKey,
   encryptToken,
+  decryptToken,
   timingSafeEqual,
 } from "../utils/crypto";
 import {
@@ -21,6 +22,7 @@ import {
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserInfo,
+  revokeProviderToken,
   type OAuthProvider,
 } from "../utils/oauth";
 import {
@@ -274,15 +276,18 @@ auth.delete("/providers/:provider", sessionMw, async (c) => {
 
     // Ensure user keeps at least one other auth method
     const [{ results: linked }, userRow] = await Promise.all([
-      c.env.DB.prepare("SELECT provider FROM oauth_accounts WHERE user_id = ?")
+      c.env.DB.prepare(
+        "SELECT provider, access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ?",
+      )
         .bind(userId)
-        .all<{ provider: string }>(),
+        .all<{ provider: string; access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
       c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
         .bind(userId)
         .first<{ api_key_hash: string | null }>(),
     ]);
 
     const hasApiKey = !!userRow?.api_key_hash;
+    const targetRow = linked.find((p) => p.provider === provider);
     const otherProviders = linked.filter((p) => p.provider !== provider).length;
     if (otherProviders === 0 && !hasApiKey) {
       return c.json({ error: "Cannot unlink the only authentication method" }, 400);
@@ -291,6 +296,31 @@ auth.delete("/providers/:provider", sessionMw, async (c) => {
     await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
       .bind(userId, provider)
       .run();
+
+    // Best-effort token revocation in the background
+    if (targetRow?.access_token_encrypted) {
+      const encCtx = `${userId}:${provider}`;
+      const encKey = c.env.ENCRYPTION_KEY;
+      const accessEnc = targetRow.access_token_encrypted;
+      const refreshEnc = targetRow.refresh_token_encrypted;
+
+      c.executionCtx.waitUntil(
+        (async () => {
+          try {
+            const accessToken = await decryptToken(accessEnc, encKey, encCtx);
+            const refreshToken = refreshEnc
+              ? await decryptToken(refreshEnc, encKey, encCtx)
+              : null;
+            await revokeProviderToken(provider, accessToken, refreshToken, c.env);
+          } catch (err) {
+            console.error(
+              `Token revocation failed for ${provider}:`,
+              err instanceof Error ? err.message : err,
+            );
+          }
+        })(),
+      );
+    }
 
     return c.body(null, 204);
   } catch (err) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -42,7 +42,15 @@ import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../uti
 const auth = new Hono<{ Bindings: Env }>();
 
 // CSRF protection — validates Origin header for non-safe methods (POST, DELETE)
-auth.use("/*", csrf());
+auth.use(
+  "/*",
+  csrf({
+    origin: (origin, c) => {
+      const appUrl = (c.env as Env).APP_URL?.replace(/\/+$/, "");
+      return appUrl ? origin === appUrl : true;
+    },
+  }),
+);
 
 // ─── Session Middleware ──────────────────────────────────
 
@@ -59,8 +67,9 @@ const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
     c.set("sessionId", session.sessionId);
     c.set("sessionTokenHash", tokenHash);
     await next();
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -131,8 +140,9 @@ auth.get("/session", sessionMw, async (c) => {
       200,
       { "Cache-Control": "no-store" },
     );
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -184,8 +194,9 @@ auth.get("/sessions", sessionMw, async (c) => {
       200,
       { "Cache-Control": "no-store" },
     );
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -282,8 +293,9 @@ auth.delete("/providers/:provider", sessionMw, async (c) => {
       .run();
 
     return c.body(null, 204);
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -317,8 +329,9 @@ auth.post("/api-key", sessionMw, async (c) => {
       200,
       { "Cache-Control": "no-store" },
     );
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -414,7 +427,7 @@ auth.get("/link/:provider/callback", async (c) => {
   const oauthError = c.req.query("error");
   if (oauthError) {
     console.error(`OAuth error from ${provider}: ${oauthError}`);
-    return c.json({ error: "OAuth authorization failed" }, 400);
+    return c.json({ error: "OAuth authorization failed" }, 400, securityHeaders());
   }
 
   // Validate state (double-submit)
@@ -424,16 +437,16 @@ auth.get("/link/:provider/callback", async (c) => {
   clearStateCookie(c, c.env);
 
   if (!stateParam || !code || !stateCookie) {
-    return c.json({ error: "Missing state or code" }, 400);
+    return c.json({ error: "Missing state or code" }, 400, securityHeaders());
   }
 
   if (!(await timingSafeEqual(stateParam, stateCookie))) {
-    return c.json({ error: "State mismatch" }, 400);
+    return c.json({ error: "State mismatch" }, 400, securityHeaders());
   }
 
   const stateData = await consumeOAuthState(c.env.KV, stateParam);
   if (!stateData || !stateData.linkUserId) {
-    return c.json({ error: "Invalid or expired state" }, 400);
+    return c.json({ error: "Invalid or expired state" }, 400, securityHeaders());
   }
 
   // Validate session from cookie
@@ -449,6 +462,15 @@ auth.get("/link/:provider/callback", async (c) => {
     const redirectUri = getRedirectUri(c, provider, true);
     const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
     const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+
+    // Email verification gate (same as login callback)
+    if (!userInfo.emailVerified) {
+      return c.json(
+        { error: "Email not verified with provider. Please verify your email first." },
+        400,
+        securityHeaders(),
+      );
+    }
 
     // Check if this provider account is already linked to a different user
     const existingLink = await c.env.DB.prepare(
@@ -512,8 +534,9 @@ auth.get("/link/:provider/callback", async (c) => {
       200,
       securityHeaders(),
     );
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 
@@ -547,7 +570,7 @@ auth.get("/:provider/callback", async (c) => {
   const oauthError = c.req.query("error");
   if (oauthError) {
     console.error(`OAuth error from ${provider}: ${oauthError}`);
-    return c.json({ error: "OAuth authorization failed" }, 400);
+    return c.json({ error: "OAuth authorization failed" }, 400, securityHeaders());
   }
 
   // 1. Validate state (double-submit)
@@ -557,16 +580,16 @@ auth.get("/:provider/callback", async (c) => {
   clearStateCookie(c, c.env);
 
   if (!stateParam || !code || !stateCookie) {
-    return c.json({ error: "Missing state or code" }, 400);
+    return c.json({ error: "Missing state or code" }, 400, securityHeaders());
   }
 
   if (!(await timingSafeEqual(stateParam, stateCookie))) {
-    return c.json({ error: "State mismatch" }, 400);
+    return c.json({ error: "State mismatch" }, 400, securityHeaders());
   }
 
   const stateData = await consumeOAuthState(c.env.KV, stateParam);
   if (!stateData) {
-    return c.json({ error: "Invalid or expired state" }, 400);
+    return c.json({ error: "Invalid or expired state" }, 400, securityHeaders());
   }
 
   try {
@@ -808,8 +831,9 @@ auth.get("/:provider/callback", async (c) => {
       200,
       securityHeaders(),
     );
-  } catch {
-    return c.json({ error: "Internal server error" }, 500);
+  } catch (err) {
+    console.error("Auth error:", err instanceof Error ? err.message : err);
+    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
 });
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -40,16 +40,23 @@ import {
   clearStateCookie,
 } from "../utils/session";
 import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../utils/user";
+import { matchOrigin } from "../utils/origin";
 
 const auth = new Hono<{ Bindings: Env }>();
+
+// Global error handler for auth routes — replaces per-handler try/catch boilerplate
+auth.onError((err, c) => {
+  console.error("Auth error:", err instanceof Error ? err.message : err);
+  return c.json({ error: "Internal server error" }, 500, securityHeaders());
+});
 
 // CSRF protection — validates Origin header for non-safe methods (POST, DELETE)
 auth.use(
   "/*",
   csrf({
     origin: (origin, c) => {
-      const appUrl = (c.env as Env).APP_URL?.replace(/\/+$/, "");
-      return appUrl ? origin === appUrl : true;
+      const appUrl = (c.env as Env).APP_URL;
+      return appUrl ? matchOrigin(origin, appUrl) === origin : true;
     },
   }),
 );
@@ -57,22 +64,17 @@ auth.use(
 // ─── Session Middleware ──────────────────────────────────
 
 const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
-  try {
-    const token = getSessionTokenFromCookie(c, c.env);
-    if (!token) return c.json({ error: "Unauthorized" }, 401);
+  const token = getSessionTokenFromCookie(c, c.env);
+  if (!token) return c.json({ error: "Unauthorized" }, 401);
 
-    const tokenHash = await sha256Hex(token);
-    const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
-    if (!session) return c.json({ error: "Unauthorized" }, 401);
+  const tokenHash = await sha256Hex(token);
+  const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
+  if (!session) return c.json({ error: "Unauthorized" }, 401);
 
-    c.set("userId", session.userId);
-    c.set("sessionId", session.sessionId);
-    c.set("sessionTokenHash", tokenHash);
-    await next();
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
-  }
+  c.set("userId", session.userId);
+  c.set("sessionId", session.sessionId);
+  c.set("sessionTokenHash", tokenHash);
+  await next();
 });
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -99,53 +101,61 @@ function securityHeaders(): Record<string, string> {
   };
 }
 
+function mapProviderRow(p: {
+  provider: string;
+  provider_user_id: string;
+  provider_username: string;
+  provider_email: string | null;
+  email_verified: number;
+  created_at: string;
+}) {
+  return {
+    provider: p.provider as OAuthProvider,
+    provider_user_id: p.provider_user_id,
+    provider_username: p.provider_username,
+    provider_email: p.provider_email ?? undefined,
+    email_verified: p.email_verified === 1,
+    created_at: normalizeDateTime(p.created_at),
+  };
+}
+
+type ProviderRow = {
+  provider: string;
+  provider_user_id: string;
+  provider_username: string;
+  provider_email: string | null;
+  email_verified: number;
+  created_at: string;
+};
+
 // ─── Session-authenticated routes (static paths first) ───
 
 // GET /session
 auth.get("/session", sessionMw, async (c) => {
-  try {
-    const userId = c.get("userId");
-    const [userRow, providers] = await Promise.all([
-      c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-        .bind(userId)
-        .first<UserRow>(),
-      c.env.DB.prepare(
-        "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
-      )
-        .bind(userId)
-        .all<{
-          provider: string;
-          provider_user_id: string;
-          provider_username: string;
-          provider_email: string | null;
-          email_verified: number;
-          created_at: string;
-        }>(),
-    ]);
+  const userId = c.get("userId");
+  const [userRow, providers] = await Promise.all([
+    c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+      .bind(userId)
+      .first<UserRow>(),
+    c.env.DB.prepare(
+      "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
+    )
+      .bind(userId)
+      .all<ProviderRow>(),
+  ]);
 
-    if (!userRow) return c.json({ error: "Unauthorized" }, 401);
+  if (!userRow) return c.json({ error: "Unauthorized" }, 401);
 
-    return c.json(
-      {
-        data: {
-          user: rowToUser(userRow),
-          providers: providers.results.map((p) => ({
-            provider: p.provider as OAuthProvider,
-            provider_user_id: p.provider_user_id,
-            provider_username: p.provider_username,
-            provider_email: p.provider_email ?? undefined,
-            email_verified: p.email_verified === 1,
-            created_at: normalizeDateTime(p.created_at),
-          })),
-        },
+  return c.json(
+    {
+      data: {
+        user: rowToUser(userRow),
+        providers: providers.results.map(mapProviderRow),
       },
-      200,
-      { "Cache-Control": "no-store" },
-    );
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
-  }
+    },
+    200,
+    { "Cache-Control": "no-store" },
+  );
 });
 
 // DELETE /session (logout)
@@ -158,48 +168,43 @@ auth.delete("/session", sessionMw, async (c) => {
 
 // GET /sessions (list all active sessions)
 auth.get("/sessions", sessionMw, async (c) => {
-  try {
-    const userId = c.get("userId");
-    const currentSessionId = c.get("sessionId");
+  const userId = c.get("userId");
+  const currentSessionId = c.get("sessionId");
 
-    const { results } = await c.env.DB.prepare(
-      `SELECT id, ip, country, city, user_agent, created_at, expires_at, last_active_at
-       FROM sessions WHERE user_id = ? AND expires_at > datetime('now')
-       ORDER BY last_active_at DESC`,
-    )
-      .bind(userId)
-      .all<{
-        id: string;
-        ip: string | null;
-        country: string | null;
-        city: string | null;
-        user_agent: string | null;
-        created_at: string;
-        expires_at: string;
-        last_active_at: string;
-      }>();
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, ip, country, city, user_agent, created_at, expires_at, last_active_at
+     FROM sessions WHERE user_id = ? AND expires_at > datetime('now')
+     ORDER BY last_active_at DESC`,
+  )
+    .bind(userId)
+    .all<{
+      id: string;
+      ip: string | null;
+      country: string | null;
+      city: string | null;
+      user_agent: string | null;
+      created_at: string;
+      expires_at: string;
+      last_active_at: string;
+    }>();
 
-    return c.json(
-      {
-        data: results.map((s) => ({
-          id: s.id,
-          ip: s.ip ?? undefined,
-          country: s.country ?? undefined,
-          city: s.city ?? undefined,
-          user_agent: s.user_agent ?? undefined,
-          created_at: normalizeDateTime(s.created_at),
-          last_active_at: normalizeDateTime(s.last_active_at),
-          expires_at: normalizeDateTime(s.expires_at),
-          is_current: s.id === currentSessionId,
-        })),
-      },
-      200,
-      { "Cache-Control": "no-store" },
-    );
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
-  }
+  return c.json(
+    {
+      data: results.map((s) => ({
+        id: s.id,
+        ip: s.ip ?? undefined,
+        country: s.country ?? undefined,
+        city: s.city ?? undefined,
+        user_agent: s.user_agent ?? undefined,
+        created_at: normalizeDateTime(s.created_at),
+        last_active_at: normalizeDateTime(s.last_active_at),
+        expires_at: normalizeDateTime(s.expires_at),
+        is_current: s.id === currentSessionId,
+      })),
+    },
+    200,
+    { "Cache-Control": "no-store" },
+  );
 });
 
 // DELETE /sessions (revoke all other sessions)
@@ -243,126 +248,102 @@ auth.get("/providers", sessionMw, async (c) => {
     "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
   )
     .bind(userId)
-    .all<{
-      provider: string;
-      provider_user_id: string;
-      provider_username: string;
-      provider_email: string | null;
-      email_verified: number;
-      created_at: string;
-    }>();
+    .all<ProviderRow>();
 
   return c.json({
-    data: results.map((p) => ({
-      provider: p.provider as OAuthProvider,
-      provider_user_id: p.provider_user_id,
-      provider_username: p.provider_username,
-      provider_email: p.provider_email ?? undefined,
-      email_verified: p.email_verified === 1,
-      created_at: normalizeDateTime(p.created_at),
-    })),
+    data: results.map(mapProviderRow),
   });
 });
 
 // DELETE /providers/:provider (unlink)
 auth.delete("/providers/:provider", sessionMw, async (c) => {
-  try {
-    const userId = c.get("userId");
-    const provider = c.req.param("provider");
+  const userId = c.get("userId");
+  const provider = c.req.param("provider");
 
-    if (!isValidProvider(provider)) {
-      return c.json({ error: "Invalid provider" }, 400);
-    }
-
-    // Ensure user keeps at least one other auth method
-    const [{ results: linked }, userRow] = await Promise.all([
-      c.env.DB.prepare(
-        "SELECT provider, access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ?",
-      )
-        .bind(userId)
-        .all<{ provider: string; access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
-      c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
-        .bind(userId)
-        .first<{ api_key_hash: string | null }>(),
-    ]);
-
-    const hasApiKey = !!userRow?.api_key_hash;
-    const targetRow = linked.find((p) => p.provider === provider);
-    const otherProviders = linked.filter((p) => p.provider !== provider).length;
-    if (otherProviders === 0 && !hasApiKey) {
-      return c.json({ error: "Cannot unlink the only authentication method" }, 400);
-    }
-
-    await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
-      .bind(userId, provider)
-      .run();
-
-    // Best-effort token revocation in the background
-    if (targetRow?.access_token_encrypted) {
-      const encCtx = `${userId}:${provider}`;
-      const encKey = c.env.ENCRYPTION_KEY;
-      const accessEnc = targetRow.access_token_encrypted;
-      const refreshEnc = targetRow.refresh_token_encrypted;
-
-      c.executionCtx.waitUntil(
-        (async () => {
-          try {
-            const accessToken = await decryptToken(accessEnc, encKey, encCtx);
-            const refreshToken = refreshEnc
-              ? await decryptToken(refreshEnc, encKey, encCtx)
-              : null;
-            await revokeProviderToken(provider, accessToken, refreshToken, c.env);
-          } catch (err) {
-            console.error(
-              `Token revocation failed for ${provider}:`,
-              err instanceof Error ? err.message : err,
-            );
-          }
-        })(),
-      );
-    }
-
-    return c.body(null, 204);
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
+  if (!isValidProvider(provider)) {
+    return c.json({ error: "Invalid provider" }, 400);
   }
+
+  // Ensure user keeps at least one other auth method
+  const [{ results: linked }, userRow] = await Promise.all([
+    c.env.DB.prepare(
+      "SELECT provider, access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ?",
+    )
+      .bind(userId)
+      .all<{ provider: string; access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
+    c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+      .bind(userId)
+      .first<{ api_key_hash: string | null }>(),
+  ]);
+
+  const hasApiKey = !!userRow?.api_key_hash;
+  const targetRow = linked.find((p) => p.provider === provider);
+  const otherProviders = linked.filter((p) => p.provider !== provider).length;
+  if (otherProviders === 0 && !hasApiKey) {
+    return c.json({ error: "Cannot unlink the only authentication method" }, 400);
+  }
+
+  await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
+    .bind(userId, provider)
+    .run();
+
+  // Best-effort token revocation in the background
+  if (targetRow?.access_token_encrypted) {
+    const encCtx = `${userId}:${provider}`;
+    const encKey = c.env.ENCRYPTION_KEY;
+    const accessEnc = targetRow.access_token_encrypted;
+    const refreshEnc = targetRow.refresh_token_encrypted;
+
+    c.executionCtx.waitUntil(
+      (async () => {
+        try {
+          const accessToken = await decryptToken(accessEnc, encKey, encCtx);
+          const refreshToken = refreshEnc
+            ? await decryptToken(refreshEnc, encKey, encCtx)
+            : null;
+          await revokeProviderToken(provider, accessToken, refreshToken, c.env);
+        } catch (err) {
+          console.error(
+            `Token revocation failed for ${provider}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      })(),
+    );
+  }
+
+  return c.body(null, 204);
 });
 
 // POST /api-key (regenerate)
 auth.post("/api-key", sessionMw, async (c) => {
-  try {
-    const userId = c.get("userId");
-    const currentTokenHash = c.get("sessionTokenHash");
+  const userId = c.get("userId");
+  const currentTokenHash = c.get("sessionTokenHash");
 
-    // Get current api_key_hash to clear KV cache
-    const user = await c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
-      .bind(userId)
-      .first<{ api_key_hash: string }>();
+  // Get current api_key_hash to clear KV cache
+  const user = await c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+    .bind(userId)
+    .first<{ api_key_hash: string }>();
 
-    if (!user) return c.json({ error: "Unauthorized" }, 401);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-    const { plaintext, hash } = await generateApiKey();
+  const { plaintext, hash } = await generateApiKey();
 
-    // Batch: update key + delete old KV cache
-    await c.env.DB.prepare("UPDATE users SET api_key_hash = ?, modified_at = datetime('now') WHERE id = ?")
-      .bind(hash, userId)
-      .run();
+  // Batch: update key + delete old KV cache
+  await c.env.DB.prepare("UPDATE users SET api_key_hash = ?, modified_at = datetime('now') WHERE id = ?")
+    .bind(hash, userId)
+    .run();
 
-    await Promise.all([
-      c.env.KV.delete(`apikey:${user.api_key_hash}`),
-      invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash),
-    ]);
+  await Promise.all([
+    c.env.KV.delete(`apikey:${user.api_key_hash}`),
+    invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash),
+  ]);
 
-    return c.json(
-      { data: { api_key: plaintext } },
-      200,
-      { "Cache-Control": "no-store" },
-    );
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
-  }
+  return c.json(
+    { data: { api_key: plaintext } },
+    200,
+    { "Cache-Control": "no-store" },
+  );
 });
 
 // POST /link/approve/:pending_link_id
@@ -488,86 +469,81 @@ auth.get("/link/:provider/callback", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  try {
-    const redirectUri = getRedirectUri(c, provider, true);
-    const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
-    const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+  const redirectUri = getRedirectUri(c, provider, true);
+  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
 
-    // Email verification gate (same as login callback)
-    if (!userInfo.emailVerified) {
-      return c.json(
-        { error: "Email not verified with provider. Please verify your email first." },
-        400,
-        securityHeaders(),
-      );
-    }
-
-    // Check if this provider account is already linked to a different user
-    const existingLink = await c.env.DB.prepare(
-      "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
-    )
-      .bind(provider, userInfo.providerUserId)
-      .first<{ user_id: string }>();
-
-    if (existingLink && existingLink.user_id !== stateData.linkUserId) {
-      return c.json({ error: "This provider account is already linked to another user" }, 409);
-    }
-
-    // Encrypt tokens with AAD context (binds ciphertext to this user+provider)
-    const encCtx = `${stateData.linkUserId}:${provider}`;
-    const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-    const refreshTokenEnc = userInfo.refreshToken
-      ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-      : null;
-
-    if (existingLink) {
-      // Update existing link
-      await c.env.DB.prepare(
-        `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-         access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-         WHERE provider = ? AND provider_user_id = ?`,
-      )
-        .bind(
-          userInfo.providerUsername,
-          userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
-          accessTokenEnc,
-          refreshTokenEnc,
-          userInfo.tokenExpiresAt,
-          provider,
-          userInfo.providerUserId,
-        )
-        .run();
-    } else {
-      // Create new link
-      await c.env.DB.prepare(
-        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-        .bind(
-          crypto.randomUUID(),
-          stateData.linkUserId,
-          provider,
-          userInfo.providerUserId,
-          userInfo.providerUsername,
-          userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
-          accessTokenEnc,
-          refreshTokenEnc,
-          userInfo.tokenExpiresAt,
-        )
-        .run();
-    }
-
+  // Email verification gate (same as login callback)
+  if (!userInfo.emailVerified) {
     return c.json(
-      { data: { provider, provider_username: userInfo.providerUsername } },
-      200,
+      { error: "Email not verified with provider. Please verify your email first." },
+      400,
       securityHeaders(),
     );
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
+
+  // Check if this provider account is already linked to a different user
+  const existingLink = await c.env.DB.prepare(
+    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
+  )
+    .bind(provider, userInfo.providerUserId)
+    .first<{ user_id: string }>();
+
+  if (existingLink && existingLink.user_id !== stateData.linkUserId) {
+    return c.json({ error: "This provider account is already linked to another user" }, 409);
+  }
+
+  // Encrypt tokens with AAD context (binds ciphertext to this user+provider)
+  const encCtx = `${stateData.linkUserId}:${provider}`;
+  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+  const refreshTokenEnc = userInfo.refreshToken
+    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+    : null;
+
+  if (existingLink) {
+    // Update existing link
+    await c.env.DB.prepare(
+      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+       WHERE provider = ? AND provider_user_id = ?`,
+    )
+      .bind(
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+        provider,
+        userInfo.providerUserId,
+      )
+      .run();
+  } else {
+    // Create new link
+    await c.env.DB.prepare(
+      `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        stateData.linkUserId,
+        provider,
+        userInfo.providerUserId,
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+      )
+      .run();
+  }
+
+  return c.json(
+    { data: { provider, provider_username: userInfo.providerUsername } },
+    200,
+    securityHeaders(),
+  );
 });
 
 // ─── Public routes (parameterized, last) ─────────────────
@@ -622,249 +598,244 @@ auth.get("/:provider/callback", async (c) => {
     return c.json({ error: "Invalid or expired state" }, 400, securityHeaders());
   }
 
-  try {
-    // 2. Exchange code for tokens
-    const redirectUri = getRedirectUri(c, provider);
-    const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
+  // 2. Exchange code for tokens
+  const redirectUri = getRedirectUri(c, provider);
+  const tokenResponse = await exchangeCode(provider, code, stateData.codeVerifier, redirectUri, c.env);
 
-    // 3. Fetch/validate user info
-    const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
+  // 3. Fetch/validate user info
+  const userInfo = await fetchUserInfo(provider, tokenResponse, c.env, c.env.KV, stateData.nonce);
 
-    // 4. Email verification gate
-    if (!userInfo.emailVerified) {
-      return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
-    }
+  // 4. Email verification gate
+  if (!userInfo.emailVerified) {
+    return c.json({ error: "Email not verified with provider. Please verify your email first." }, 400);
+  }
 
-    // 5. Account matching — check for existing OAuth link
-    const existingOAuth = await c.env.DB.prepare(
-      "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
-    )
-      .bind(provider, userInfo.providerUserId)
-      .first<{ user_id: string }>();
+  // 5. Account matching — check for existing OAuth link
+  const existingOAuth = await c.env.DB.prepare(
+    "SELECT user_id FROM oauth_accounts WHERE provider = ? AND provider_user_id = ?",
+  )
+    .bind(provider, userInfo.providerUserId)
+    .first<{ user_id: string }>();
 
-    if (existingOAuth) {
-      // ─── Existing user login ─────────────────────
-      const encCtx = `${existingOAuth.user_id}:${provider}`;
-      const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-      const refreshTokenEnc = userInfo.refreshToken
-        ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-        : null;
-
-      // Update provider tokens
-      await c.env.DB.prepare(
-        `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
-         access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
-         WHERE provider = ? AND provider_user_id = ?`,
-      )
-        .bind(
-          userInfo.providerUsername,
-          userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
-          accessTokenEnc,
-          refreshTokenEnc,
-          userInfo.tokenExpiresAt,
-          provider,
-          userInfo.providerUserId,
-        )
-        .run();
-
-      // Create session
-      const sessionToken = generateSessionToken();
-      const sessionTokenHash = await sha256Hex(sessionToken);
-      await createSession(c.env.DB, existingOAuth.user_id, sessionTokenHash, c.req.raw);
-      setSessionCookie(c, sessionToken, c.env);
-
-      const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-        .bind(existingOAuth.user_id)
-        .first<UserRow>();
-
-      if (!userRow) return c.json({ error: "User not found" }, 500);
-
-      return c.json(
-        { data: { user: rowToUser(userRow), is_new_user: false } },
-        200,
-        securityHeaders(),
-      );
-    }
-
-    // No existing OAuth link — check if email matches an existing user
-    if (userInfo.providerEmail) {
-      const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
-        .bind(userInfo.providerEmail)
-        .first<{ id: string; username: string }>();
-
-      if (emailMatch) {
-        // Limit active pending links per user
-        const activeLinkCount = await c.env.DB.prepare(
-          "SELECT COUNT(*) as count FROM pending_links WHERE existing_user_id = ? AND expires_at > datetime('now')",
-        )
-          .bind(emailMatch.id)
-          .first<{ count: number }>();
-        if (activeLinkCount && activeLinkCount.count >= 3) {
-          return c.json({ error: "Too many pending link requests" }, 429);
-        }
-
-        // Encrypt tokens with AAD context
-        const encCtx = `${emailMatch.id}:${provider}`;
-        const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-        const refreshTokenEnc = userInfo.refreshToken
-          ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-          : null;
-
-        // Create pending link for manual approval
-        const pendingId = crypto.randomUUID();
-        const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
-          .toISOString()
-          .replace("T", " ")
-          .replace("Z", "");
-
-        await c.env.DB.prepare(
-          `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        )
-          .bind(
-            pendingId,
-            emailMatch.id,
-            provider,
-            userInfo.providerUserId,
-            userInfo.providerUsername,
-            userInfo.providerEmail,
-            userInfo.emailVerified ? 1 : 0,
-            accessTokenEnc,
-            refreshTokenEnc,
-            userInfo.tokenExpiresAt,
-            pendingExpiry,
-          )
-          .run();
-
-        // Return minimal pending link info (no full user profile — unauthenticated response)
-        return c.json(
-          {
-            data: {
-              pending_link: {
-                id: pendingId,
-                provider: provider as OAuthProvider,
-                provider_username: userInfo.providerUsername,
-                provider_email: userInfo.providerEmail!,
-                expires_at: normalizeDateTime(pendingExpiry),
-              },
-            },
-          },
-          200,
-          securityHeaders(),
-        );
-      }
-    }
-
-    // No existing account — new user creation
-    const isSingleUser = c.env.INSTANCE_MODE !== "multi";
-    const userId = crypto.randomUUID();
-    const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
-
-    let username = userInfo.providerUsername.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64) || `user_${userId.slice(0, 8)}`;
-
-    // Handle username collision by appending random suffix
-    const existingUsername = await c.env.DB.prepare("SELECT 1 FROM users WHERE username = ?")
-      .bind(username)
-      .first();
-    if (existingUsername) {
-      username = `${username.slice(0, 55)}_${userId.slice(0, 8)}`;
-    }
-
-    // Encrypt tokens with AAD context
-    const encCtx = `${userId}:${provider}`;
+  if (existingOAuth) {
+    // ─── Existing user login ─────────────────────
+    const encCtx = `${existingOAuth.user_id}:${provider}`;
     const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
     const refreshTokenEnc = userInfo.refreshToken
       ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
       : null;
 
-    const oauthAccountId = crypto.randomUUID();
-
-    if (isSingleUser) {
-      // Atomic: create user only if no users exist (prevents TOCTOU race)
-      const batchResult = await c.env.DB.batch([
-        c.env.DB.prepare(
-          `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-           SELECT ?, ?, ?, ?, datetime('now'), datetime('now')
-           WHERE (SELECT COUNT(*) FROM users) = 0`,
-        ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
-        c.env.DB.prepare(
-          `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-           SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-           WHERE EXISTS (SELECT 1 FROM users WHERE id = ?)`,
-        ).bind(
-          oauthAccountId,
-          userId,
-          provider,
-          userInfo.providerUserId,
-          userInfo.providerUsername,
-          userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
-          accessTokenEnc,
-          refreshTokenEnc,
-          userInfo.tokenExpiresAt,
-          userId,
-        ),
-      ]);
-
-      if (batchResult[0].meta.changes === 0) {
-        return c.json(
-          { error: "Registration closed. This instance only allows one user." },
-          403,
-        );
-      }
-    } else {
-      // Multi-user mode: unconditional insert
-      await c.env.DB.batch([
-        c.env.DB.prepare(
-          `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-           VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
-        ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
-        c.env.DB.prepare(
-          `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        ).bind(
-          oauthAccountId,
-          userId,
-          provider,
-          userInfo.providerUserId,
-          userInfo.providerUsername,
-          userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
-          accessTokenEnc,
-          refreshTokenEnc,
-          userInfo.tokenExpiresAt,
-        ),
-      ]);
-    }
+    // Update provider tokens
+    await c.env.DB.prepare(
+      `UPDATE oauth_accounts SET provider_username = ?, provider_email = ?, email_verified = ?,
+       access_token_encrypted = ?, refresh_token_encrypted = ?, token_expires_at = ?
+       WHERE provider = ? AND provider_user_id = ?`,
+    )
+      .bind(
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+        provider,
+        userInfo.providerUserId,
+      )
+      .run();
 
     // Create session
     const sessionToken = generateSessionToken();
     const sessionTokenHash = await sha256Hex(sessionToken);
-    await createSession(c.env.DB, userId, sessionTokenHash, c.req.raw);
+    await createSession(c.env.DB, existingOAuth.user_id, sessionTokenHash, c.req.raw);
     setSessionCookie(c, sessionToken, c.env);
 
     const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-      .bind(userId)
+      .bind(existingOAuth.user_id)
       .first<UserRow>();
 
-    if (!userRow) return c.json({ error: "Internal server error" }, 500);
+    if (!userRow) return c.json({ error: "User not found" }, 500);
 
     return c.json(
-      {
-        data: {
-          user: rowToUser(userRow),
-          api_key: apiKeyPlaintext,
-          is_new_user: true,
-        },
-      },
+      { data: { user: rowToUser(userRow), is_new_user: false } },
       200,
       securityHeaders(),
     );
-  } catch (err) {
-    console.error("Auth error:", err instanceof Error ? err.message : err);
-    return c.json({ error: "Internal server error" }, 500, securityHeaders());
   }
+
+  // No existing OAuth link — check if email matches an existing user
+  if (userInfo.providerEmail) {
+    const emailMatch = await c.env.DB.prepare("SELECT id, username FROM users WHERE email = ?")
+      .bind(userInfo.providerEmail)
+      .first<{ id: string; username: string }>();
+
+    if (emailMatch) {
+      // Limit active pending links per user
+      const activeLinkCount = await c.env.DB.prepare(
+        "SELECT COUNT(*) as count FROM pending_links WHERE existing_user_id = ? AND expires_at > datetime('now')",
+      )
+        .bind(emailMatch.id)
+        .first<{ count: number }>();
+      if (activeLinkCount && activeLinkCount.count >= 3) {
+        return c.json({ error: "Too many pending link requests" }, 429);
+      }
+
+      // Encrypt tokens with AAD context
+      const encCtx = `${emailMatch.id}:${provider}`;
+      const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+      const refreshTokenEnc = userInfo.refreshToken
+        ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+        : null;
+
+      // Create pending link for manual approval
+      const pendingId = crypto.randomUUID();
+      const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
+        .toISOString()
+        .replace("T", " ")
+        .replace("Z", "");
+
+      await c.env.DB.prepare(
+        `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          pendingId,
+          emailMatch.id,
+          provider,
+          userInfo.providerUserId,
+          userInfo.providerUsername,
+          userInfo.providerEmail,
+          userInfo.emailVerified ? 1 : 0,
+          accessTokenEnc,
+          refreshTokenEnc,
+          userInfo.tokenExpiresAt,
+          pendingExpiry,
+        )
+        .run();
+
+      // Return minimal pending link info (no full user profile — unauthenticated response)
+      return c.json(
+        {
+          data: {
+            pending_link: {
+              id: pendingId,
+              provider: provider as OAuthProvider,
+              provider_username: userInfo.providerUsername,
+              provider_email: userInfo.providerEmail!,
+              expires_at: normalizeDateTime(pendingExpiry),
+            },
+          },
+        },
+        200,
+        securityHeaders(),
+      );
+    }
+  }
+
+  // No existing account — new user creation
+  const isSingleUser = c.env.INSTANCE_MODE !== "multi";
+  const userId = crypto.randomUUID();
+  const { plaintext: apiKeyPlaintext, hash: apiKeyHash } = await generateApiKey();
+
+  let username = userInfo.providerUsername.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64) || `user_${userId.slice(0, 8)}`;
+
+  // Handle username collision by appending random suffix
+  const existingUsername = await c.env.DB.prepare("SELECT 1 FROM users WHERE username = ?")
+    .bind(username)
+    .first();
+  if (existingUsername) {
+    username = `${username.slice(0, 55)}_${userId.slice(0, 8)}`;
+  }
+
+  // Encrypt tokens with AAD context
+  const encCtx = `${userId}:${provider}`;
+  const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+  const refreshTokenEnc = userInfo.refreshToken
+    ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+    : null;
+
+  const oauthAccountId = crypto.randomUUID();
+
+  if (isSingleUser) {
+    // Atomic: create user only if no users exist (prevents TOCTOU race)
+    const batchResult = await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+         SELECT ?, ?, ?, ?, datetime('now'), datetime('now')
+         WHERE (SELECT COUNT(*) FROM users) = 0`,
+      ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
+      c.env.DB.prepare(
+        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+         WHERE EXISTS (SELECT 1 FROM users WHERE id = ?)`,
+      ).bind(
+        oauthAccountId,
+        userId,
+        provider,
+        userInfo.providerUserId,
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+        userId,
+      ),
+    ]);
+
+    if (batchResult[0].meta.changes === 0) {
+      return c.json(
+        { error: "Registration closed. This instance only allows one user." },
+        403,
+      );
+    }
+  } else {
+    // Multi-user mode: unconditional insert
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
+      c.env.DB.prepare(
+        `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        oauthAccountId,
+        userId,
+        provider,
+        userInfo.providerUserId,
+        userInfo.providerUsername,
+        userInfo.providerEmail,
+        userInfo.emailVerified ? 1 : 0,
+        accessTokenEnc,
+        refreshTokenEnc,
+        userInfo.tokenExpiresAt,
+      ),
+    ]);
+  }
+
+  // Create session
+  const sessionToken = generateSessionToken();
+  const sessionTokenHash = await sha256Hex(sessionToken);
+  await createSession(c.env.DB, userId, sessionTokenHash, c.req.raw);
+  setSessionCookie(c, sessionToken, c.env);
+
+  const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+    .bind(userId)
+    .first<UserRow>();
+
+  if (!userRow) return c.json({ error: "Internal server error" }, 500);
+
+  return c.json(
+    {
+      data: {
+        user: rowToUser(userRow),
+        api_key: apiKeyPlaintext,
+        is_new_user: true,
+      },
+    },
+    200,
+    securityHeaders(),
+  );
 });
 
 export default auth;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -47,17 +47,21 @@ auth.use("/*", csrf());
 // ─── Session Middleware ──────────────────────────────────
 
 const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
-  const token = getSessionTokenFromCookie(c, c.env);
-  if (!token) return c.json({ error: "Unauthorized" }, 401);
+  try {
+    const token = getSessionTokenFromCookie(c, c.env);
+    if (!token) return c.json({ error: "Unauthorized" }, 401);
 
-  const tokenHash = await sha256Hex(token);
-  const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
-  if (!session) return c.json({ error: "Unauthorized" }, 401);
+    const tokenHash = await sha256Hex(token);
+    const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
+    if (!session) return c.json({ error: "Unauthorized" }, 401);
 
-  c.set("userId", session.userId);
-  c.set("sessionId", session.sessionId);
-  c.set("sessionTokenHash", tokenHash);
-  await next();
+    c.set("userId", session.userId);
+    c.set("sessionId", session.sessionId);
+    c.set("sessionTokenHash", tokenHash);
+    await next();
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -65,7 +69,7 @@ const sessionMw = createMiddleware<SessionAuthEnv>(async (c, next) => {
 function getRedirectUri(c: { req: { url: string }; env: Env }, provider: string, isLink = false): string {
   let origin = c.env.APP_URL?.replace(/\/+$/, "");
   if (!origin) {
-    if (c.env.ENVIRONMENT === "development" || c.env.ENVIRONMENT === undefined) {
+    if (c.env.ENVIRONMENT === "development") {
       origin = new URL(c.req.url).origin;
     } else {
       throw new Error("APP_URL environment variable is required in production");
@@ -88,44 +92,48 @@ function securityHeaders(): Record<string, string> {
 
 // GET /session
 auth.get("/session", sessionMw, async (c) => {
-  const userId = c.get("userId");
-  const [userRow, providers] = await Promise.all([
-    c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
-      .bind(userId)
-      .first<UserRow>(),
-    c.env.DB.prepare(
-      "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
-    )
-      .bind(userId)
-      .all<{
-        provider: string;
-        provider_user_id: string;
-        provider_username: string;
-        provider_email: string | null;
-        email_verified: number;
-        created_at: string;
-      }>(),
-  ]);
+  try {
+    const userId = c.get("userId");
+    const [userRow, providers] = await Promise.all([
+      c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
+        .bind(userId)
+        .first<UserRow>(),
+      c.env.DB.prepare(
+        "SELECT provider, provider_user_id, provider_username, provider_email, email_verified, created_at FROM oauth_accounts WHERE user_id = ?",
+      )
+        .bind(userId)
+        .all<{
+          provider: string;
+          provider_user_id: string;
+          provider_username: string;
+          provider_email: string | null;
+          email_verified: number;
+          created_at: string;
+        }>(),
+    ]);
 
-  if (!userRow) return c.json({ error: "Unauthorized" }, 401);
+    if (!userRow) return c.json({ error: "Unauthorized" }, 401);
 
-  return c.json(
-    {
-      data: {
-        user: rowToUser(userRow),
-        providers: providers.results.map((p) => ({
-          provider: p.provider as OAuthProvider,
-          provider_user_id: p.provider_user_id,
-          provider_username: p.provider_username,
-          provider_email: p.provider_email ?? undefined,
-          email_verified: p.email_verified === 1,
-          created_at: normalizeDateTime(p.created_at),
-        })),
+    return c.json(
+      {
+        data: {
+          user: rowToUser(userRow),
+          providers: providers.results.map((p) => ({
+            provider: p.provider as OAuthProvider,
+            provider_user_id: p.provider_user_id,
+            provider_username: p.provider_username,
+            provider_email: p.provider_email ?? undefined,
+            email_verified: p.email_verified === 1,
+            created_at: normalizeDateTime(p.created_at),
+          })),
+        },
       },
-    },
-    200,
-    { "Cache-Control": "no-store" },
-  );
+      200,
+      { "Cache-Control": "no-store" },
+    );
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 // DELETE /session (logout)
@@ -138,43 +146,47 @@ auth.delete("/session", sessionMw, async (c) => {
 
 // GET /sessions (list all active sessions)
 auth.get("/sessions", sessionMw, async (c) => {
-  const userId = c.get("userId");
-  const currentSessionId = c.get("sessionId");
+  try {
+    const userId = c.get("userId");
+    const currentSessionId = c.get("sessionId");
 
-  const { results } = await c.env.DB.prepare(
-    `SELECT id, ip, country, city, user_agent, created_at, expires_at, last_active_at
-     FROM sessions WHERE user_id = ? AND expires_at > datetime('now')
-     ORDER BY last_active_at DESC`,
-  )
-    .bind(userId)
-    .all<{
-      id: string;
-      ip: string | null;
-      country: string | null;
-      city: string | null;
-      user_agent: string | null;
-      created_at: string;
-      expires_at: string;
-      last_active_at: string;
-    }>();
+    const { results } = await c.env.DB.prepare(
+      `SELECT id, ip, country, city, user_agent, created_at, expires_at, last_active_at
+       FROM sessions WHERE user_id = ? AND expires_at > datetime('now')
+       ORDER BY last_active_at DESC`,
+    )
+      .bind(userId)
+      .all<{
+        id: string;
+        ip: string | null;
+        country: string | null;
+        city: string | null;
+        user_agent: string | null;
+        created_at: string;
+        expires_at: string;
+        last_active_at: string;
+      }>();
 
-  return c.json(
-    {
-      data: results.map((s) => ({
-        id: s.id,
-        ip: s.ip ?? undefined,
-        country: s.country ?? undefined,
-        city: s.city ?? undefined,
-        user_agent: s.user_agent ?? undefined,
-        created_at: normalizeDateTime(s.created_at),
-        last_active_at: normalizeDateTime(s.last_active_at),
-        expires_at: normalizeDateTime(s.expires_at),
-        is_current: s.id === currentSessionId,
-      })),
-    },
-    200,
-    { "Cache-Control": "no-store" },
-  );
+    return c.json(
+      {
+        data: results.map((s) => ({
+          id: s.id,
+          ip: s.ip ?? undefined,
+          country: s.country ?? undefined,
+          city: s.city ?? undefined,
+          user_agent: s.user_agent ?? undefined,
+          created_at: normalizeDateTime(s.created_at),
+          last_active_at: normalizeDateTime(s.last_active_at),
+          expires_at: normalizeDateTime(s.expires_at),
+          is_current: s.id === currentSessionId,
+        })),
+      },
+      200,
+      { "Cache-Control": "no-store" },
+    );
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 // DELETE /sessions (revoke all other sessions)
@@ -241,65 +253,73 @@ auth.get("/providers", sessionMw, async (c) => {
 
 // DELETE /providers/:provider (unlink)
 auth.delete("/providers/:provider", sessionMw, async (c) => {
-  const userId = c.get("userId");
-  const provider = c.req.param("provider");
+  try {
+    const userId = c.get("userId");
+    const provider = c.req.param("provider");
 
-  if (!isValidProvider(provider)) {
-    return c.json({ error: "Invalid provider" }, 400);
+    if (!isValidProvider(provider)) {
+      return c.json({ error: "Invalid provider" }, 400);
+    }
+
+    // Ensure user keeps at least one other auth method
+    const [{ results: linked }, userRow] = await Promise.all([
+      c.env.DB.prepare("SELECT provider FROM oauth_accounts WHERE user_id = ?")
+        .bind(userId)
+        .all<{ provider: string }>(),
+      c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+        .bind(userId)
+        .first<{ api_key_hash: string | null }>(),
+    ]);
+
+    const hasApiKey = !!userRow?.api_key_hash;
+    const otherProviders = linked.filter((p) => p.provider !== provider).length;
+    if (otherProviders === 0 && !hasApiKey) {
+      return c.json({ error: "Cannot unlink the only authentication method" }, 400);
+    }
+
+    await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
+      .bind(userId, provider)
+      .run();
+
+    return c.body(null, 204);
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
   }
-
-  // Ensure user keeps at least one other auth method
-  const [{ results: linked }, userRow] = await Promise.all([
-    c.env.DB.prepare("SELECT provider FROM oauth_accounts WHERE user_id = ?")
-      .bind(userId)
-      .all<{ provider: string }>(),
-    c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
-      .bind(userId)
-      .first<{ api_key_hash: string | null }>(),
-  ]);
-
-  const hasApiKey = !!userRow?.api_key_hash;
-  const otherProviders = linked.filter((p) => p.provider !== provider).length;
-  if (otherProviders === 0 && !hasApiKey) {
-    return c.json({ error: "Cannot unlink the only authentication method" }, 400);
-  }
-
-  await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
-    .bind(userId, provider)
-    .run();
-
-  return c.body(null, 204);
 });
 
 // POST /api-key (regenerate)
 auth.post("/api-key", sessionMw, async (c) => {
-  const userId = c.get("userId");
-  const currentTokenHash = c.get("sessionTokenHash");
+  try {
+    const userId = c.get("userId");
+    const currentTokenHash = c.get("sessionTokenHash");
 
-  // Get current api_key_hash to clear KV cache
-  const user = await c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
-    .bind(userId)
-    .first<{ api_key_hash: string }>();
+    // Get current api_key_hash to clear KV cache
+    const user = await c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
+      .bind(userId)
+      .first<{ api_key_hash: string }>();
 
-  if (!user) return c.json({ error: "Unauthorized" }, 401);
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-  const { plaintext, hash } = await generateApiKey();
+    const { plaintext, hash } = await generateApiKey();
 
-  // Batch: update key + delete old KV cache
-  await c.env.DB.prepare("UPDATE users SET api_key_hash = ?, modified_at = datetime('now') WHERE id = ?")
-    .bind(hash, userId)
-    .run();
+    // Batch: update key + delete old KV cache
+    await c.env.DB.prepare("UPDATE users SET api_key_hash = ?, modified_at = datetime('now') WHERE id = ?")
+      .bind(hash, userId)
+      .run();
 
-  await Promise.all([
-    c.env.KV.delete(`apikey:${user.api_key_hash}`),
-    invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash),
-  ]);
+    await Promise.all([
+      c.env.KV.delete(`apikey:${user.api_key_hash}`),
+      invalidateOtherSessions(c.env.DB, c.env.KV, userId, currentTokenHash),
+    ]);
 
-  return c.json(
-    { data: { api_key: plaintext } },
-    200,
-    { "Cache-Control": "no-store" },
-  );
+    return c.json(
+      { data: { api_key: plaintext } },
+      200,
+      { "Cache-Control": "no-store" },
+    );
+  } catch {
+    return c.json({ error: "Internal server error" }, 500);
+  }
 });
 
 // POST /link/approve/:pending_link_id
@@ -393,7 +413,8 @@ auth.get("/link/:provider/callback", async (c) => {
   // Handle OAuth error (e.g., user denied access)
   const oauthError = c.req.query("error");
   if (oauthError) {
-    return c.json({ error: `OAuth error: ${oauthError}` }, 400);
+    console.error(`OAuth error from ${provider}: ${oauthError}`);
+    return c.json({ error: "OAuth authorization failed" }, 400);
   }
 
   // Validate state (double-submit)
@@ -525,7 +546,8 @@ auth.get("/:provider/callback", async (c) => {
   // Handle OAuth error (e.g., user denied access)
   const oauthError = c.req.query("error");
   if (oauthError) {
-    return c.json({ error: `OAuth error: ${oauthError}` }, 400);
+    console.error(`OAuth error from ${provider}: ${oauthError}`);
+    return c.json({ error: "OAuth authorization failed" }, 400);
   }
 
   // 1. Validate state (double-submit)
@@ -773,10 +795,12 @@ auth.get("/:provider/callback", async (c) => {
       .bind(userId)
       .first<UserRow>();
 
+    if (!userRow) return c.json({ error: "Internal server error" }, 500);
+
     return c.json(
       {
         data: {
-          user: rowToUser(userRow!),
+          user: rowToUser(userRow),
           api_key: apiKeyPlaintext,
           is_new_user: true,
         },

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -2,67 +2,15 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
+import { type UserRow, USER_COLUMNS, rowToUser } from "../utils/user";
 
-type User = components["schemas"]["User"];
 type Project = components["schemas"]["Project"];
-
-type UserRow = {
-  id: string;
-  username: string;
-  display_name: string | null;
-  email: string | null;
-  photo: string | null;
-  bio: string | null;
-  city: string | null;
-  timezone: string;
-  timeout: number;
-  is_hireable: number;
-  github_username: string | null;
-  twitter_username: string | null;
-  website: string | null;
-  created_at: string;
-  modified_at: string;
-};
-
-const USER_COLUMNS = `id, username, display_name, email, photo, bio, city, timezone, timeout, is_hireable, github_username, twitter_username, website, created_at, modified_at`;
 
 const users = new Hono<AuthEnv>();
 
 users.use("*", authMiddleware);
 
 // ─── Helpers ──────────────────────────────────────────────
-
-function normalizeDateTime(dt: string): string {
-  return dt.includes("T") ? dt : dt.replace(" ", "T") + "Z";
-}
-
-function rowToUser(
-  row: UserRow,
-  lastHeartbeat?: { project: string | null; time: number } | null,
-): User {
-  return {
-    id: row.id,
-    username: row.username,
-    display_name: row.display_name ?? undefined,
-    email: row.email ?? undefined,
-    photo: row.photo ?? undefined,
-    bio: row.bio ?? undefined,
-    city: row.city ?? undefined,
-    timezone: row.timezone,
-    timeout: row.timeout,
-    is_hireable: row.is_hireable === 1,
-    github_username: row.github_username ?? undefined,
-    twitter_username: row.twitter_username ?? undefined,
-    website: row.website ?? undefined,
-    plan: "free",
-    last_heartbeat_at: lastHeartbeat
-      ? new Date(lastHeartbeat.time * 1000).toISOString()
-      : undefined,
-    last_project: lastHeartbeat?.project ?? undefined,
-    created_at: normalizeDateTime(row.created_at),
-    modified_at: normalizeDateTime(row.modified_at),
-  };
-}
 
 function formatTimeAgo(epoch: number): string {
   const seconds = Math.floor(Date.now() / 1000 - epoch);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,12 +17,21 @@ export interface Env {
 
   // Instance mode: "single" (default) or "multi" (future)
   INSTANCE_MODE?: string;
+
+  // Runtime environment (set via wrangler.toml [vars] or secret)
+  ENVIRONMENT?: string;
 }
 
 // Hono environment with authenticated user context
 export type AuthEnv = {
   Bindings: Env;
   Variables: { userId: string };
+};
+
+// Hono environment for session-authenticated routes
+export type SessionAuthEnv = {
+  Bindings: Env;
+  Variables: { userId: string; sessionId: string; sessionTokenHash: string };
 };
 
 // NOTE: For API request/response types, use generated types from

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ export interface Env {
   DISCORD_CLIENT_SECRET: string;
 
   // Security
-  SESSION_SECRET: string;
   ENCRYPTION_KEY: string;
 
   // Instance mode: "single" (default) or "multi" (future)
@@ -20,6 +19,10 @@ export interface Env {
 
   // Runtime environment (set via wrangler.toml [vars] or secret)
   ENVIRONMENT?: string;
+
+  // Public origin for OAuth redirect URIs (e.g., "https://time.example.com")
+  // If unset, derived from request Host header (safe behind Cloudflare, risky with custom proxies)
+  APP_URL?: string;
 }
 
 // Hono environment with authenticated user context

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,6 @@
 import type { HonoRequest } from "hono";
 import type { Env } from "../types";
+import { sha256Hex } from "./crypto";
 
 /**
  * Extract API key from request (WakaTime-compatible auth)
@@ -24,16 +25,6 @@ export function getApiKey(req: HonoRequest): string | null {
   }
 
   return req.query("api_key") ?? null;
-}
-
-/**
- * SHA-256 hash a string and return hex-encoded result.
- */
-async function sha256Hex(input: string): Promise<string> {
-  const data = new TextEncoder().encode(input);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = new Uint8Array(hashBuffer);
-  return Array.from(hashArray, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 /**

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -84,15 +84,21 @@ export async function encryptToken(plaintext: string, keyHex: string): Promise<s
   return `${base64url(iv)}.${base64urlFromBuffer(ciphertext)}`;
 }
 
+function base64urlDecode(input: string): Uint8Array {
+  // Restore standard base64: replace URL-safe chars and add padding
+  let b64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4;
+  if (pad === 2) b64 += "==";
+  else if (pad === 3) b64 += "=";
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
 export async function decryptToken(encrypted: string, keyHex: string): Promise<string> {
   const key = await importAesKey(keyHex);
-  const [ivB64, ctB64] = encrypted.split(".");
-  const iv = Uint8Array.from(atob(ivB64.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
-    c.charCodeAt(0),
-  );
-  const ciphertext = Uint8Array.from(atob(ctB64.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
-    c.charCodeAt(0),
-  );
+  const parts = encrypted.split(".");
+  if (parts.length !== 2) throw new Error("Invalid encrypted token format");
+  const iv = base64urlDecode(parts[0]);
+  const ciphertext = base64urlDecode(parts[1]);
   const plainBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
   return new TextDecoder().decode(plainBuf);
 }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -69,6 +69,9 @@ export async function generateApiKey(): Promise<{ plaintext: string; hash: strin
 // ─── AES-256-GCM encryption for OAuth tokens at rest ─────
 
 async function importAesKey(keyHex: string): Promise<CryptoKey> {
+  if (!/^[0-9a-fA-F]{64}$/.test(keyHex)) {
+    throw new Error("ENCRYPTION_KEY must be exactly 64 hex characters (256 bits)");
+  }
   const keyBytes = new Uint8Array(keyHex.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
   return crypto.subtle.importKey("raw", keyBytes, { name: "AES-GCM" }, false, [
     "encrypt",

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,116 @@
+/**
+ * Cryptographic primitives using Web Crypto API (Cloudflare Workers compatible).
+ */
+
+// ─── Hashing ─────────────────────────────────────────────
+
+export async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Raw(input: string): Promise<ArrayBuffer> {
+  const data = new TextEncoder().encode(input);
+  return crypto.subtle.digest("SHA-256", data);
+}
+
+// ─── Random / Encoding ───────────────────────────────────
+
+function randomBytes(n: number): Uint8Array {
+  const buf = new Uint8Array(n);
+  crypto.getRandomValues(buf);
+  return buf;
+}
+
+export function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlFromBuffer(buf: ArrayBuffer): string {
+  return base64url(new Uint8Array(buf));
+}
+
+// ─── PKCE ────────────────────────────────────────────────
+
+export function generateCodeVerifier(): string {
+  return base64url(randomBytes(32));
+}
+
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const hash = await sha256Raw(verifier);
+  return base64urlFromBuffer(hash);
+}
+
+// ─── Tokens / State ──────────────────────────────────────
+
+export function generateState(): string {
+  return base64url(randomBytes(32));
+}
+
+export function generateSessionToken(): string {
+  return base64url(randomBytes(32));
+}
+
+export function generateNonce(): string {
+  return base64url(randomBytes(32));
+}
+
+export async function generateApiKey(): Promise<{ plaintext: string; hash: string }> {
+  const raw = base64url(randomBytes(32));
+  const plaintext = `ck_${raw}`;
+  const hash = await sha256Hex(plaintext);
+  return { plaintext, hash };
+}
+
+// ─── AES-256-GCM encryption for OAuth tokens at rest ─────
+
+async function importAesKey(keyHex: string): Promise<CryptoKey> {
+  const keyBytes = new Uint8Array(keyHex.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+  return crypto.subtle.importKey("raw", keyBytes, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export async function encryptToken(plaintext: string, keyHex: string): Promise<string> {
+  const key = await importAesKey(keyHex);
+  const iv = randomBytes(12);
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
+  return `${base64url(iv)}.${base64urlFromBuffer(ciphertext)}`;
+}
+
+export async function decryptToken(encrypted: string, keyHex: string): Promise<string> {
+  const key = await importAesKey(keyHex);
+  const [ivB64, ctB64] = encrypted.split(".");
+  const iv = Uint8Array.from(atob(ivB64.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+    c.charCodeAt(0),
+  );
+  const ciphertext = Uint8Array.from(atob(ctB64.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+    c.charCodeAt(0),
+  );
+  const plainBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  return new TextDecoder().decode(plainBuf);
+}
+
+// ─── Constant-time comparison ────────────────────────────
+
+export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.byteLength !== bBytes.byteLength) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    randomBytes(32),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, aBytes);
+  return crypto.subtle.verify("HMAC", key, sig, bBytes);
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -76,11 +76,13 @@ async function importAesKey(keyHex: string): Promise<CryptoKey> {
   ]);
 }
 
-export async function encryptToken(plaintext: string, keyHex: string): Promise<string> {
+export async function encryptToken(plaintext: string, keyHex: string, context?: string): Promise<string> {
   const key = await importAesKey(keyHex);
   const iv = randomBytes(12);
   const encoded = new TextEncoder().encode(plaintext);
-  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
+  const params: { name: string; iv: Uint8Array; additionalData?: ArrayBuffer | ArrayBufferView } = { name: "AES-GCM", iv };
+  if (context) params.additionalData = new TextEncoder().encode(context);
+  const ciphertext = await crypto.subtle.encrypt(params, key, encoded);
   return `${base64url(iv)}.${base64urlFromBuffer(ciphertext)}`;
 }
 
@@ -93,22 +95,25 @@ function base64urlDecode(input: string): Uint8Array {
   return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
 }
 
-export async function decryptToken(encrypted: string, keyHex: string): Promise<string> {
+export async function decryptToken(encrypted: string, keyHex: string, context?: string): Promise<string> {
   const key = await importAesKey(keyHex);
   const parts = encrypted.split(".");
   if (parts.length !== 2) throw new Error("Invalid encrypted token format");
   const iv = base64urlDecode(parts[0]);
   const ciphertext = base64urlDecode(parts[1]);
-  const plainBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  const params: { name: string; iv: Uint8Array; additionalData?: ArrayBuffer | ArrayBufferView } = { name: "AES-GCM", iv };
+  if (context) params.additionalData = new TextEncoder().encode(context);
+  const plainBuf = await crypto.subtle.decrypt(params, key, ciphertext);
   return new TextDecoder().decode(plainBuf);
 }
 
 // ─── Constant-time comparison ────────────────────────────
 
-export function timingSafeEqual(a: string, b: string): boolean {
+export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
   const encoder = new TextEncoder();
-  const aBytes = encoder.encode(a);
-  const bBytes = encoder.encode(b);
-  if (aBytes.byteLength !== bBytes.byteLength) return false;
-  return crypto.subtle.timingSafeEqual(aBytes, bBytes);
+  const [aHash, bHash] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(a)),
+    crypto.subtle.digest("SHA-256", encoder.encode(b)),
+  ]);
+  return crypto.subtle.timingSafeEqual(aHash, bHash);
 }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -105,18 +105,10 @@ export async function decryptToken(encrypted: string, keyHex: string): Promise<s
 
 // ─── Constant-time comparison ────────────────────────────
 
-export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+export function timingSafeEqual(a: string, b: string): boolean {
   const encoder = new TextEncoder();
   const aBytes = encoder.encode(a);
   const bBytes = encoder.encode(b);
   if (aBytes.byteLength !== bBytes.byteLength) return false;
-  const key = await crypto.subtle.importKey(
-    "raw",
-    randomBytes(32),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign", "verify"],
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, aBytes);
-  return crypto.subtle.verify("HMAC", key, sig, bBytes);
+  return crypto.subtle.timingSafeEqual(aBytes, bBytes);
 }

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -228,6 +228,8 @@ async function fetchGitHubUser(
 
 // ─── Google (OpenID Connect) ─────────────────────────────
 
+// Per-isolate ephemeral cache — each Workers isolate has its own copy;
+// resets on cold start or isolate eviction, which is fine for a hot-path optimisation.
 let cachedJWKS: jose.JWTVerifyGetKey | null = null;
 let jwksCachedAt = 0;
 const JWKS_MEMORY_TTL = 60_000; // 1 min in-memory, KV has 10min TTL
@@ -385,13 +387,12 @@ export async function revokeProviderToken(
       }
       case "google": {
         const token = refreshToken ?? accessToken;
-        const res = await fetch(
-          `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(token)}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          },
-        );
+        const body = new URLSearchParams({ token });
+        const res = await fetch("https://oauth2.googleapis.com/revoke", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: body.toString(),
+        });
         if (!res.ok) {
           console.error(`Google token revocation failed: HTTP ${res.status}`);
         }

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -274,7 +274,7 @@ async function verifyGoogleJwt(
     issuer: ["https://accounts.google.com", "accounts.google.com"],
     audience: env.GOOGLE_CLIENT_ID,
     maxTokenAge: "5 minutes",
-    clockTolerance: "30 seconds",
+    clockTolerance: "5 seconds",
   };
 
   try {
@@ -283,7 +283,10 @@ async function verifyGoogleJwt(
     return payload;
   } catch (err) {
     // If signature verification fails, Google may have rotated keys — clear cache and retry
-    if (err instanceof jose.errors.JWSSignatureVerificationFailed) {
+    if (
+      err instanceof jose.errors.JWSSignatureVerificationFailed ||
+      err instanceof jose.errors.JWKSNoMatchingKey
+    ) {
       cachedJWKS = null;
       jwksCachedAt = 0;
       await kv.delete("google:jwks");
@@ -307,8 +310,8 @@ async function validateGoogleIdToken(
   const payload = await verifyGoogleJwt(idToken, env, kv);
 
   // Validate azp (authorized party) — prevents cross-client token reuse
-  if (payload.azp && payload.azp !== env.GOOGLE_CLIENT_ID) {
-    throw new Error("Google id_token azp mismatch");
+  if (!payload.azp || payload.azp !== env.GOOGLE_CLIENT_ID) {
+    throw new Error("Google id_token azp missing or mismatch");
   }
 
   // Validate nonce — if we sent one, the token MUST contain it
@@ -336,9 +339,13 @@ async function validateGoogleIdToken(
     }
   }
 
+  if (!payload.sub) {
+    throw new Error("Google id_token missing sub claim");
+  }
+
   return {
-    providerUserId: payload.sub!,
-    providerUsername: (payload.name as string) ?? (payload.email as string) ?? payload.sub!,
+    providerUserId: payload.sub,
+    providerUsername: (payload.name as string) ?? (payload.email as string) ?? payload.sub,
     providerEmail: (payload.email as string) ?? null,
     emailVerified: payload.email_verified === true,
     accessToken,
@@ -355,7 +362,10 @@ async function fetchDiscordUser(
   tokenExpiresAt: string | null,
 ): Promise<ProviderUserInfo> {
   const res = await fetch("https://discord.com/api/v10/users/@me", {
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": "CloudTime/1.0",
+    },
   });
 
   if (!res.ok) throw new Error(`Discord /users/@me failed: ${res.status}`);

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -354,6 +354,81 @@ async function validateGoogleIdToken(
   };
 }
 
+// ─── Token Revocation ────────────────────────────────────
+
+export async function revokeProviderToken(
+  provider: OAuthProvider,
+  accessToken: string,
+  refreshToken: string | null,
+  env: Env,
+): Promise<void> {
+  try {
+    switch (provider) {
+      case "github": {
+        const res = await fetch(
+          `https://api.github.com/applications/${env.GITHUB_CLIENT_ID}/token`,
+          {
+            method: "DELETE",
+            headers: {
+              Authorization: `Basic ${btoa(`${env.GITHUB_CLIENT_ID}:${env.GITHUB_CLIENT_SECRET}`)}`,
+              Accept: "application/vnd.github+json",
+              "Content-Type": "application/json",
+              "User-Agent": "CloudTime/1.0",
+            },
+            body: JSON.stringify({ access_token: accessToken }),
+          },
+        );
+        if (!res.ok && res.status !== 422) {
+          console.error(`GitHub token revocation failed: HTTP ${res.status}`);
+        }
+        break;
+      }
+      case "google": {
+        const token = refreshToken ?? accessToken;
+        const res = await fetch(
+          `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(token)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          },
+        );
+        if (!res.ok) {
+          console.error(`Google token revocation failed: HTTP ${res.status}`);
+        }
+        break;
+      }
+      case "discord": {
+        const revokeDiscordToken = async (token: string, hint: string) => {
+          const body = new URLSearchParams({
+            token,
+            token_type_hint: hint,
+            client_id: env.DISCORD_CLIENT_ID,
+            client_secret: env.DISCORD_CLIENT_SECRET,
+          });
+          const res = await fetch("https://discord.com/api/v10/oauth2/token/revoke", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: body.toString(),
+          });
+          if (!res.ok) {
+            console.error(`Discord ${hint} revocation failed: HTTP ${res.status}`);
+          }
+        };
+        await revokeDiscordToken(accessToken, "access_token");
+        if (refreshToken) {
+          await revokeDiscordToken(refreshToken, "refresh_token");
+        }
+        break;
+      }
+    }
+  } catch (err) {
+    console.error(
+      `Token revocation error for ${provider}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
 // ─── Discord ─────────────────────────────────────────────
 
 async function fetchDiscordUser(

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -259,6 +259,36 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
   return cachedJWKS;
 }
 
+async function verifyGoogleJwt(
+  idToken: string,
+  env: Env,
+  kv: KVNamespace,
+): Promise<jose.JWTPayload> {
+  const verifyOpts: jose.JWTVerifyOptions = {
+    issuer: ["https://accounts.google.com", "accounts.google.com"],
+    audience: env.GOOGLE_CLIENT_ID,
+    maxTokenAge: "5 minutes",
+    clockTolerance: "30 seconds",
+  };
+
+  try {
+    const jwks = await getGoogleJWKS(kv);
+    const { payload } = await jose.jwtVerify(idToken, jwks, verifyOpts);
+    return payload;
+  } catch (err) {
+    // If signature verification fails, Google may have rotated keys — clear cache and retry
+    if (err instanceof jose.errors.JWSSignatureVerificationFailed) {
+      cachedJWKS = null;
+      jwksCachedAt = 0;
+      await kv.delete("google:jwks");
+      const freshJwks = await getGoogleJWKS(kv);
+      const { payload } = await jose.jwtVerify(idToken, freshJwks, verifyOpts);
+      return payload;
+    }
+    throw err;
+  }
+}
+
 async function validateGoogleIdToken(
   idToken: string,
   accessToken: string,
@@ -268,21 +298,21 @@ async function validateGoogleIdToken(
   kv: KVNamespace,
   nonce?: string,
 ): Promise<ProviderUserInfo> {
-  const jwks = await getGoogleJWKS(kv);
-
-  const { payload } = await jose.jwtVerify(idToken, jwks, {
-    issuer: ["https://accounts.google.com", "accounts.google.com"],
-    audience: env.GOOGLE_CLIENT_ID,
-  });
+  const payload = await verifyGoogleJwt(idToken, env, kv);
 
   // Validate azp (authorized party) — prevents cross-client token reuse
   if (payload.azp && payload.azp !== env.GOOGLE_CLIENT_ID) {
     throw new Error("Google id_token azp mismatch");
   }
 
-  // Validate nonce
-  if (nonce && payload.nonce !== nonce) {
-    throw new Error("Google id_token nonce mismatch");
+  // Validate nonce — if we sent one, the token MUST contain it
+  if (nonce) {
+    if (!payload.nonce) {
+      throw new Error("Google id_token missing expected nonce");
+    }
+    if (payload.nonce !== nonce) {
+      throw new Error("Google id_token nonce mismatch");
+    }
   }
 
   // Validate at_hash (access token hash) if present

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -113,7 +113,8 @@ export async function exchangeCode(
 
   // GitHub returns 200 even on errors
   if (data.error) {
-    throw new Error(`OAuth token exchange failed: ${data.error} - ${data.error_description ?? ""}`);
+    console.error(`OAuth token exchange failed for ${provider}: ${data.error} - ${data.error_description ?? ""}`);
+    throw new Error("OAuth token exchange failed");
   }
 
   if (!res.ok) {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -39,6 +39,7 @@ export function buildAuthorizeUrl(
       const url = new URL("https://github.com/login/oauth/authorize");
       url.searchParams.set("client_id", env.GITHUB_CLIENT_ID);
       url.searchParams.set("redirect_uri", redirectUri);
+      url.searchParams.set("scope", "read:user user:email");
       url.searchParams.set("state", state);
       url.searchParams.set("code_challenge", codeChallenge);
       url.searchParams.set("code_challenge_method", "S256");
@@ -164,9 +165,12 @@ export async function fetchUserInfo(
   switch (provider) {
     case "github":
       return fetchGitHubUser(tokenResponse.access_token, tokenResponse.refresh_token ?? null, expiresAt);
-    case "google":
+    case "google": {
+      if (!tokenResponse.id_token) {
+        throw new Error("Google OAuth response missing id_token — ensure 'openid' scope is requested");
+      }
       return validateGoogleIdToken(
-        tokenResponse.id_token!,
+        tokenResponse.id_token,
         tokenResponse.access_token,
         tokenResponse.refresh_token ?? null,
         expiresAt,
@@ -174,6 +178,7 @@ export async function fetchUserInfo(
         kv,
         nonce,
       );
+    }
     case "discord":
       return fetchDiscordUser(tokenResponse.access_token, tokenResponse.refresh_token ?? null, expiresAt);
   }

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -242,10 +242,15 @@ async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
   const kvKey = "google:jwks";
   const cached = await kv.get(kvKey);
   if (cached) {
-    const jwks = JSON.parse(cached) as jose.JSONWebKeySet;
-    cachedJWKS = jose.createLocalJWKSet(jwks);
-    jwksCachedAt = Date.now();
-    return cachedJWKS;
+    try {
+      const jwks = JSON.parse(cached) as jose.JSONWebKeySet;
+      cachedJWKS = jose.createLocalJWKSet(jwks);
+      jwksCachedAt = Date.now();
+      return cachedJWKS;
+    } catch {
+      await kv.delete(kvKey);
+      // Fall through to fetch fresh JWKS
+    }
   }
 
   // Fetch from Google

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -414,10 +414,11 @@ export async function revokeProviderToken(
             console.error(`Discord ${hint} revocation failed: HTTP ${res.status}`);
           }
         };
-        await revokeDiscordToken(accessToken, "access_token");
+        const revocations: Promise<void>[] = [revokeDiscordToken(accessToken, "access_token")];
         if (refreshToken) {
-          await revokeDiscordToken(refreshToken, "refresh_token");
+          revocations.push(revokeDiscordToken(refreshToken, "refresh_token"));
         }
+        await Promise.all(revocations);
         break;
       }
     }

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -1,0 +1,339 @@
+/**
+ * OAuth provider configurations, token exchange, and user info fetching.
+ */
+import * as jose from "jose";
+import type { Env } from "../types";
+
+// ─── Types ───────────────────────────────────────────────
+
+export type OAuthProvider = "github" | "google" | "discord";
+
+const VALID_PROVIDERS = new Set<string>(["github", "google", "discord"]);
+
+export function isValidProvider(s: string): s is OAuthProvider {
+  return VALID_PROVIDERS.has(s);
+}
+
+export interface ProviderUserInfo {
+  providerUserId: string;
+  providerUsername: string;
+  providerEmail: string | null;
+  emailVerified: boolean;
+  accessToken: string;
+  refreshToken: string | null;
+  tokenExpiresAt: string | null;
+}
+
+// ─── Authorization URLs ──────────────────────────────────
+
+export function buildAuthorizeUrl(
+  provider: OAuthProvider,
+  env: Env,
+  redirectUri: string,
+  codeChallenge: string,
+  state: string,
+  nonce?: string,
+): string {
+  switch (provider) {
+    case "github": {
+      const url = new URL("https://github.com/login/oauth/authorize");
+      url.searchParams.set("client_id", env.GITHUB_CLIENT_ID);
+      url.searchParams.set("redirect_uri", redirectUri);
+      url.searchParams.set("state", state);
+      url.searchParams.set("code_challenge", codeChallenge);
+      url.searchParams.set("code_challenge_method", "S256");
+      return url.toString();
+    }
+    case "google": {
+      const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+      url.searchParams.set("client_id", env.GOOGLE_CLIENT_ID);
+      url.searchParams.set("redirect_uri", redirectUri);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("scope", "openid email profile");
+      url.searchParams.set("state", state);
+      url.searchParams.set("code_challenge", codeChallenge);
+      url.searchParams.set("code_challenge_method", "S256");
+      if (nonce) url.searchParams.set("nonce", nonce);
+      return url.toString();
+    }
+    case "discord": {
+      const url = new URL("https://discord.com/oauth2/authorize");
+      url.searchParams.set("client_id", env.DISCORD_CLIENT_ID);
+      url.searchParams.set("redirect_uri", redirectUri);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("scope", "identify email");
+      url.searchParams.set("state", state);
+      url.searchParams.set("code_challenge", codeChallenge);
+      url.searchParams.set("code_challenge_method", "S256");
+      return url.toString();
+    }
+  }
+}
+
+// ─── Token Exchange ──────────────────────────────────────
+
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  scope?: string;
+}
+
+export async function exchangeCode(
+  provider: OAuthProvider,
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+  env: Env,
+): Promise<TokenResponse> {
+  const { url, clientId, clientSecret } = getTokenEndpoint(provider, env);
+
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId,
+    client_secret: clientSecret,
+    code_verifier: codeVerifier,
+  });
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: body.toString(),
+  });
+
+  const data = (await res.json()) as TokenResponse & { error?: string; error_description?: string };
+
+  // GitHub returns 200 even on errors
+  if (data.error) {
+    throw new Error(`OAuth token exchange failed: ${data.error} - ${data.error_description ?? ""}`);
+  }
+
+  if (!res.ok) {
+    throw new Error(`OAuth token exchange failed: HTTP ${res.status}`);
+  }
+
+  return data;
+}
+
+function getTokenEndpoint(
+  provider: OAuthProvider,
+  env: Env,
+): { url: string; clientId: string; clientSecret: string } {
+  switch (provider) {
+    case "github":
+      return {
+        url: "https://github.com/login/oauth/access_token",
+        clientId: env.GITHUB_CLIENT_ID,
+        clientSecret: env.GITHUB_CLIENT_SECRET,
+      };
+    case "google":
+      return {
+        url: "https://oauth2.googleapis.com/token",
+        clientId: env.GOOGLE_CLIENT_ID,
+        clientSecret: env.GOOGLE_CLIENT_SECRET,
+      };
+    case "discord":
+      return {
+        url: "https://discord.com/api/v10/oauth2/token",
+        clientId: env.DISCORD_CLIENT_ID,
+        clientSecret: env.DISCORD_CLIENT_SECRET,
+      };
+  }
+}
+
+// ─── User Info Fetching ──────────────────────────────────
+
+export async function fetchUserInfo(
+  provider: OAuthProvider,
+  tokenResponse: TokenResponse,
+  env: Env,
+  kv: KVNamespace,
+  nonce?: string,
+): Promise<ProviderUserInfo> {
+  const expiresAt = tokenResponse.expires_in
+    ? new Date(Date.now() + tokenResponse.expires_in * 1000).toISOString()
+    : null;
+
+  switch (provider) {
+    case "github":
+      return fetchGitHubUser(tokenResponse.access_token, tokenResponse.refresh_token ?? null, expiresAt);
+    case "google":
+      return validateGoogleIdToken(
+        tokenResponse.id_token!,
+        tokenResponse.access_token,
+        tokenResponse.refresh_token ?? null,
+        expiresAt,
+        env,
+        kv,
+        nonce,
+      );
+    case "discord":
+      return fetchDiscordUser(tokenResponse.access_token, tokenResponse.refresh_token ?? null, expiresAt);
+  }
+}
+
+// ─── GitHub ──────────────────────────────────────────────
+
+async function fetchGitHubUser(
+  accessToken: string,
+  refreshToken: string | null,
+  tokenExpiresAt: string | null,
+): Promise<ProviderUserInfo> {
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "CloudTime/1.0",
+  };
+
+  const [userRes, emailsRes] = await Promise.all([
+    fetch("https://api.github.com/user", { headers }),
+    fetch("https://api.github.com/user/emails", { headers }),
+  ]);
+
+  if (!userRes.ok) throw new Error(`GitHub /user failed: ${userRes.status}`);
+  if (!emailsRes.ok) throw new Error(`GitHub /user/emails failed: ${emailsRes.status}`);
+
+  const user = (await userRes.json()) as { id: number; login: string };
+  const emails = (await emailsRes.json()) as Array<{
+    email: string;
+    primary: boolean;
+    verified: boolean;
+  }>;
+
+  const primaryEmail = emails.find((e) => e.primary && e.verified);
+
+  return {
+    providerUserId: String(user.id),
+    providerUsername: user.login,
+    providerEmail: primaryEmail?.email ?? null,
+    emailVerified: !!primaryEmail,
+    accessToken,
+    refreshToken,
+    tokenExpiresAt,
+  };
+}
+
+// ─── Google (OpenID Connect) ─────────────────────────────
+
+let cachedJWKS: jose.JWTVerifyGetKey | null = null;
+let jwksCachedAt = 0;
+const JWKS_MEMORY_TTL = 60_000; // 1 min in-memory, KV has 10min TTL
+
+async function getGoogleJWKS(kv: KVNamespace): Promise<jose.JWTVerifyGetKey> {
+  // In-memory cache for hot path
+  if (cachedJWKS && Date.now() - jwksCachedAt < JWKS_MEMORY_TTL) {
+    return cachedJWKS;
+  }
+
+  // Try KV cache
+  const kvKey = "google:jwks";
+  const cached = await kv.get(kvKey);
+  if (cached) {
+    const jwks = JSON.parse(cached) as jose.JSONWebKeySet;
+    cachedJWKS = jose.createLocalJWKSet(jwks);
+    jwksCachedAt = Date.now();
+    return cachedJWKS;
+  }
+
+  // Fetch from Google
+  const res = await fetch("https://www.googleapis.com/oauth2/v3/certs");
+  if (!res.ok) throw new Error(`Failed to fetch Google JWKS: ${res.status}`);
+  const jwks = (await res.json()) as jose.JSONWebKeySet;
+
+  // Cache in KV (10 min TTL)
+  await kv.put(kvKey, JSON.stringify(jwks), { expirationTtl: 600 });
+  cachedJWKS = jose.createLocalJWKSet(jwks);
+  jwksCachedAt = Date.now();
+  return cachedJWKS;
+}
+
+async function validateGoogleIdToken(
+  idToken: string,
+  accessToken: string,
+  refreshToken: string | null,
+  tokenExpiresAt: string | null,
+  env: Env,
+  kv: KVNamespace,
+  nonce?: string,
+): Promise<ProviderUserInfo> {
+  const jwks = await getGoogleJWKS(kv);
+
+  const { payload } = await jose.jwtVerify(idToken, jwks, {
+    issuer: ["https://accounts.google.com", "accounts.google.com"],
+    audience: env.GOOGLE_CLIENT_ID,
+  });
+
+  // Validate azp (authorized party) — prevents cross-client token reuse
+  if (payload.azp && payload.azp !== env.GOOGLE_CLIENT_ID) {
+    throw new Error("Google id_token azp mismatch");
+  }
+
+  // Validate nonce
+  if (nonce && payload.nonce !== nonce) {
+    throw new Error("Google id_token nonce mismatch");
+  }
+
+  // Validate at_hash (access token hash) if present
+  if (payload.at_hash && typeof payload.at_hash === "string") {
+    const atHashBuf = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(accessToken),
+    );
+    const halfHash = new Uint8Array(atHashBuf.slice(0, 16));
+    let binary = "";
+    for (const b of halfHash) binary += String.fromCharCode(b);
+    const expected = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    if (expected !== payload.at_hash) {
+      throw new Error("Google id_token at_hash mismatch");
+    }
+  }
+
+  return {
+    providerUserId: payload.sub!,
+    providerUsername: (payload.name as string) ?? (payload.email as string) ?? payload.sub!,
+    providerEmail: (payload.email as string) ?? null,
+    emailVerified: payload.email_verified === true,
+    accessToken,
+    refreshToken,
+    tokenExpiresAt,
+  };
+}
+
+// ─── Discord ─────────────────────────────────────────────
+
+async function fetchDiscordUser(
+  accessToken: string,
+  refreshToken: string | null,
+  tokenExpiresAt: string | null,
+): Promise<ProviderUserInfo> {
+  const res = await fetch("https://discord.com/api/v10/users/@me", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!res.ok) throw new Error(`Discord /users/@me failed: ${res.status}`);
+
+  const user = (await res.json()) as {
+    id: string;
+    username: string;
+    global_name: string | null;
+    email: string | null;
+    verified: boolean;
+  };
+
+  return {
+    providerUserId: user.id,
+    providerUsername: user.global_name ?? user.username,
+    providerEmail: user.verified ? user.email : null,
+    emailVerified: user.verified && user.email !== null,
+    accessToken,
+    refreshToken,
+    tokenExpiresAt,
+  };
+}

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared CORS / CSRF origin matching logic.
+ *
+ * Used by both the global CORS middleware and auth-route CSRF middleware
+ * to avoid duplicating the same origin callback.
+ */
+
+/**
+ * Returns the allowed origin string for CORS / CSRF validation.
+ * - If APP_URL is set, only that origin is accepted (returns "" on mismatch).
+ * - If APP_URL is unset (dev), all origins are reflected back (allow-all).
+ */
+export function matchOrigin(origin: string, appUrl?: string): string {
+  if (appUrl) {
+    const normalized = appUrl.replace(/\/+$/, "");
+    return origin === normalized ? origin : "";
+  }
+  // Development: reflect origin (allow all)
+  return origin;
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -208,7 +208,6 @@ export function setSessionCookie(c: Context, token: string, env: Env): void {
     sameSite: "Lax",
     path: "/",
     maxAge: ABSOLUTE_EXPIRY,
-    ...(isDev ? {} : { prefix: "host" }),
   });
 }
 
@@ -251,9 +250,14 @@ export async function consumeOAuthState(
 
 // ─── State Cookie (double-submit) ────────────────────────
 
+function getStateCookieName(env: Env): string {
+  return env.ENVIRONMENT === "development" ? "oauth_state" : "__Host-oauth_state";
+}
+
 export function setStateCookie(c: Context, state: string, env: Env): void {
   const isDev = env.ENVIRONMENT === "development";
-  setCookie(c, "oauth_state", state, {
+  const name = getStateCookieName(env);
+  setCookie(c, name, state, {
     httpOnly: true,
     secure: !isDev,
     sameSite: "Lax",
@@ -262,10 +266,10 @@ export function setStateCookie(c: Context, state: string, env: Env): void {
   });
 }
 
-export function getStateCookie(c: Context): string | null {
-  return getCookie(c, "oauth_state") ?? null;
+export function getStateCookie(c: Context, env: Env): string | null {
+  return getCookie(c, getStateCookieName(env)) ?? null;
 }
 
-export function clearStateCookie(c: Context): void {
-  deleteCookie(c, "oauth_state", { path: "/" });
+export function clearStateCookie(c: Context, env: Env): void {
+  deleteCookie(c, getStateCookieName(env), { path: "/" });
 }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -207,7 +207,7 @@ export async function invalidateAllUserSessions(
 // ─── Cookie Helpers ──────────────────────────────────────
 
 function isDev(env: Env): boolean {
-  return env.ENVIRONMENT === "development" || env.ENVIRONMENT === undefined;
+  return env.ENVIRONMENT === "development";
 }
 
 export function getSessionCookieName(env: Env): string {
@@ -264,7 +264,11 @@ export async function consumeOAuthState(
   const raw = await kv.get(key);
   if (!raw) return null;
   await kv.delete(key);
-  return JSON.parse(raw) as OAuthStateData;
+  try {
+    return JSON.parse(raw) as OAuthStateData;
+  } catch {
+    return null;
+  }
 }
 
 // ─── State Cookie (double-submit) ────────────────────────

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -186,24 +186,6 @@ export async function invalidateOtherSessions(
   await Promise.all(deletes);
 }
 
-export async function invalidateAllUserSessions(
-  db: D1Database,
-  kv: KVNamespace,
-  userId: string,
-): Promise<void> {
-  const { results } = await db
-    .prepare("SELECT token_hash FROM sessions WHERE user_id = ?")
-    .bind(userId)
-    .all<{ token_hash: string }>();
-
-  const deletes: Promise<unknown>[] = results.map((r) => kv.delete(`session:${r.token_hash}`));
-  deletes.push(
-    db.prepare("DELETE FROM sessions WHERE user_id = ?").bind(userId).run(),
-  );
-
-  await Promise.all(deletes);
-}
-
 // ─── Cookie Helpers ──────────────────────────────────────
 
 function isDev(env: Env): boolean {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -227,7 +227,12 @@ export function setSessionCookie(c: Context, token: string, env: Env): void {
 
 export function clearSessionCookie(c: Context, env: Env): void {
   const name = getSessionCookieName(env);
-  deleteCookie(c, name, { path: "/" });
+  deleteCookie(c, name, {
+    path: "/",
+    secure: !isDev(env),
+    httpOnly: true,
+    sameSite: "Lax",
+  });
 }
 
 export function getSessionTokenFromCookie(c: Context, env: Env): string | null {
@@ -284,5 +289,10 @@ export function getStateCookie(c: Context, env: Env): string | null {
 }
 
 export function clearStateCookie(c: Context, env: Env): void {
-  deleteCookie(c, getStateCookieName(env), { path: "/" });
+  deleteCookie(c, getStateCookieName(env), {
+    path: "/",
+    secure: !isDev(env),
+    httpOnly: true,
+    sameSite: "Lax",
+  });
 }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -3,7 +3,6 @@
  */
 import type { Context } from "hono";
 import { getCookie, setCookie, deleteCookie } from "hono/cookie";
-import { sha256Hex } from "./crypto";
 import type { Env } from "../types";
 
 // ─── Constants ───────────────────────────────────────────
@@ -62,19 +61,31 @@ export async function validateSession(
   const cacheKey = `session:${tokenHash}`;
   const cached = await kv.get(cacheKey);
   if (cached) {
-    const data = JSON.parse(cached) as SessionData;
+    let data: SessionData;
+    try {
+      data = JSON.parse(cached) as SessionData;
+    } catch {
+      await kv.delete(cacheKey);
+      return null;
+    }
     const now = new Date();
     const expiresAt = new Date(data.expiresAt.replace(" ", "T") + "Z");
     const lastActive = new Date(data.lastActiveAt.replace(" ", "T") + "Z");
 
     // Check absolute expiry
     if (now > expiresAt) {
-      await kv.delete(cacheKey);
+      await Promise.all([
+        kv.delete(cacheKey),
+        db.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(tokenHash).run(),
+      ]);
       return null;
     }
     // Check idle timeout
     if ((now.getTime() - lastActive.getTime()) / 1000 > IDLE_TIMEOUT) {
-      await kv.delete(cacheKey);
+      await Promise.all([
+        kv.delete(cacheKey),
+        db.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(tokenHash).run(),
+      ]);
       return null;
     }
 
@@ -195,16 +206,19 @@ export async function invalidateAllUserSessions(
 
 // ─── Cookie Helpers ──────────────────────────────────────
 
+function isDev(env: Env): boolean {
+  return env.ENVIRONMENT === "development" || env.ENVIRONMENT === undefined;
+}
+
 export function getSessionCookieName(env: Env): string {
-  return env.ENVIRONMENT === "development" ? "session" : "__Host-session";
+  return isDev(env) ? "session" : "__Host-session";
 }
 
 export function setSessionCookie(c: Context, token: string, env: Env): void {
   const name = getSessionCookieName(env);
-  const isDev = env.ENVIRONMENT === "development";
   setCookie(c, name, token, {
     httpOnly: true,
-    secure: !isDev,
+    secure: !isDev(env),
     sameSite: "Lax",
     path: "/",
     maxAge: ABSOLUTE_EXPIRY,
@@ -251,15 +265,14 @@ export async function consumeOAuthState(
 // ─── State Cookie (double-submit) ────────────────────────
 
 function getStateCookieName(env: Env): string {
-  return env.ENVIRONMENT === "development" ? "oauth_state" : "__Host-oauth_state";
+  return isDev(env) ? "oauth_state" : "__Host-oauth_state";
 }
 
 export function setStateCookie(c: Context, state: string, env: Env): void {
-  const isDev = env.ENVIRONMENT === "development";
   const name = getStateCookieName(env);
   setCookie(c, name, state, {
     httpOnly: true,
-    secure: !isDev,
+    secure: !isDev(env),
     sameSite: "Lax",
     path: "/",
     maxAge: STATE_TTL,

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,271 @@
+/**
+ * Session lifecycle, cookie helpers, and OAuth state KV storage.
+ */
+import type { Context } from "hono";
+import { getCookie, setCookie, deleteCookie } from "hono/cookie";
+import { sha256Hex } from "./crypto";
+import type { Env } from "../types";
+
+// ─── Constants ───────────────────────────────────────────
+
+const IDLE_TIMEOUT = 24 * 60 * 60; // 24h
+const ABSOLUTE_EXPIRY = 7 * 24 * 60 * 60; // 7d
+const ACTIVITY_THROTTLE = 5 * 60; // 5min
+const STATE_TTL = 600; // 10min
+const SESSION_CACHE_TTL = 300; // 5min
+
+// ─── Session CRUD ────────────────────────────────────────
+
+export interface SessionData {
+  userId: string;
+  sessionId: string;
+  expiresAt: string;
+  lastActiveAt: string;
+}
+
+export async function createSession(
+  db: D1Database,
+  userId: string,
+  tokenHash: string,
+  request: Request,
+): Promise<{ sessionId: string; expiresAt: string }> {
+  const sessionId = crypto.randomUUID();
+  const now = new Date().toISOString().replace("T", " ").replace("Z", "");
+  const expiresAt = new Date(Date.now() + ABSOLUTE_EXPIRY * 1000)
+    .toISOString()
+    .replace("T", " ")
+    .replace("Z", "");
+
+  const ip = request.headers.get("CF-Connecting-IP") ?? null;
+  const cf = (request as Request & { cf?: { country?: string; city?: string } }).cf;
+  const country = cf?.country ?? null;
+  const city = cf?.city ?? null;
+  const userAgent = request.headers.get("User-Agent") ?? null;
+
+  await db
+    .prepare(
+      `INSERT INTO sessions (id, user_id, token_hash, ip, country, city, user_agent, created_at, expires_at, last_active_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(sessionId, userId, tokenHash, ip, country, city, userAgent, now, expiresAt, now)
+    .run();
+
+  return { sessionId, expiresAt };
+}
+
+export async function validateSession(
+  db: D1Database,
+  kv: KVNamespace,
+  tokenHash: string,
+): Promise<SessionData | null> {
+  // Check KV cache first
+  const cacheKey = `session:${tokenHash}`;
+  const cached = await kv.get(cacheKey);
+  if (cached) {
+    const data = JSON.parse(cached) as SessionData;
+    const now = new Date();
+    const expiresAt = new Date(data.expiresAt.replace(" ", "T") + "Z");
+    const lastActive = new Date(data.lastActiveAt.replace(" ", "T") + "Z");
+
+    // Check absolute expiry
+    if (now > expiresAt) {
+      await kv.delete(cacheKey);
+      return null;
+    }
+    // Check idle timeout
+    if ((now.getTime() - lastActive.getTime()) / 1000 > IDLE_TIMEOUT) {
+      await kv.delete(cacheKey);
+      return null;
+    }
+
+    // Throttled activity update
+    if ((now.getTime() - lastActive.getTime()) / 1000 > ACTIVITY_THROTTLE) {
+      const nowStr = now.toISOString().replace("T", " ").replace("Z", "");
+      data.lastActiveAt = nowStr;
+      await Promise.all([
+        db
+          .prepare("UPDATE sessions SET last_active_at = ? WHERE token_hash = ?")
+          .bind(nowStr, tokenHash)
+          .run(),
+        kv.put(cacheKey, JSON.stringify(data), { expirationTtl: SESSION_CACHE_TTL }),
+      ]);
+    }
+
+    return data;
+  }
+
+  // Fallback to D1
+  const row = await db
+    .prepare(
+      "SELECT id, user_id, expires_at, last_active_at FROM sessions WHERE token_hash = ?",
+    )
+    .bind(tokenHash)
+    .first<{ id: string; user_id: string; expires_at: string; last_active_at: string }>();
+
+  if (!row) return null;
+
+  const now = new Date();
+  const expiresAt = new Date(row.expires_at.replace(" ", "T") + "Z");
+  const lastActive = new Date(row.last_active_at.replace(" ", "T") + "Z");
+
+  if (now > expiresAt) {
+    await db.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(tokenHash).run();
+    return null;
+  }
+
+  if ((now.getTime() - lastActive.getTime()) / 1000 > IDLE_TIMEOUT) {
+    await db.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(tokenHash).run();
+    return null;
+  }
+
+  const data: SessionData = {
+    userId: row.user_id,
+    sessionId: row.id,
+    expiresAt: row.expires_at,
+    lastActiveAt: row.last_active_at,
+  };
+
+  // Throttled activity update
+  if ((now.getTime() - lastActive.getTime()) / 1000 > ACTIVITY_THROTTLE) {
+    const nowStr = now.toISOString().replace("T", " ").replace("Z", "");
+    data.lastActiveAt = nowStr;
+    await db
+      .prepare("UPDATE sessions SET last_active_at = ? WHERE token_hash = ?")
+      .bind(nowStr, tokenHash)
+      .run();
+  }
+
+  // Cache in KV
+  await kv.put(cacheKey, JSON.stringify(data), { expirationTtl: SESSION_CACHE_TTL });
+
+  return data;
+}
+
+export async function invalidateSession(
+  db: D1Database,
+  kv: KVNamespace,
+  tokenHash: string,
+): Promise<void> {
+  await Promise.all([
+    db.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(tokenHash).run(),
+    kv.delete(`session:${tokenHash}`),
+  ]);
+}
+
+export async function invalidateOtherSessions(
+  db: D1Database,
+  kv: KVNamespace,
+  userId: string,
+  currentTokenHash: string,
+): Promise<void> {
+  // Get all other session hashes to clear KV
+  const { results } = await db
+    .prepare("SELECT token_hash FROM sessions WHERE user_id = ? AND token_hash != ?")
+    .bind(userId, currentTokenHash)
+    .all<{ token_hash: string }>();
+
+  const deletes: Promise<unknown>[] = results.map((r) => kv.delete(`session:${r.token_hash}`));
+  deletes.push(
+    db
+      .prepare("DELETE FROM sessions WHERE user_id = ? AND token_hash != ?")
+      .bind(userId, currentTokenHash)
+      .run(),
+  );
+
+  await Promise.all(deletes);
+}
+
+export async function invalidateAllUserSessions(
+  db: D1Database,
+  kv: KVNamespace,
+  userId: string,
+): Promise<void> {
+  const { results } = await db
+    .prepare("SELECT token_hash FROM sessions WHERE user_id = ?")
+    .bind(userId)
+    .all<{ token_hash: string }>();
+
+  const deletes: Promise<unknown>[] = results.map((r) => kv.delete(`session:${r.token_hash}`));
+  deletes.push(
+    db.prepare("DELETE FROM sessions WHERE user_id = ?").bind(userId).run(),
+  );
+
+  await Promise.all(deletes);
+}
+
+// ─── Cookie Helpers ──────────────────────────────────────
+
+export function getSessionCookieName(env: Env): string {
+  return env.ENVIRONMENT === "development" ? "session" : "__Host-session";
+}
+
+export function setSessionCookie(c: Context, token: string, env: Env): void {
+  const name = getSessionCookieName(env);
+  const isDev = env.ENVIRONMENT === "development";
+  setCookie(c, name, token, {
+    httpOnly: true,
+    secure: !isDev,
+    sameSite: "Lax",
+    path: "/",
+    maxAge: ABSOLUTE_EXPIRY,
+    ...(isDev ? {} : { prefix: "host" }),
+  });
+}
+
+export function clearSessionCookie(c: Context, env: Env): void {
+  const name = getSessionCookieName(env);
+  deleteCookie(c, name, { path: "/" });
+}
+
+export function getSessionTokenFromCookie(c: Context, env: Env): string | null {
+  const name = getSessionCookieName(env);
+  return getCookie(c, name) ?? null;
+}
+
+// ─── OAuth State KV ──────────────────────────────────────
+
+export interface OAuthStateData {
+  codeVerifier: string;
+  nonce?: string;
+  linkUserId?: string;
+}
+
+export async function storeOAuthState(
+  kv: KVNamespace,
+  state: string,
+  data: OAuthStateData,
+): Promise<void> {
+  await kv.put(`oauth:state:${state}`, JSON.stringify(data), { expirationTtl: STATE_TTL });
+}
+
+export async function consumeOAuthState(
+  kv: KVNamespace,
+  state: string,
+): Promise<OAuthStateData | null> {
+  const key = `oauth:state:${state}`;
+  const raw = await kv.get(key);
+  if (!raw) return null;
+  await kv.delete(key);
+  return JSON.parse(raw) as OAuthStateData;
+}
+
+// ─── State Cookie (double-submit) ────────────────────────
+
+export function setStateCookie(c: Context, state: string, env: Env): void {
+  const isDev = env.ENVIRONMENT === "development";
+  setCookie(c, "oauth_state", state, {
+    httpOnly: true,
+    secure: !isDev,
+    sameSite: "Lax",
+    path: "/",
+    maxAge: STATE_TTL,
+  });
+}
+
+export function getStateCookie(c: Context): string | null {
+  return getCookie(c, "oauth_state") ?? null;
+}
+
+export function clearStateCookie(c: Context): void {
+  deleteCookie(c, "oauth_state", { path: "/" });
+}

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared user row mapping utilities.
+ * Extracted from routes/users.ts for reuse in auth routes.
+ */
+import type { components } from "../types/generated";
+
+type User = components["schemas"]["User"];
+
+export type UserRow = {
+  id: string;
+  username: string;
+  display_name: string | null;
+  email: string | null;
+  photo: string | null;
+  bio: string | null;
+  city: string | null;
+  timezone: string;
+  timeout: number;
+  is_hireable: number;
+  github_username: string | null;
+  twitter_username: string | null;
+  website: string | null;
+  created_at: string;
+  modified_at: string;
+};
+
+export const USER_COLUMNS = `id, username, display_name, email, photo, bio, city, timezone, timeout, is_hireable, github_username, twitter_username, website, created_at, modified_at`;
+
+export function normalizeDateTime(dt: string): string {
+  return dt.includes("T") ? dt : dt.replace(" ", "T") + "Z";
+}
+
+export function rowToUser(
+  row: UserRow,
+  lastHeartbeat?: { project: string | null; time: number } | null,
+): User {
+  return {
+    id: row.id,
+    username: row.username,
+    display_name: row.display_name ?? undefined,
+    email: row.email ?? undefined,
+    photo: row.photo ?? undefined,
+    bio: row.bio ?? undefined,
+    city: row.city ?? undefined,
+    timezone: row.timezone,
+    timeout: row.timeout,
+    is_hireable: row.is_hireable === 1,
+    github_username: row.github_username ?? undefined,
+    twitter_username: row.twitter_username ?? undefined,
+    website: row.website ?? undefined,
+    plan: "free",
+    last_heartbeat_at: lastHeartbeat
+      ? new Date(lastHeartbeat.time * 1000).toISOString()
+      : undefined,
+    last_project: lastHeartbeat?.project ?? undefined,
+    created_at: normalizeDateTime(row.created_at),
+    modified_at: normalizeDateTime(row.modified_at),
+  };
+}


### PR DESCRIPTION
## Summary

Implements the full OAuth authentication system and adds token revocation on provider unlink.

- **13 auth endpoints** across 4 flows: OAuth login (GitHub/Google/Discord), account linking with PendingLink approval, session management with sliding+absolute expiry, and API key regeneration
- All OAuth tokens **encrypted at rest** with AES-256-GCM (AAD context: `userId:provider`)
- Auth middleware falls back to session cookies when no API key is present
- `revokeProviderToken()` in `src/utils/oauth.ts` — calls each provider's token revocation endpoint (GitHub DELETE, Google POST, Discord POST ×2)
- `DELETE /providers/:provider` unlink handler decrypts stored tokens and revokes them via `waitUntil()` after returning 204

## Security highlights

| Area | Approach |
|------|----------|
| PKCE | S256 code challenge on all 3 providers |
| CSRF | Hono `csrf()` + double-submit state cookie |
| Tokens at rest | AES-256-GCM with per-user+provider AAD |
| Session | SHA-256 hashed token, sliding idle (24h) + absolute (7d) expiry |
| Cookies | `HttpOnly`, `Secure`, `SameSite=Lax`, `__Host-` prefix in production |
| CORS | Restricted to `APP_URL` origin with credentials |
| Single-user | Atomic `INSERT...SELECT WHERE (COUNT=0)` prevents TOCTOU race |
| Timing | `crypto.subtle.timingSafeEqual` via SHA-256 hash comparison |

## Token revocation details (closes #35)

| Provider | Endpoint | Notes |
|----------|----------|-------|
| GitHub | `DELETE /applications/{client_id}/token` | Basic auth; 422 treated as success (already revoked) |
| Google | `POST /revoke` | Token sent in POST body; prefers refresh token (cascades to access token) |
| Discord | `POST /oauth2/token/revoke` | Parallel calls for access + refresh tokens |

Edge cases handled:
- NULL tokens → skip silently
- Decryption failure (rotated key) → log and continue
- Provider API error → log and continue
- Provider not linked (0 rows deleted) → no tokens to revoke

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] OAuth login flow works for each provider (GitHub, Google, Discord)
- [ ] Session cookie set correctly; logout clears it
- [ ] Account linking creates pending link when email matches existing user
- [ ] Unlink a provider → response is still 204
- [ ] Worker logs show revocation attempt (or skip if no tokens)
- [ ] Revoked token no longer works on provider API
- [ ] Single-user mode rejects second user registration
- [ ] API key regeneration invalidates old key and other sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)