### PR TITLE
feat: gate PendingLink creation on email_verified (issue #39)

### DIFF
--- a/specs/064-email-verified-pendinglink/checklists/requirements.md
+++ b/specs/064-email-verified-pendinglink/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Verify Existing User Email Before Creating PendingLink
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions section documents the backfill rationale and scope boundary (no out-of-band email verification).

--- a/specs/064-email-verified-pendinglink/contracts/openapi-diff.md
+++ b/specs/064-email-verified-pendinglink/contracts/openapi-diff.md
@@ -1,0 +1,34 @@
+# OpenAPI Contract Change: email_verified on User
+
+**Date**: 2026-03-13 | **Branch**: `064-email-verified-pendinglink`
+
+## Change
+
+Add `email_verified` boolean field to the `User` schema component in `schemas/openapi.yaml`.
+
+## Affected Endpoints
+
+All endpoints that return a User object:
+
+| Endpoint | Method | Response field |
+|----------|--------|---------------|
+| `/auth/{provider}/callback` | GET | `data.user.email_verified` |
+| `/auth/link/approve/{pending_link_id}` | POST | `data.user.email_verified` |
+| `/auth/session` | GET | `data.user.email_verified` |
+
+## Schema Diff
+
+```yaml
+# In components.schemas.User.properties, add:
+email_verified:
+  type: boolean
+  description: Whether the user's email address has been verified through a trusted source.
+  example: true
+
+# Add to required list if User has one, otherwise it has a default (false)
+```
+
+## Compatibility
+
+- **Additive change**: New field added to existing response. Existing clients that don't read `email_verified` are unaffected.
+- **No breaking changes**: No fields removed, renamed, or type-changed.

--- a/specs/064-email-verified-pendinglink/data-model.md
+++ b/specs/064-email-verified-pendinglink/data-model.md
@@ -1,0 +1,120 @@
+# Data Model: Verify Existing User Email Before Creating PendingLink
+
+**Date**: 2026-03-13 | **Branch**: `064-email-verified-pendinglink`
+
+## Schema Changes
+
+### users table
+
+**New column**:
+
+| Column | Type | Default | Nullable | Description |
+|--------|------|---------|----------|-------------|
+| email_verified | INTEGER | 0 | NOT NULL | Account-level email verification status (0 = unverified, 1 = verified) |
+
+**Migration SQL**:
+
+```sql
+-- Step 1: Add column with default
+ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0;
+
+-- Step 2: Backfill from oauth_accounts
+UPDATE users SET email_verified = 1
+WHERE id IN (
+  SELECT DISTINCT user_id FROM oauth_accounts WHERE email_verified = 1
+);
+```
+
+**Validation rules**:
+- Value must be 0 or 1 (enforced by application logic; SQLite has no native boolean type)
+- Set to 1 when: user created via OAuth with verified email, or PendingLink approved with verified email
+- Reset to 0 when: user changes email address (future feature)
+- Never downgraded from 1 to 0 by provider status changes (high-water mark)
+
+### pending_links table
+
+No schema changes. PendingLink creation is now gated on `users.email_verified` at the application level.
+
+### oauth_accounts table
+
+No schema changes. Existing `email_verified` column continues to track per-provider verification status independently.
+
+## Entity Relationships
+
+```text
+users (1) ──── (N) oauth_accounts
+  │                    │
+  │ email_verified     │ email_verified
+  │ (account-level)    │ (provider-level)
+  │                    │
+  └──── (N) pending_links
+              │
+              │ email_verified
+              │ (snapshot from provider at creation time)
+```
+
+**Key distinction**:
+- `users.email_verified`: Account-level flag. Used to gate PendingLink creation.
+- `oauth_accounts.email_verified`: Per-provider flag. Records what the provider reported.
+- `pending_links.email_verified`: Snapshot of provider status at PendingLink creation time.
+
+## State Transitions for users.email_verified
+
+```text
+[Account Created]
+       │
+       ├─ Via OAuth (verified email) ──→ email_verified = 1
+       │
+       └─ Via future manual registration ──→ email_verified = 0
+                                                    │
+                                                    ├─ Verify email (future) ──→ 1
+                                                    │
+                                                    └─ OAuth login matches email
+                                                         │
+                                                         └─ email cleared to NULL
+                                                            (new user gets the email)
+
+[PendingLink Approved]
+       │
+       └─ Provider email verified ──→ email_verified = 1 (if not already)
+```
+
+## Affected Queries
+
+### login.ts — Email match (modified)
+
+```sql
+-- Before:
+SELECT id FROM users WHERE email = ?
+
+-- After:
+SELECT id, email_verified FROM users WHERE email = ?
+```
+
+### login.ts — Clear unverified user's email (new)
+
+```sql
+-- Batched with new user creation for atomicity
+UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?
+```
+
+**Security logging** (FR-008, FR-009): Log before executing the batch:
+- `console.error("Security: skipping PendingLink — existing user {id} email unverified for provider {provider}")`
+- `console.error("Security: clearing unverified email {email} from user {id}")`
+
+### login.ts — New user creation (modified)
+
+```sql
+-- Existing INSERT gains email_verified column:
+INSERT INTO users (id, username, email, email_verified, api_key_hash, created_at, modified_at)
+VALUES (?, ?, ?, 1, ?, datetime('now'), datetime('now'))
+```
+
+**Batching note**: The email cleanup UPDATE should be prepended to the existing `db.batch()` that creates the new user + oauth_account, ensuring atomicity.
+
+### link.ts — PendingLink approval (modified)
+
+```sql
+-- Add to existing db.batch():
+UPDATE users SET email_verified = 1, modified_at = datetime('now') WHERE id = ? AND email_verified = 0
+```

--- a/specs/064-email-verified-pendinglink/plan.md
+++ b/specs/064-email-verified-pendinglink/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Verify Existing User Email Before Creating PendingLink
+
+**Branch**: `064-email-verified-pendinglink` | **Date**: 2026-03-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/064-email-verified-pendinglink/spec.md`
+
+## Summary
+
+Add an `email_verified` column to the `users` table to track account-level email verification status. Gate PendingLink creation on the existing user having `email_verified = true`. When the existing user's email is unverified, clear their email to NULL and create a new user with the verified email instead. Backfill existing users from `oauth_accounts.email_verified`. Log security events for skipped PendingLinks and cleared emails.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7, openapi-typescript (code generation)
+**Storage**: Cloudflare D1 (SQLite)
+**Testing**: `npx tsc --noEmit`, manual testing against D1
+**Target Platform**: Cloudflare Workers (edge)
+**Project Type**: web-service
+**Performance Goals**: 10ms CPU per request (Workers free tier)
+**Constraints**: D1 SQLite, no Node.js APIs, Web Crypto API only
+**Scale/Scope**: Single-user mode (`INSTANCE_MODE=single`)
+
+## Security Literature Validation
+
+Findings from internet research (see [research.md](./research.md) R0):
+
+| Threat | Source | Our Mitigation | Status |
+|--------|--------|---------------|--------|
+| Classic-Federated Merge Attack | Microsoft MSRC (USENIX 2022) | PendingLink requires manual approval + email_verified gate | MITIGATED |
+| Google OAuth domain takeover | Truffle Security (Jan 2025) | Primary matching uses provider_user_id (sub), not email. Email is a hint only. | MITIGATED |
+| Email spoofing via OAuth | RFC 9700 (Jan 2025) | PKCE enforced, redirect URI validated, email_verified check added | MITIGATED |
+| Pre-hijacking detection | Microsoft MSRC (2022) | Security event logging for skipped PendingLinks and cleared emails (FR-008, FR-009) | ADDED |
+
+**Future consideration** (not in scope): If manual registration is added, clearing an unverified user's email should also invalidate their active sessions to prevent continued attacker access.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI spec update required first (new `email_verified` field on User response). Commit order: spec → generate → implement. |
+| II. Cloudflare-Native | PASS | D1 migration via `ALTER TABLE ADD COLUMN`. Backfill is a single UPDATE. Email cleanup batched with user creation. |
+| III. Type Safety | PASS | Generated types will include `email_verified` after spec update + `npm run generate`. |
+| IV. Legal | PASS | No WakaTime references. |
+| V. Simplicity First | PASS | Minimal change: one column, one conditional branch, one backfill query, two log statements. No new abstractions. |
+
+**Post-design re-check**: All gates still PASS. Security logging (FR-008, FR-009) uses existing `console.error` — no new dependencies or abstractions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/064-email-verified-pendinglink/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+schemas/
+└── openapi.yaml                    # Add email_verified to User schema
+
+src/
+├── db/
+│   └── schema.sql                  # Add email_verified column to users table
+├── routes/auth/
+│   ├── login.ts                    # Gate PendingLink on email_verified; set on new user creation; security logging
+│   └── link.ts                     # Set email_verified on PendingLink approval
+├── types/
+│   └── generated.ts                # Regenerated (not hand-edited)
+└── utils/
+    └── user.ts                     # Add email_verified to UserRow / rowToUser if needed
+```
+
+**Structure Decision**: Existing single-project structure. Changes are scoped to auth routes, schema, and the OpenAPI spec. No new files or directories needed.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity justification needed.

--- a/specs/064-email-verified-pendinglink/quickstart.md
+++ b/specs/064-email-verified-pendinglink/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Verify Existing User Email Before Creating PendingLink
+
+**Branch**: `064-email-verified-pendinglink`
+
+## Prerequisites
+
+- Node.js, npm installed
+- Cloudflare Wrangler CLI configured
+- Access to D1 database (local or remote)
+
+## Implementation Order (SDD workflow)
+
+### PR1: Spec + Schema
+
+1. **Update OpenAPI spec** — Add `email_verified` to User schema in `schemas/openapi.yaml`
+2. **Regenerate types** — `npm run generate`
+3. **Update DB schema** — Add `email_verified` column to `users` in `src/db/schema.sql`
+4. **Write migration** — Create migration SQL for existing databases
+
+### PR2: Implementation
+
+5. **Update user utility** — Add `email_verified` to `UserRow` type and `rowToUser()` in `src/utils/user.ts`
+6. **Modify login flow** — In `src/routes/auth/login.ts`:
+   - Fetch `email_verified` in email match query
+   - If unverified: clear existing user's email, fall through to new user creation
+   - Set `email_verified = 1` when creating new user with verified email
+7. **Modify link approval** — In `src/routes/auth/link.ts`:
+   - Set `email_verified = 1` on existing user when PendingLink is approved with verified provider email
+8. **Type check** — `npx tsc --noEmit`
+
+## Verification
+
+```bash
+# Type check
+npx tsc --noEmit
+
+# Local dev server
+npx wrangler dev
+
+# Run migration on local D1
+npx wrangler d1 execute cloudtime-db --local --file=migrations/XXXX_add_email_verified.sql
+```
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `schemas/openapi.yaml` | Add `email_verified` to User schema |
+| `src/types/generated.ts` | Regenerated (not hand-edited) |
+| `src/db/schema.sql` | Add column to CREATE TABLE |
+| `src/routes/auth/login.ts` | Gate PendingLink + set on creation |
+| `src/routes/auth/link.ts` | Set on PendingLink approval |
+| `src/utils/user.ts` | Add to UserRow + rowToUser |

--- a/specs/064-email-verified-pendinglink/research.md
+++ b/specs/064-email-verified-pendinglink/research.md
@@ -1,0 +1,84 @@
+# Research: Verify Existing User Email Before Creating PendingLink
+
+**Date**: 2026-03-13 | **Branch**: `064-email-verified-pendinglink`
+
+## R0: Security Literature Review
+
+**Sources reviewed**:
+- Microsoft MSRC "Pre-hijacking Attacks on Web User Accounts" (USENIX Security 2022)
+- Truffle Security "Google OAuth is Broken (Sort Of)" (Jan 2025)
+- RFC 9700 "Best Current Practice for OAuth 2.0 Security" (Jan 2025)
+- OWASP Authentication Cheat Sheet & OAuth2 Cheat Sheet
+- Google OAuth Account Linking documentation (updated Jan 2025)
+
+### Key findings
+
+**1. Classic-Federated Merge Attack (Microsoft, 2022)**:
+An attacker creates an account with the victim's email via a classic (password) route. When the victim later signs up via OAuth with the same email, the service merges the accounts — giving the attacker access. Microsoft found 35 of 75 major services vulnerable. Recommended mitigations:
+- Verify email addresses upon account creation
+- Never auto-merge accounts; require approval from both account holders
+- Check that the user currently controls both accounts before merging
+
+**Our plan's alignment**: CloudTime already requires manual PendingLink approval (not auto-merge). Adding `email_verified` gating is an additional defense-in-depth layer. **PASS**.
+
+**2. Google OAuth domain takeover (Truffle Security, 2025)**:
+Anyone can buy a failed startup's domain, re-create employee email accounts, and use them to OAuth-sign-in to third-party services. Google's `sub` claim is the only stable identifier, but it changes in ~0.04% of logins. Google now recommends: "Always use the `sub` field as it is unique to a Google Account, not the `email` field."
+
+**Our plan's alignment**: CloudTime uses `provider_user_id` (sub) for primary OAuth matching. Email is only used as a secondary hint for PendingLink suggestions, which require manual approval. **PASS**.
+
+**3. RFC 9700 (IETF, 2025)**:
+Mandates PKCE for all client types, exact redirect URI matching, one-time authorization codes. Does not directly address account linking, but emphasizes defense-in-depth and minimizing implicit trust in email claims.
+
+**Our plan's alignment**: PKCE and redirect URI validation already implemented. Plan adds email trust gating. **PASS**.
+
+### Gaps identified from literature review
+
+**Gap 1 — Security audit logging**: Microsoft's research emphasizes logging pre-hijacking attempts for detection. The current plan does not explicitly require logging when a PendingLink is skipped due to unverified email or when an unverified user's email is cleared. **Recommendation**: Add `console.error` logging for both security events to aid in incident investigation.
+
+**Gap 2 — Session invalidation on email clear**: When clearing an unverified user's email (Option B), the unverified user's active sessions remain valid. In the current system this is low risk (all users are OAuth-created with verified emails), but if manual registration is added in the future, this could allow an attacker to maintain access after losing their email claim. **Recommendation**: Document as a future consideration, not a current blocker (no manual registration exists yet).
+
+## R1: D1 Schema Migration Strategy
+
+**Decision**: Use `ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0` followed by a backfill UPDATE.
+
+**Rationale**: D1 (SQLite) supports `ALTER TABLE ADD COLUMN` with a DEFAULT value. SQLite stores the default in the table schema definition and applies it lazily — this is a non-blocking operation even with existing rows. The backfill UPDATE sets `email_verified = 1` for users with verified OAuth accounts. Confirmed via Cloudflare community docs and D1 SQL statements reference.
+
+**Alternatives considered**:
+- Recreate table with new schema (DROP + CREATE + INSERT): Unnecessary complexity; ALTER TABLE works for adding a column with default.
+- Application-level default (NULL column + COALESCE): Adds runtime overhead on every query; better to set the default at the schema level.
+
+## R2: Email Match Query Modification
+
+**Decision**: Modify the email match query in `login.ts` (line 167) from `SELECT id FROM users WHERE email = ?` to `SELECT id, email_verified FROM users WHERE email = ?`, then branch on `email_verified`.
+
+**Rationale**: Fetching `email_verified` in the same query avoids a second round-trip. The branching logic is straightforward: if `email_verified = true`, proceed with PendingLink creation (existing flow); if `false`, clear the existing user's email and fall through to new user creation.
+
+**Alternatives considered**:
+- Add `AND email_verified = 1` to the WHERE clause: This would silently skip the match when unverified, but we need to actively clear the existing user's email (per clarification). A simple WHERE filter wouldn't trigger the email cleanup.
+
+## R3: Email Cleanup for Unverified Users
+
+**Decision**: When the existing user has `email_verified = false`, execute `UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?` before falling through to new user creation. Log this as a security event.
+
+**Rationale**: This resolves the UNIQUE constraint collision (per clarification session). The unverified user loses their email claim, and the new OAuth user gets the verified email. The UPDATE is a single D1 statement with negligible cost. Per the Microsoft pre-hijacking research, this action should be logged for security auditing.
+
+**Alternatives considered**:
+- Batch the UPDATE with the new user INSERT via `db.batch()`: Recommended approach — add the UPDATE to the existing batch (INSERT user + INSERT oauth_account) for atomicity.
+
+## R4: PendingLink Approval — Setting email_verified
+
+**Decision**: In `link.ts`, after the PendingLink is approved (batch INSERT into oauth_accounts + DELETE pending_link), add an UPDATE to set `users.email_verified = 1` if the pending link's `email_verified = 1`.
+
+**Rationale**: When a user approves a PendingLink from a provider with a verified email, the user's account-level email should be marked as verified (high-water mark behavior). This can be added to the existing `db.batch()` call.
+
+**Alternatives considered**:
+- Only set email_verified during user creation: Misses the case where an existing user gains verification through a newly linked provider.
+
+## R5: OpenAPI Spec Change Scope
+
+**Decision**: Add `email_verified` (boolean) to the User schema in `schemas/openapi.yaml`. This field appears in the GET /session response (user object).
+
+**Rationale**: The field should be visible to the frontend so it can display verification status. Per SDD, the spec must be updated first, then types regenerated, then implementation committed.
+
+**Alternatives considered**:
+- Internal-only field (not exposed via API): Reduces transparency; the frontend may need to display verification badges or warnings in the future.

--- a/specs/064-email-verified-pendinglink/spec.md
+++ b/specs/064-email-verified-pendinglink/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Verify Existing User Email Before Creating PendingLink
+
+**Feature Branch**: `064-email-verified-pendinglink`
+**Created**: 2026-03-13
+**Status**: Draft
+**Input**: Issue #39 — Harden PendingLink creation by requiring the existing user's email to be verified before offering account linking.
+
+## Clarifications
+
+### Session 2026-03-13
+
+- Q: When PendingLink is skipped due to unverified existing user email and a new user is created, how should the email UNIQUE constraint collision be handled? → A: Create the new user with the email, and clear the unverified existing user's email to NULL.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - PendingLink blocked when existing user email is unverified (Priority: P1)
+
+A user signs in via OAuth with a verified provider email that matches an existing user account. If the existing user's email was never verified (e.g., the account was created through a future manual registration flow), the system must NOT create a PendingLink. This prevents an attacker from claiming an unverified email and then having a legitimate OAuth user prompted to link into the attacker's account.
+
+**Why this priority**: This is the core security fix. Without it, an attacker who registers with an unverified email can trick a legitimate user into linking their OAuth identity to the attacker's account.
+
+**Independent Test**: Create a user with an unverified email, then attempt OAuth login with a provider-verified email matching that address. The system should skip PendingLink creation and instead create a new, separate user account.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user with `email_verified = false` and email "alice@example.com", **When** a new OAuth login arrives with provider-verified email "alice@example.com", **Then** no PendingLink is created, the existing user's email is set to NULL, and a new user account is created with email "alice@example.com".
+2. **Given** an existing user with `email_verified = false`, **When** the email match check runs, **Then** the system clears the existing user's email and falls through to new account creation with the verified email.
+
+---
+
+### User Story 2 - PendingLink created when existing user email IS verified (Priority: P1)
+
+When the existing user's email has been verified (either through OAuth-based verification at account creation or through a future email verification flow), the PendingLink creation should proceed as it does today. This preserves the current account-linking experience for legitimate users.
+
+**Why this priority**: Equal priority with Story 1 — together they define the complete behavior change.
+
+**Independent Test**: Create a user via OAuth with a verified email, then attempt login with a different OAuth provider using the same verified email. The system should create a PendingLink as it does today.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user with `email_verified = true` and email "bob@example.com", **When** a new OAuth login arrives with provider-verified email "bob@example.com", **Then** a PendingLink is created and the user is prompted to approve the link.
+2. **Given** an existing user created via OAuth with a verified provider email, **Then** the user's `email_verified` column is `true`.
+
+---
+
+### User Story 3 - Email verification status set on user creation (Priority: P1)
+
+When a new user account is created via OAuth login with a provider-verified email, the system must record `email_verified = true` on the users table. This ensures that users created through OAuth have their verification status properly tracked at the account level, not just at the provider level.
+
+**Why this priority**: Without this, the check in Story 1 has no verified users to match against — existing OAuth-created users would all have `email_verified = false`.
+
+**Independent Test**: Create a new account via OAuth with a verified email, then query the users table and confirm `email_verified = true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new OAuth login with `emailVerified = true` from the provider, **When** a new user account is created, **Then** `users.email_verified` is set to `true`.
+2. **Given** a new OAuth login with `emailVerified = false` (blocked earlier in the flow), **Then** the request is rejected before user creation (existing behavior).
+
+---
+
+### User Story 4 - Backfill email verification for existing users (Priority: P2)
+
+Existing user accounts created before this change have no `email_verified` value. Since all current users were created via OAuth with verified emails (the system currently rejects unverified emails at login), the migration should default `email_verified` to `true` for users who have at least one OAuth account with `email_verified = 1`.
+
+**Why this priority**: Important for correctness but lower priority because it's a one-time migration concern. Without the backfill, existing users would lose PendingLink functionality until they re-authenticate.
+
+**Independent Test**: Run the migration on a database with existing users, then verify that users with verified OAuth accounts have `email_verified = true`, and any users without verified OAuth accounts have `email_verified = false`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user with an OAuth account where `oauth_accounts.email_verified = 1`, **When** the migration runs, **Then** `users.email_verified` is set to `true`.
+2. **Given** an existing user with no OAuth accounts (hypothetical), **When** the migration runs, **Then** `users.email_verified` defaults to `false`.
+
+---
+
+### Edge Cases
+
+- What happens when a user has multiple OAuth accounts with conflicting email verification states? The user-level `email_verified` should be `true` if ANY linked provider has verified the email.
+- What happens when an OAuth provider's email verification status changes after account creation? The user-level `email_verified` is set at creation time and during provider linking; it is not retroactively downgraded.
+- What happens when a user changes their email address in a future profile-edit feature? The `email_verified` flag should be reset to `false` until the new email is verified.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST add an `email_verified` attribute (default `false`) to the user account.
+- **FR-002**: System MUST set `email_verified = true` on the user account when creating a new user via OAuth with a provider-verified email.
+- **FR-003**: System MUST check that the existing user's `email_verified` is `true` before creating a PendingLink during OAuth email matching.
+- **FR-004**: If the existing user's email is not verified, the system MUST skip PendingLink creation and clear the unverified existing user's email to NULL. In multi-user mode, a new user account is created with the provider-verified email. In single-user mode, the email cleanup still occurs but new user creation is subject to the existing single-user guard (max one user).
+- **FR-005**: System MUST include a data migration that backfills `email_verified = true` for existing users who have at least one linked provider with a verified email.
+- **FR-006**: System MUST set `email_verified = true` on the existing user when a PendingLink is approved and the linked provider has a verified email.
+- **FR-007**: The PendingLink approval flow MUST continue to work unchanged for users whose email is already verified. (Regression guard — verified by ensuring T010 only updates when `email_verified = 0`; add explicit regression test if test suite is introduced.)
+- **FR-008**: System MUST log a security event when PendingLink creation is skipped due to unverified email (including the existing user ID and provider).
+- **FR-009**: System MUST log a security event when an unverified user's email is cleared to NULL (including the affected user ID and the email that was cleared).
+
+### Key Entities
+
+- **User**: Gains a new `email_verified` attribute indicating whether the account-level email has been verified through any trusted source (OAuth provider with verified email).
+- **PendingLink**: No change. Creation is now gated on the existing user's `email_verified` status.
+
+## Assumptions
+
+- All current users in the system were created via OAuth with verified provider emails (the system rejects unverified emails at login). Therefore, the migration can safely backfill `email_verified = true` for users with verified OAuth accounts.
+- Out-of-band email verification (e.g., sending a verification email) is out of scope for this issue. The scope focuses on tracking verification status from OAuth providers. A future manual registration flow would need its own email verification mechanism.
+- The `email_verified` flag on the user account is a "high-water mark" — once set to `true`, it is not downgraded if a provider later reports the email as unverified. It can only be reset if the user changes their email address (future feature).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: No PendingLink is ever created when the target user's email is unverified — 100% enforcement of the verification check.
+- **SC-002**: All existing users with verified OAuth accounts retain full PendingLink functionality after migration (zero regression).
+- **SC-003**: New users created via OAuth with verified emails are immediately eligible for PendingLink matching (`email_verified = true` from creation).
+- **SC-004**: The account-linking flow completes with no additional user-facing steps compared to today (no UX regression for verified users).

--- a/specs/064-email-verified-pendinglink/tasks.md
+++ b/specs/064-email-verified-pendinglink/tasks.md
@@ -1,0 +1,158 @@
+# Tasks: Verify Existing User Email Before Creating PendingLink
+
+**Input**: Design documents from `/specs/064-email-verified-pendinglink/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested. Test tasks omitted.
+
+**Organization**: Tasks follow SDD 2-PR workflow (PR1: Spec+Schema, PR2: Implementation) and are grouped by user story within each PR.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup — Spec + Schema (PR1)
+
+**Purpose**: Update OpenAPI spec, regenerate types, update DB schema, and create migration file. Per SDD, spec changes must be committed before implementation.
+
+- [x] T001 Add `email_verified` boolean property to User schema component in `schemas/openapi.yaml` — add to properties with `type: boolean`, `description`, and `example: true`; add to required list if one exists
+- [x] T002 Run `npm run generate` to regenerate `src/types/generated.ts` — verify `email_verified` appears in the generated User type
+- [x] T003 [P] Add `email_verified INTEGER NOT NULL DEFAULT 0` column to `users` CREATE TABLE statement in `src/db/schema.sql`
+- [x] T004 [P] [US4] Create D1 migration file `migrations/XXXX_add_email_verified.sql` with `ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0` followed by backfill `UPDATE users SET email_verified = 1 WHERE id IN (SELECT DISTINCT user_id FROM oauth_accounts WHERE email_verified = 1)`
+
+**Checkpoint**: PR1 ready — spec, types, schema, and migration complete. Commit and merge before PR2.
+
+---
+
+## Phase 2: Foundational — User Type Mapping (PR2)
+
+**Purpose**: Update the shared user utility to include `email_verified` before modifying any route handlers.
+
+**CRITICAL**: Must complete before any user story implementation.
+
+- [x] T005 Add `email_verified` field to `UserRow` type and `rowToUser()` mapping function in `src/utils/user.ts` — ensure it maps `INTEGER` (0/1) to `boolean` for API responses
+
+**Checkpoint**: Foundation ready — UserRow type includes email_verified. Route handler work can begin.
+
+---
+
+## Phase 3: User Stories 1, 2, 3 — Login Flow Email Verified Gating (Priority: P1) MVP
+
+**Goal**: Gate PendingLink creation on `email_verified`, clear unverified emails, and set `email_verified = 1` on new OAuth user creation. These three stories are implemented together because they share the same code path in `login.ts`.
+
+**Independent Test**: Create a user with unverified email → OAuth login with same email → verify no PendingLink created, old user email cleared, new user created with email. Then: create a user via OAuth (verified) → second OAuth login with same email → verify PendingLink IS created.
+
+### Implementation
+
+- [x] T006 [P] [US3] Modify new user creation INSERT statements (both single-user and multi-user paths) to include `email_verified` column with value `1` in `src/routes/auth/login.ts` (lines ~272 and ~305)
+- [x] T007 [US1] [US2] Modify email match query from `SELECT id FROM users WHERE email = ?` to `SELECT id, email_verified FROM users WHERE email = ?` in `src/routes/auth/login.ts` (line ~167) — add conditional branch: if `email_verified = 1` proceed to PendingLink (existing flow); if `email_verified = 0` fall through to email cleanup + new user creation
+- [x] T008 [US1] Implement email cleanup for unverified users in `src/routes/auth/login.ts` — when `email_verified = 0`: prepend `UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?` to the `db.batch()` that creates the new user + oauth_account, ensuring atomicity. Note: in single-user mode the existing guard (`WHERE (SELECT COUNT(*) FROM users) = 0`) will block the new user INSERT — the email cleanup still runs but user creation is subject to the single-user limit
+- [x] T009 [US1] Add security event logging in `src/routes/auth/login.ts` — log `console.error("Security: skipping PendingLink — existing user {id} email unverified for provider {provider}")` (FR-008) and `console.error("Security: clearing unverified email {email} from user {id}")` (FR-009) before executing the batch
+
+**Checkpoint**: Core security fix complete. PendingLink gated on email_verified, unverified emails cleared, new users get email_verified = 1. Stories 1, 2, 3 independently testable.
+
+---
+
+## Phase 4: FR-006 — PendingLink Approval Sets email_verified
+
+**Goal**: When a PendingLink is approved and the linked provider has a verified email, set `email_verified = 1` on the existing user.
+
+**Independent Test**: Approve a PendingLink from a provider with verified email → verify `users.email_verified` is now `1`.
+
+### Implementation
+
+- [x] T010 [P] [US2] Add `UPDATE users SET email_verified = 1, modified_at = datetime('now') WHERE id = ? AND email_verified = 0` to the existing `db.batch()` in the PendingLink approval handler in `src/routes/auth/link.ts` (line ~92) — only when `pending_link.email_verified = 1`
+
+**Checkpoint**: PendingLink approval flow complete. Verified providers propagate email_verified to user account.
+
+---
+
+## Phase 5: Polish & Validation
+
+**Purpose**: Type safety validation and final verification.
+
+- [x] T011 Run `npx tsc --noEmit` to validate all changes compile without type errors
+- [x] T012 Verify all User-returning endpoints (`/auth/session`, `/auth/{provider}/callback`, `/auth/link/approve/{id}`) include `email_verified` in response per `contracts/openapi-diff.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (T002 must complete for generated types)
+- **Phase 3 (US1+US2+US3)**: Depends on Phase 2 (T005 must complete for UserRow type)
+- **Phase 4 (FR-006)**: Depends on Phase 2 (T005). Can run in parallel with Phase 3 (different file: link.ts vs login.ts)
+- **Phase 5 (Polish)**: Depends on Phases 3 and 4 completion
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on foundational T005. Implemented in T007, T008, T009.
+- **US2 (P1)**: Depends on foundational T005. Implemented in T007 (same conditional branch as US1) and T010 (link.ts).
+- **US3 (P1)**: Depends on foundational T005. Implemented in T006. No dependency on US1/US2.
+- **US4 (P2)**: No code dependency. Migration file T004 is independent (created in Phase 1).
+
+### Within Phase 3
+
+- T006 (US3) can start independently — modifies user creation INSERT
+- T007 (US1+US2) must complete before T008 — T007 adds the conditional branch, T008 adds cleanup logic within that branch
+- T009 depends on T008 — logging goes alongside the cleanup logic
+
+### Parallel Opportunities
+
+```text
+Phase 1: T003 [P] and T004 [P] can run in parallel (different files)
+Phase 3+4: T006 [US3] and T010 [US2] can run in parallel (login.ts vs link.ts)
+```
+
+---
+
+## Parallel Example: Phase 3 + Phase 4
+
+```bash
+# These can run in parallel (different files):
+Task T006: "Modify user creation INSERT in src/routes/auth/login.ts"
+Task T010: "Add email_verified UPDATE to PendingLink approval in src/routes/auth/link.ts"
+
+# These must be sequential (same file, same function):
+Task T007 → Task T008 → Task T009 (all in login.ts email match flow)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 1 + 2 + 3)
+
+1. Complete Phase 1: Spec + Schema (PR1)
+2. Complete Phase 2: User type mapping
+3. Complete Phase 3: Login flow gating (US1+US2+US3)
+4. **STOP and VALIDATE**: Type check + manual test
+5. This alone delivers the core security fix (SC-001, SC-003)
+
+### Full Delivery (add Phase 4 + 5)
+
+6. Complete Phase 4: PendingLink approval sets email_verified (FR-006)
+7. Complete Phase 5: Final validation
+8. All success criteria met (SC-001 through SC-004)
+
+### PR Structure (SDD 2-PR Workflow)
+
+- **PR1**: T001, T002, T003, T004 (Spec + Schema + Migration)
+- **PR2**: T005, T006, T007, T008, T009, T010, T011, T012 (Implementation)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1/US2/US3 are tightly coupled in login.ts — implemented together in Phase 3
+- US4 is covered by the migration file in T004 (Phase 1)
+- Commit after each task or logical group
+- Per constitution: spec changes (PR1) must merge before implementation (PR2)

--- a/src/routes/auth/link.ts
+++ b/src/routes/auth/link.ts
@@ -88,8 +88,8 @@ link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
 
     const oauthId = crypto.randomUUID();
 
-    // Create oauth_account + delete pending_link in batch
-    await c.env.DB.batch([
+    // Create oauth_account + delete pending_link + optionally set email_verified
+    const batchStmts = [
       c.env.DB.prepare(
         `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -113,7 +113,18 @@ link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
         pending.token_expires_at,
       ),
       c.env.DB.prepare("DELETE FROM pending_links WHERE id = ?").bind(pendingLinkId),
-    ]);
+    ];
+
+    // FR-006: Propagate email_verified from approved provider to user account
+    if (pending.email_verified === 1) {
+      batchStmts.push(
+        c.env.DB.prepare(
+          `UPDATE users SET email_verified = 1, modified_at = datetime('now') WHERE id = ? AND email_verified = 0`,
+        ).bind(userId),
+      );
+    }
+
+    await c.env.DB.batch(batchStmts);
 
     const userRow = await c.env.DB.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`)
       .bind(userId)

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -133,7 +133,7 @@ login.get("/:provider/callback", async (c) => {
         .bind(
           userInfo.providerUsername,
           userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
+          1, // emailVerified guaranteed true by gate at line 108
           accessTokenEnc,
           refreshTokenEnc,
           userInfo.tokenExpiresAt,
@@ -249,10 +249,7 @@ login.get("/:provider/callback", async (c) => {
           );
         } else {
           // Existing user's email is NOT verified — skip PendingLink, clear email, fall through to new user creation
-          // FR-008: Security event — PendingLink skipped
-          console.error(`Security: skipping PendingLink — existing user ${emailMatch.id} email unverified for provider ${provider}`);
-          // FR-009: Security event — clearing unverified email
-          console.error(`Security: clearing unverified email ${userInfo.providerEmail} from user ${emailMatch.id}`);
+          // FR-008/FR-009: logged after batch succeeds (see below)
           unverifiedUserId = emailMatch.id;
         }
       }
@@ -287,13 +284,6 @@ login.get("/:provider/callback", async (c) => {
 
     const oauthAccountId = crypto.randomUUID();
 
-    // Email cleanup statement for unverified users (prepended to batch for atomicity)
-    const emailCleanupStmt = unverifiedUserId
-      ? c.env.DB.prepare(
-          `UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?`,
-        ).bind(unverifiedUserId)
-      : null;
-
     if (isSingleUser) {
       // Atomic: create user only if no users exist (prevents TOCTOU race)
       const batchResult = await c.env.DB.batch([
@@ -313,7 +303,7 @@ login.get("/:provider/callback", async (c) => {
           userInfo.providerUserId,
           userInfo.providerUsername,
           userInfo.providerEmail,
-          userInfo.emailVerified ? 1 : 0,
+          1, // emailVerified guaranteed true by gate at line 108
           accessTokenEnc,
           refreshTokenEnc,
           userInfo.tokenExpiresAt,
@@ -346,14 +336,25 @@ login.get("/:provider/callback", async (c) => {
             userInfo.providerUserId,
             userInfo.providerUsername,
             userInfo.providerEmail,
-            userInfo.emailVerified ? 1 : 0,
+            1, // emailVerified guaranteed true by gate at line 108
             accessTokenEnc,
             refreshTokenEnc,
             userInfo.tokenExpiresAt,
           ),
         ];
-        if (emailCleanupStmt) multiUserStmts.unshift(emailCleanupStmt);
+        // Email cleanup for unverified users (prepended to batch for atomicity)
+        if (unverifiedUserId) {
+          multiUserStmts.unshift(
+            c.env.DB.prepare(
+              `UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?`,
+            ).bind(unverifiedUserId),
+          );
+        }
         await c.env.DB.batch(multiUserStmts);
+        // FR-008/FR-009: Security events logged after successful batch
+        if (unverifiedUserId) {
+          console.error(`Security: skipped PendingLink and cleared email for user ${unverifiedUserId} — email unverified, provider ${provider}`);
+        }
       } catch (insertErr) {
         // UNIQUE constraint violation on email — concurrent signup with same email
         const msg = insertErr instanceof Error ? insertErr.message : "";

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -163,92 +163,114 @@ login.get("/:provider/callback", async (c) => {
     }
 
     // No existing OAuth link — check if email matches an existing user
+    let unverifiedUserId: string | null = null;
     if (userInfo.providerEmail) {
-      const emailMatch = await c.env.DB.prepare("SELECT id FROM users WHERE email = ?")
+      const emailMatch = await c.env.DB.prepare("SELECT id, email_verified FROM users WHERE email = ?")
         .bind(userInfo.providerEmail)
-        .first<{ id: string }>();
+        .first<{ id: string; email_verified: number }>();
 
       if (emailMatch) {
-        // Limit active pending links per user
-        const activeLinkCount = await c.env.DB.prepare(
-          "SELECT COUNT(*) as count FROM pending_links WHERE existing_user_id = ? AND expires_at > datetime('now')",
-        )
-          .bind(emailMatch.id)
-          .first<{ count: number }>();
-        if (activeLinkCount && activeLinkCount.count >= 3) {
-          return c.json({ error: "Too many pending link requests" }, 429, {
-            ...noCacheHeaders(),
-            "Retry-After": "3600",
-          });
-        }
-
-        // Encrypt tokens with AAD context
-        const encCtx = `${emailMatch.id}:${provider}`;
-        const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
-        const refreshTokenEnc = userInfo.refreshToken
-          ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
-          : null;
-
-        // Create pending link for manual approval
-        const pendingId = crypto.randomUUID();
-        const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
-          .toISOString()
-          .replace("T", " ")
-          .replace("Z", "");
-
-        const linkResult = await c.env.DB.prepare(
-          `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(existing_user_id, provider, provider_user_id) DO UPDATE SET
-             provider_username = excluded.provider_username,
-             provider_email = excluded.provider_email,
-             email_verified = excluded.email_verified,
-             access_token_encrypted = excluded.access_token_encrypted,
-             refresh_token_encrypted = excluded.refresh_token_encrypted,
-             token_expires_at = excluded.token_expires_at,
-             expires_at = excluded.expires_at
-           RETURNING id`,
-        )
-          .bind(
-            pendingId,
-            emailMatch.id,
-            provider,
-            userInfo.providerUserId,
-            userInfo.providerUsername,
-            userInfo.providerEmail,
-            userInfo.emailVerified ? 1 : 0,
-            accessTokenEnc,
-            refreshTokenEnc,
-            userInfo.tokenExpiresAt,
-            pendingExpiry,
+        if (emailMatch.email_verified === 1) {
+          // Existing user's email is verified — proceed with PendingLink creation
+          // Limit active pending links per user
+          const activeLinkCount = await c.env.DB.prepare(
+            "SELECT COUNT(*) as count FROM pending_links WHERE existing_user_id = ? AND expires_at > datetime('now')",
           )
-          .first<{ id: string }>();
+            .bind(emailMatch.id)
+            .first<{ count: number }>();
+          if (activeLinkCount && activeLinkCount.count >= 3) {
+            return c.json({ error: "Too many pending link requests" }, 429, {
+              ...noCacheHeaders(),
+              "Retry-After": "3600",
+            });
+          }
 
-        if (!linkResult) {
-          return c.json({ error: "Internal server error" }, 500, noCacheHeaders());
-        }
+          // Encrypt tokens with AAD context
+          const encCtx = `${emailMatch.id}:${provider}`;
+          const accessTokenEnc = await encryptToken(userInfo.accessToken, c.env.ENCRYPTION_KEY, encCtx);
+          const refreshTokenEnc = userInfo.refreshToken
+            ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
+            : null;
 
-        // Return minimal pending link info (no full user profile — unauthenticated response)
-        return c.json(
-          {
-            data: {
-              pending_link: {
-                id: linkResult.id,
-                provider: provider as OAuthProvider,
-                provider_username: userInfo.providerUsername,
-                provider_email: userInfo.providerEmail as string,
-                expires_at: normalizeDateTime(pendingExpiry),
+          // Create pending link for manual approval
+          const pendingId = crypto.randomUUID();
+          const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
+            .toISOString()
+            .replace("T", " ")
+            .replace("Z", "");
+
+          const linkResult = await c.env.DB.prepare(
+            `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(existing_user_id, provider, provider_user_id) DO UPDATE SET
+               provider_username = excluded.provider_username,
+               provider_email = excluded.provider_email,
+               email_verified = excluded.email_verified,
+               access_token_encrypted = excluded.access_token_encrypted,
+               refresh_token_encrypted = excluded.refresh_token_encrypted,
+               token_expires_at = excluded.token_expires_at,
+               expires_at = excluded.expires_at
+             RETURNING id`,
+          )
+            .bind(
+              pendingId,
+              emailMatch.id,
+              provider,
+              userInfo.providerUserId,
+              userInfo.providerUsername,
+              userInfo.providerEmail,
+              userInfo.emailVerified ? 1 : 0,
+              accessTokenEnc,
+              refreshTokenEnc,
+              userInfo.tokenExpiresAt,
+              pendingExpiry,
+            )
+            .first<{ id: string }>();
+
+          if (!linkResult) {
+            return c.json({ error: "Internal server error" }, 500, noCacheHeaders());
+          }
+
+          // Return minimal pending link info (no full user profile — unauthenticated response)
+          return c.json(
+            {
+              data: {
+                pending_link: {
+                  id: linkResult.id,
+                  provider: provider as OAuthProvider,
+                  provider_username: userInfo.providerUsername,
+                  provider_email: userInfo.providerEmail as string,
+                  expires_at: normalizeDateTime(pendingExpiry),
+                },
               },
             },
-          },
-          200,
-          noCacheHeaders(),
-        );
+            200,
+            noCacheHeaders(),
+          );
+        } else {
+          // Existing user's email is NOT verified — skip PendingLink, clear email, fall through to new user creation
+          // FR-008: Security event — PendingLink skipped
+          console.error(`Security: skipping PendingLink — existing user ${emailMatch.id} email unverified for provider ${provider}`);
+          // FR-009: Security event — clearing unverified email
+          console.error(`Security: clearing unverified email ${userInfo.providerEmail} from user ${emailMatch.id}`);
+          unverifiedUserId = emailMatch.id;
+        }
       }
     }
 
     // No existing account — new user creation
     const isSingleUser = c.env.INSTANCE_MODE !== "multi";
+
+    // Single-user guard: don't clear email if we can't create a new user to take it
+    if (isSingleUser && unverifiedUserId) {
+      console.error(`Security: skipping email cleanup in single-user mode — cannot create replacement user for ${unverifiedUserId}`);
+      return c.json(
+        { error: "Registration closed. This instance only allows one user." },
+        403,
+        noCacheHeaders(),
+      );
+    }
+
     const userId = crypto.randomUUID();
     const { hash: apiKeyHash } = await generateApiKey();
 
@@ -265,12 +287,19 @@ login.get("/:provider/callback", async (c) => {
 
     const oauthAccountId = crypto.randomUUID();
 
+    // Email cleanup statement for unverified users (prepended to batch for atomicity)
+    const emailCleanupStmt = unverifiedUserId
+      ? c.env.DB.prepare(
+          `UPDATE users SET email = NULL, modified_at = datetime('now') WHERE id = ?`,
+        ).bind(unverifiedUserId)
+      : null;
+
     if (isSingleUser) {
       // Atomic: create user only if no users exist (prevents TOCTOU race)
       const batchResult = await c.env.DB.batch([
         c.env.DB.prepare(
-          `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-           SELECT ?, ?, ?, ?, datetime('now'), datetime('now')
+          `INSERT INTO users (id, username, email, email_verified, api_key_hash, created_at, modified_at)
+           SELECT ?, ?, ?, 1, ?, datetime('now'), datetime('now')
            WHERE (SELECT COUNT(*) FROM users) = 0`,
         ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
         c.env.DB.prepare(
@@ -302,10 +331,10 @@ login.get("/:provider/callback", async (c) => {
     } else {
       // Multi-user mode: unconditional insert
       try {
-        await c.env.DB.batch([
+        const multiUserStmts = [
           c.env.DB.prepare(
-            `INSERT INTO users (id, username, email, api_key_hash, created_at, modified_at)
-             VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+            `INSERT INTO users (id, username, email, email_verified, api_key_hash, created_at, modified_at)
+             VALUES (?, ?, ?, 1, ?, datetime('now'), datetime('now'))`,
           ).bind(userId, username, userInfo.providerEmail, apiKeyHash),
           c.env.DB.prepare(
             `INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at)
@@ -322,7 +351,9 @@ login.get("/:provider/callback", async (c) => {
             refreshTokenEnc,
             userInfo.tokenExpiresAt,
           ),
-        ]);
+        ];
+        if (emailCleanupStmt) multiUserStmts.unshift(emailCleanupStmt);
+        await c.env.DB.batch(multiUserStmts);
       } catch (insertErr) {
         // UNIQUE constraint violation on email — concurrent signup with same email
         const msg = insertErr instanceof Error ? insertErr.message : "";

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -16,6 +16,7 @@ export type UserRow = {
   city: string | null;
   timezone: string;
   timeout: number;
+  email_verified: number;
   is_hireable: number;
   github_username: string | null;
   twitter_username: string | null;
@@ -24,7 +25,7 @@ export type UserRow = {
   modified_at: string;
 };
 
-export const USER_COLUMNS = `id, username, display_name, email, photo, bio, city, timezone, timeout, is_hireable, github_username, twitter_username, website, created_at, modified_at`;
+export const USER_COLUMNS = `id, username, display_name, email, email_verified, photo, bio, city, timezone, timeout, is_hireable, github_username, twitter_username, website, created_at, modified_at`;
 
 export function normalizeDateTime(dt: string): string {
   return dt.includes("T") ? dt : dt.replace(" ", "T") + "Z";
@@ -44,6 +45,7 @@ export function rowToUser(
     username: row.username,
     display_name: row.display_name ?? undefined,
     email: row.email ?? undefined,
+    email_verified: row.email_verified === 1,
     photo: row.photo ?? undefined,
     bio: row.bio ?? undefined,
     city: row.city ?? undefined,


### PR DESCRIPTION
## Summary

Implementation of the email_verified PendingLink gate (spec + schema were merged in PR #81).

- Gate PendingLink creation on `users.email_verified = 1` — unverified emails no longer trigger account linking prompts
- When an unverified email match is found in multi-user mode, clear the existing user's email to NULL and create a new user with the verified email (atomically via `db.batch()`)
- In single-user mode, early-return with 403 instead of clearing email (prevents data loss when new user creation would be blocked)
- Set `email_verified = 1` on new OAuth user creation and on PendingLink approval with a verified provider
- Add security event logging (FR-008, FR-009) for skipped PendingLinks and cleared emails — no PII in logs, logged only after successful batch
- Add SpecKit design artifacts (`specs/064-email-verified-pendinglink/`)

## Security Context

Mitigates the Classic-Federated Merge Attack (Microsoft MSRC, USENIX 2022) where an attacker registers with an unverified email matching a future OAuth user's address, then tricks the legitimate user into linking to the attacker's account.

## Changed Files

| File | Change |
|------|--------|
| `src/utils/user.ts` | Add `email_verified` to UserRow, USER_COLUMNS, rowToUser() |
| `src/routes/auth/login.ts` | Email match gating, email cleanup, single-user guard, security logging (no PII) |
| `src/routes/auth/link.ts` | Propagate email_verified on PendingLink approval |
| `specs/064-email-verified-pendinglink/` | SpecKit design artifacts (spec, plan, research, data-model, tasks) |

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Create user with unverified email → OAuth login with same verified email → no PendingLink created, old email cleared, new user created (multi-user mode)
- [ ] Single-user mode with unverified email match → 403 returned, existing user email NOT cleared
- [ ] Create user via OAuth (verified) → second OAuth login with same email → PendingLink IS created
- [ ] Approve PendingLink from verified provider → user's `email_verified` set to 1
- [ ] All User-returning endpoints include `email_verified` in response
- [ ] Security logs contain no PII (only user IDs and provider names)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)