### PR TITLE
fix: revoke provider OAuth tokens on unlink (#35)

### DIFF
--- a/src/routes/auth/sessions.ts
+++ b/src/routes/auth/sessions.ts
@@ -5,8 +5,8 @@
  */
 import { Hono } from "hono";
 import type { SessionAuthEnv } from "../../types";
-import { generateApiKey } from "../../utils/crypto";
-import { isValidProvider, type OAuthProvider } from "../../utils/oauth";
+import { generateApiKey, decryptToken } from "../../utils/crypto";
+import { isValidProvider, revokeProviderToken, type OAuthProvider } from "../../utils/oauth";
 import {
   invalidateSession,
   invalidateOtherSessions,
@@ -205,7 +205,7 @@ sessions.get("/providers", async (c) => {
   }
 });
 
-// DELETE /providers/:provider (unlink)
+// DELETE /providers/:provider (unlink + revoke tokens)
 sessions.delete("/providers/:provider", async (c) => {
   try {
     const userId = c.get("userId");
@@ -215,13 +215,20 @@ sessions.delete("/providers/:provider", async (c) => {
       return c.json({ error: "Invalid provider" }, 400);
     }
 
-    const [{ results: linked }, userRow] = await Promise.all([
+    // Fetch auth guard data and encrypted tokens in parallel.
+    // Only load tokens for the target provider (avoid loading all providers' secrets).
+    const [{ results: linked }, userRow, targetRow] = await Promise.all([
       c.env.DB.prepare("SELECT provider FROM oauth_accounts WHERE user_id = ?")
         .bind(userId)
         .all<{ provider: string }>(),
       c.env.DB.prepare("SELECT api_key_hash FROM users WHERE id = ?")
         .bind(userId)
         .first<{ api_key_hash: string }>(),
+      c.env.DB.prepare(
+        "SELECT access_token_encrypted, refresh_token_encrypted FROM oauth_accounts WHERE user_id = ? AND provider = ?",
+      )
+        .bind(userId, provider)
+        .first<{ access_token_encrypted: string | null; refresh_token_encrypted: string | null }>(),
     ]);
 
     // api_key_hash is NOT NULL, so hasApiKey is always true — guard is defensive
@@ -234,6 +241,31 @@ sessions.delete("/providers/:provider", async (c) => {
     await c.env.DB.prepare("DELETE FROM oauth_accounts WHERE user_id = ? AND provider = ?")
       .bind(userId, provider)
       .run();
+
+    // Best-effort token revocation in the background (non-blocking)
+    if (targetRow?.access_token_encrypted) {
+      const encCtx = `${userId}:${provider}`;
+      const encKey = c.env.ENCRYPTION_KEY;
+      const accessEnc = targetRow.access_token_encrypted;
+      const refreshEnc = targetRow.refresh_token_encrypted;
+
+      c.executionCtx.waitUntil(
+        (async () => {
+          try {
+            const accessToken = await decryptToken(accessEnc, encKey, encCtx);
+            const refreshToken = refreshEnc
+              ? await decryptToken(refreshEnc, encKey, encCtx)
+              : null;
+            await revokeProviderToken(provider, accessToken, refreshToken, c.env);
+          } catch (err) {
+            console.error(
+              `Token revocation failed for ${provider}:`,
+              err instanceof Error ? err.message : err,
+            );
+          }
+        })(),
+      );
+    }
 
     return c.body(null, 204);
   } catch (err) {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -449,6 +449,79 @@ async function validateGoogleIdToken(
   };
 }
 
+// ─── Token Revocation ────────────────────────────────────
+
+export async function revokeProviderToken(
+  provider: OAuthProvider,
+  accessToken: string,
+  refreshToken: string | null,
+  env: Env,
+): Promise<void> {
+  switch (provider) {
+    case "github": {
+      const res = await fetch(
+        `https://api.github.com/applications/${env.GITHUB_CLIENT_ID}/token`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Basic ${btoa(`${env.GITHUB_CLIENT_ID}:${env.GITHUB_CLIENT_SECRET}`)}`,
+            Accept: "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "CloudTime/1.0",
+          },
+          body: JSON.stringify({ access_token: accessToken }),
+          ...PROVIDER_FETCH_OPTS,
+        },
+      );
+      // 422 = already revoked, treat as success
+      if (!res.ok && res.status !== 422) {
+        console.error(`GitHub token revocation failed: HTTP ${res.status}`);
+      }
+      break;
+    }
+    case "google": {
+      // Prefer refresh token (revoking it cascades to the access token)
+      const token = refreshToken ?? accessToken;
+      const body = new URLSearchParams({ token });
+      const res = await fetch("https://oauth2.googleapis.com/revoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        ...PROVIDER_FETCH_OPTS,
+      });
+      if (!res.ok) {
+        console.error(`Google token revocation failed: HTTP ${res.status}`);
+      }
+      break;
+    }
+    case "discord": {
+      const revokeOne = async (token: string, hint: string) => {
+        const body = new URLSearchParams({
+          token,
+          token_type_hint: hint,
+          client_id: env.DISCORD_CLIENT_ID,
+          client_secret: env.DISCORD_CLIENT_SECRET,
+        });
+        const res = await fetch("https://discord.com/api/v10/oauth2/token/revoke", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: body.toString(),
+          ...PROVIDER_FETCH_OPTS,
+        });
+        if (!res.ok) {
+          console.error(`Discord ${hint} revocation failed: HTTP ${res.status}`);
+        }
+      };
+      const tasks: Promise<void>[] = [revokeOne(accessToken, "access_token")];
+      if (refreshToken) {
+        tasks.push(revokeOne(refreshToken, "refresh_token"));
+      }
+      await Promise.all(tasks);
+      break;
+    }
+  }
+}
+
 // ─── Discord ─────────────────────────────────────────────
 
 async function fetchDiscordUser(

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -482,15 +482,26 @@ export async function revokeProviderToken(
     case "google": {
       // Prefer refresh token (revoking it cascades to the access token)
       const token = refreshToken ?? accessToken;
-      const body = new URLSearchParams({ token });
       const res = await fetch("https://oauth2.googleapis.com/revoke", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: body.toString(),
+        body: new URLSearchParams({ token }).toString(),
         ...PROVIDER_FETCH_OPTS,
       });
       if (!res.ok) {
         console.error(`Google token revocation failed: HTTP ${res.status}`);
+        // If refresh token revocation failed, also try revoking the access token directly
+        if (refreshToken) {
+          const fallback = await fetch("https://oauth2.googleapis.com/revoke", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ token: accessToken }).toString(),
+            ...PROVIDER_FETCH_OPTS,
+          });
+          if (!fallback.ok) {
+            console.error(`Google access token revocation also failed: HTTP ${fallback.status}`);
+          }
+        }
       }
       break;
     }


### PR DESCRIPTION
## Summary

- Adds `revokeProviderToken()` to `src/utils/oauth.ts` — calls each provider's token revocation endpoint (GitHub DELETE, Google POST, Discord POST ×2)
- Updates `DELETE /providers/:provider` in `src/routes/auth/sessions.ts` to decrypt stored tokens and revoke them via `waitUntil()` after returning 204

Supersedes #78 (which was branched before Auth 1-6 landed on develop and reimplemented the entire OAuth system).

## Token revocation details

| Provider | Endpoint | Notes |
|----------|----------|-------|
| GitHub | `DELETE /applications/{client_id}/token` | Basic auth; 422 treated as success (already revoked) |
| Google | `POST /revoke` | Token sent in POST body; prefers refresh token (cascades to access token) |
| Discord | `POST /oauth2/token/revoke` | Parallel calls for access + refresh tokens |

Edge cases handled:
- NULL encrypted tokens → skip silently
- Decryption failure (rotated key) → log and continue
- Provider API error → log and continue (best-effort)
- Provider not linked (0 rows deleted) → no tokens to revoke

Closes #35

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Unlink a provider → response is still 204
- [ ] Worker logs show revocation attempt (or skip if no tokens)
- [ ] Revoked token no longer works on provider API

🤖 Generated with [Claude Code](https://claude.com/claude-code)