### PR TITLE
feat: timezone-aware defaults for authenticated endpoints

### DIFF
--- a/docs/timezone-behavior.md
+++ b/docs/timezone-behavior.md
@@ -1,0 +1,38 @@
+# Timezone Behavior
+
+This document describes how CloudTime handles timezones for summary bucketing, query parameters, and known limitations.
+
+## Authenticated Endpoints
+
+All authenticated endpoints (`/summaries`, `/stats/:range`, `/status_bar/today`, `/all_time_since_today`, `/durations`) accept an optional `timezone` query parameter (IANA format, e.g. `Asia/Tokyo`).
+
+When the `timezone` query parameter is omitted, it defaults to the authenticated user's **profile timezone** (set via `PATCH /api/v1/users/current/profile`). If the user has not set a timezone, it defaults to `UTC`.
+
+This means "Today" and "Yesterday" ranges align with the user's local calendar date automatically.
+
+## Global Stats
+
+The `GET /api/v1/stats/global` endpoint is unauthenticated and defaults to `UTC` when no `timezone` parameter is provided. It does not have access to a user profile.
+
+Summary data queried by global stats is bucketed by each user's profile timezone at cron aggregation time. In multi-user mode, this means the `summaries.date` column contains timezone-local dates from potentially different timezones. Cross-user timezone aggregation is a known limitation deferred to Milestone 4 (multi-user support).
+
+## Cron Bucketing
+
+The cron aggregation job (`src/cron/aggregate.ts`) buckets heartbeats into daily summaries using the user's profile timezone. This means a heartbeat at `2025-01-15 02:00 UTC` is bucketed as `2025-01-15` for a UTC user, but as `2025-01-15` (11:00 JST) for an `Asia/Tokyo` user.
+
+This approach ensures that summary rows reflect the user's local calendar date.
+
+## DST Handling
+
+Day boundaries are computed using `Intl.DateTimeFormat` with the user's IANA timezone. This correctly handles Daylight Saving Time transitions — days may be 23 or 25 hours long depending on the DST shift.
+
+## Changing Your Timezone
+
+Changing your profile timezone affects **future** cron aggregation runs only. Previously aggregated summary rows retain their original date bucketing. Historical summaries are **not** re-bucketed.
+
+If you change your timezone, there may be a brief period where the most recent day's summary has mixed bucketing (partially bucketed under the old timezone, partially under the new one).
+
+## References
+
+- Issue #28: Summaries UTC bucketing problem
+- Issue #29: Global stats timezone concerns (deferred to Milestone 4)

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,15 +1,24 @@
 import { createMiddleware } from "hono/factory";
+import type { Context } from "hono";
 import type { AuthEnv } from "../types";
 import { getApiKey, getUserId } from "../utils/auth";
 import { sha256Hex } from "../utils/crypto";
 import { getSessionTokenFromCookie, validateSession } from "../utils/session";
 
-async function fetchUserTimezone(db: D1Database, userId: string): Promise<string> {
-  const row = await db
+/**
+ * Lazily fetch the authenticated user's profile timezone.
+ * Caches on the Hono context so the D1 query runs at most once per request.
+ */
+export async function getUserTimezone(c: Context<AuthEnv>): Promise<string> {
+  const cached = c.get("userTimezone");
+  if (cached) return cached;
+  const row = await c.env.DB
     .prepare("SELECT timezone FROM users WHERE id = ?")
-    .bind(userId)
+    .bind(c.get("userId"))
     .first<{ timezone: string }>();
-  return row?.timezone ?? "UTC";
+  const tz = row?.timezone ?? "UTC";
+  c.set("userTimezone", tz);
+  return tz;
 }
 
 export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
@@ -20,7 +29,6 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
       const userId = await getUserId(apiKey, c.env);
       if (!userId) return c.json({ error: "Unauthorized" }, 401);
       c.set("userId", userId);
-      c.set("userTimezone", await fetchUserTimezone(c.env.DB, userId));
       await next();
       c.header("Cache-Control", "no-store");
       c.header("Pragma", "no-cache");
@@ -34,7 +42,6 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
       const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
       if (session) {
         c.set("userId", session.userId);
-        c.set("userTimezone", await fetchUserTimezone(c.env.DB, session.userId));
         await next();
         c.header("Cache-Control", "no-store");
         c.header("Pragma", "no-cache");

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,14 @@ import { getApiKey, getUserId } from "../utils/auth";
 import { sha256Hex } from "../utils/crypto";
 import { getSessionTokenFromCookie, validateSession } from "../utils/session";
 
+async function fetchUserTimezone(db: D1Database, userId: string): Promise<string> {
+  const row = await db
+    .prepare("SELECT timezone FROM users WHERE id = ?")
+    .bind(userId)
+    .first<{ timezone: string }>();
+  return row?.timezone ?? "UTC";
+}
+
 export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
   try {
     // 1. Try API key auth — if a key is present but invalid, reject immediately
@@ -12,6 +20,7 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
       const userId = await getUserId(apiKey, c.env);
       if (!userId) return c.json({ error: "Unauthorized" }, 401);
       c.set("userId", userId);
+      c.set("userTimezone", await fetchUserTimezone(c.env.DB, userId));
       await next();
       c.header("Cache-Control", "no-store");
       c.header("Pragma", "no-cache");
@@ -25,6 +34,7 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
       const session = await validateSession(c.env.DB, c.env.KV, tokenHash);
       if (session) {
         c.set("userId", session.userId);
+        c.set("userTimezone", await fetchUserTimezone(c.env.DB, session.userId));
         await next();
         c.header("Cache-Control", "no-store");
         c.header("Pragma", "no-cache");

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
-import { formatDigital, formatHumanReadable, getToday, formatDate, isValidTimezone } from "../utils/time-format";
+import { formatDigital, formatHumanReadable, getToday, formatDate, isValidTimezone, getEpochBoundsForDate } from "../utils/time-format";
 import { resolveStatsRange } from "../utils/stats-range";
 import { buildSummary, aggregateDimension, DIMENSIONS, DIMENSION_TO_KEY, type SummaryRow } from "../utils/summary-builder";
 import { checkUpToDate } from "../utils/aggregation-status";
@@ -22,10 +22,11 @@ stats.use("/*", authMiddleware);
 
 stats.get("/stats/:range", async (c) => {
   const rangeParam = c.req.param("range");
-  const tz = c.req.query("timezone");
-  if (tz && !isValidTimezone(tz)) {
+  const tzParam = c.req.query("timezone");
+  if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
+  const tz = tzParam || c.get("userTimezone");
   const resolved = resolveStatsRange(rangeParam, tz);
   if (!resolved) {
     return c.json({ error: "Invalid range. Use: last_7_days, last_30_days, last_6_months, last_year, all_time, YYYY, or YYYY-MM" }, 400);
@@ -90,7 +91,7 @@ stats.get("/stats/:range", async (c) => {
       start: `${resolved.start}T00:00:00Z`,
       end: `${resolved.end}T23:59:59Z`,
       text: resolved.text,
-      timezone: tz ?? "UTC",
+      timezone: tz,
     },
     status: isUpToDate ? "ok" : "pending_update",
     is_already_updating: false,
@@ -104,12 +105,13 @@ stats.get("/stats/:range", async (c) => {
 
 stats.get("/status_bar/today", async (c) => {
   const userId = c.get("userId");
-  const tz = c.req.query("timezone");
-  if (tz && !isValidTimezone(tz)) {
+  const tzParam = c.req.query("timezone");
+  if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
+  const tz = tzParam || c.get("userTimezone");
   const today = formatDate(getToday(tz));
-  const cacheKey = `statusbar:${userId}:${today}`;
+  const cacheKey = `statusbar:${userId}:${today}:${tz}`;
 
   // Check KV cache
   const cached = await c.env.KV.get(cacheKey, "json") as { data: Summary; cached_at: string } | null;
@@ -135,10 +137,11 @@ stats.get("/status_bar/today", async (c) => {
 stats.get("/all_time_since_today", async (c) => {
   const userId = c.get("userId");
   const project = c.req.query("project");
-  const tz = c.req.query("timezone");
-  if (tz && !isValidTimezone(tz)) {
+  const tzParam = c.req.query("timezone");
+  if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
+  const tz = tzParam || c.get("userTimezone");
 
   let sql = "SELECT COALESCE(SUM(total_seconds), 0) as total_seconds, MIN(date) as first_date FROM summaries WHERE user_id = ?";
   const params: (string | number)[] = [userId];
@@ -166,7 +169,7 @@ stats.get("/all_time_since_today", async (c) => {
       start: `${firstDate}T00:00:00Z`,
       end: `${today}T23:59:59Z`,
       text: "All Time",
-      timezone: tz ?? "UTC",
+      timezone: tz,
     },
     ...(project ? { project } : {}),
   };
@@ -199,14 +202,14 @@ stats.get("/durations", async (c) => {
   const project = c.req.query("project");
   const branchesParam = c.req.query("branches");
   const sliceBy = c.req.query("slice_by") ?? "project";
+  const tzParam = c.req.query("timezone");
+  if (tzParam && !isValidTimezone(tzParam)) {
+    return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
+  }
+  const tz = tzParam || c.get("userTimezone");
 
-  // Convert date to UNIX epoch range
-  const dayStart = Date.UTC(
-    parseInt(date.slice(0, 4)),
-    parseInt(date.slice(5, 7)) - 1,
-    parseInt(date.slice(8, 10)),
-  ) / 1000;
-  const dayEnd = dayStart + 86400;
+  // Convert date to UNIX epoch range in user's timezone
+  const { start: dayStart, end: dayEnd } = getEpochBoundsForDate(date, tz);
 
   // Build query
   let sql = `SELECT time, entity, project, language, branch, category, machine, editor, operating_system, is_write
@@ -272,7 +275,7 @@ stats.get("/durations", async (c) => {
     branches: Array.from(branchSet).sort(),
     start: date,
     end: date,
-    timezone: "UTC",
+    timezone: tz,
   });
 });
 

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
-import { authMiddleware } from "../middleware/auth";
+import { authMiddleware, getUserTimezone } from "../middleware/auth";
 import { formatDigital, formatHumanReadable, getToday, formatDate, isValidTimezone, getEpochBoundsForDate } from "../utils/time-format";
 import { resolveStatsRange } from "../utils/stats-range";
 import { buildSummary, aggregateDimension, DIMENSIONS, DIMENSION_TO_KEY, type SummaryRow } from "../utils/summary-builder";
@@ -26,7 +26,7 @@ stats.get("/stats/:range", async (c) => {
   if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
-  const tz = tzParam || c.get("userTimezone");
+  const tz = tzParam || await getUserTimezone(c);
   const resolved = resolveStatsRange(rangeParam, tz);
   if (!resolved) {
     return c.json({ error: "Invalid range. Use: last_7_days, last_30_days, last_6_months, last_year, all_time, YYYY, or YYYY-MM" }, 400);
@@ -109,7 +109,7 @@ stats.get("/status_bar/today", async (c) => {
   if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
-  const tz = tzParam || c.get("userTimezone");
+  const tz = tzParam || await getUserTimezone(c);
   const today = formatDate(getToday(tz));
   const cacheKey = `statusbar:${userId}:${today}:${tz}`;
 
@@ -141,7 +141,7 @@ stats.get("/all_time_since_today", async (c) => {
   if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
-  const tz = tzParam || c.get("userTimezone");
+  const tz = tzParam || await getUserTimezone(c);
 
   let sql = "SELECT COALESCE(SUM(total_seconds), 0) as total_seconds, MIN(date) as first_date FROM summaries WHERE user_id = ?";
   const params: (string | number)[] = [userId];
@@ -206,7 +206,7 @@ stats.get("/durations", async (c) => {
   if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
-  const tz = tzParam || c.get("userTimezone");
+  const tz = tzParam || await getUserTimezone(c);
 
   // Convert date to UNIX epoch range in user's timezone
   const { start: dayStart, end: dayEnd } = getEpochBoundsForDate(date, tz);

--- a/src/routes/summaries.ts
+++ b/src/routes/summaries.ts
@@ -22,10 +22,11 @@ summaries.get("/summaries", async (c) => {
   const end = c.req.query("end");
   const project = c.req.query("project");
   const branchesParam = c.req.query("branches");
-  const tz = c.req.query("timezone");
-  if (tz && !isValidTimezone(tz)) {
+  const tzParam = c.req.query("timezone");
+  if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
+  const tz = tzParam || c.get("userTimezone");
 
   const resolved = resolveDateRange(range, start, end, tz);
   if (!resolved) {

--- a/src/routes/summaries.ts
+++ b/src/routes/summaries.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
-import { authMiddleware } from "../middleware/auth";
+import { authMiddleware, getUserTimezone } from "../middleware/auth";
 import { resolveDateRange, formatDigital, formatHumanReadable, isValidTimezone } from "../utils/time-format";
 import { buildSummary, type SummaryRow } from "../utils/summary-builder";
 
@@ -26,7 +26,7 @@ summaries.get("/summaries", async (c) => {
   if (tzParam && !isValidTimezone(tzParam)) {
     return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
   }
-  const tz = tzParam || c.get("userTimezone");
+  const tz = tzParam || await getUserTimezone(c);
 
   const resolved = resolveDateRange(range, start, end, tz);
   if (!resolved) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface Env {
 // Hono environment with authenticated user context
 export type AuthEnv = {
   Bindings: Env;
-  Variables: { userId: string; userTimezone: string };
+  Variables: { userId: string; userTimezone?: string };
 };
 
 // Hono environment for session-authenticated routes

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface Env {
 // Hono environment with authenticated user context
 export type AuthEnv = {
   Bindings: Env;
-  Variables: { userId: string };
+  Variables: { userId: string; userTimezone: string };
 };
 
 // Hono environment for session-authenticated routes

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -67,6 +67,39 @@ export function getToday(tz?: string): Date {
   return new Date(Date.UTC(y, m - 1, d));
 }
 
+/**
+ * Get epoch boundaries (start inclusive, end exclusive) for a calendar date in a timezone.
+ * Returns the UTC epoch seconds for midnight-to-midnight of the given date in the given timezone.
+ */
+export function getEpochBoundsForDate(dateStr: string, tz?: string): { start: number; end: number } {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const utcMidnightSecs = Date.UTC(y, m - 1, d) / 1000;
+
+  if (!tz || tz === "UTC") {
+    return { start: utcMidnightSecs, end: utcMidnightSecs + 86400 };
+  }
+
+  const refDate = new Date(utcMidnightSecs * 1000);
+  const opts: Intl.DateTimeFormatOptions = {
+    year: "numeric", month: "numeric", day: "numeric",
+    hour: "numeric", minute: "numeric", second: "numeric",
+    hourCycle: "h23",
+  };
+
+  const utcParts = new Intl.DateTimeFormat("en-US", { ...opts, timeZone: "UTC" }).formatToParts(refDate);
+  const tzParts = new Intl.DateTimeFormat("en-US", { ...opts, timeZone: tz }).formatToParts(refDate);
+
+  const toMs = (parts: Intl.DateTimeFormatPart[]) => {
+    const g = (t: string) => parseInt(parts.find((p) => p.type === t)?.value ?? "0", 10);
+    return Date.UTC(g("year"), g("month") - 1, g("day"), g("hour"), g("minute"), g("second"));
+  };
+
+  const offsetSecs = (toMs(tzParts) - toMs(utcParts)) / 1000;
+  const startSecs = utcMidnightSecs - offsetSecs;
+
+  return { start: startSecs, end: startSecs + 86400 };
+}
+
 /** Format seconds as digital clock: "2:30" */
 export function formatDigital(totalSeconds: number): string {
   const h = Math.floor(totalSeconds / 3600);

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -67,37 +67,58 @@ export function getToday(tz?: string): Date {
   return new Date(Date.UTC(y, m - 1, d));
 }
 
-/**
- * Get epoch boundaries (start inclusive, end exclusive) for a calendar date in a timezone.
- * Returns the UTC epoch seconds for midnight-to-midnight of the given date in the given timezone.
- */
-export function getEpochBoundsForDate(dateStr: string, tz?: string): { start: number; end: number } {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  const utcMidnightSecs = Date.UTC(y, m - 1, d) / 1000;
+const epochFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
-  if (!tz || tz === "UTC") {
-    return { start: utcMidnightSecs, end: utcMidnightSecs + 86400 };
-  }
-
-  const refDate = new Date(utcMidnightSecs * 1000);
-  const opts: Intl.DateTimeFormatOptions = {
+function getEpochFormatter(tz: string): Intl.DateTimeFormat {
+  const cached = epochFormatterCache.get(tz);
+  if (cached) return cached;
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
     year: "numeric", month: "numeric", day: "numeric",
     hour: "numeric", minute: "numeric", second: "numeric",
     hourCycle: "h23",
-  };
+  });
+  epochFormatterCache.set(tz, fmt);
+  return fmt;
+}
 
-  const utcParts = new Intl.DateTimeFormat("en-US", { ...opts, timeZone: "UTC" }).formatToParts(refDate);
-  const tzParts = new Intl.DateTimeFormat("en-US", { ...opts, timeZone: tz }).formatToParts(refDate);
+/**
+ * Compute the UTC epoch (seconds) of local midnight for a given YYYY-MM-DD in a timezone.
+ */
+function midnightEpoch(y: number, m: number, d: number, tz: string): number {
+  const utcMidnightMs = Date.UTC(y, m - 1, d);
+  const refDate = new Date(utcMidnightMs);
+
+  const utcFmt = getEpochFormatter("UTC");
+  const tzFmt = getEpochFormatter(tz);
 
   const toMs = (parts: Intl.DateTimeFormatPart[]) => {
     const g = (t: string) => parseInt(parts.find((p) => p.type === t)?.value ?? "0", 10);
     return Date.UTC(g("year"), g("month") - 1, g("day"), g("hour"), g("minute"), g("second"));
   };
 
-  const offsetSecs = (toMs(tzParts) - toMs(utcParts)) / 1000;
-  const startSecs = utcMidnightSecs - offsetSecs;
+  const offsetMs = toMs(tzFmt.formatToParts(refDate)) - toMs(utcFmt.formatToParts(refDate));
+  return (utcMidnightMs - offsetMs) / 1000;
+}
 
-  return { start: startSecs, end: startSecs + 86400 };
+/**
+ * Get epoch boundaries (start inclusive, end exclusive) for a calendar date in a timezone.
+ * Computes both boundaries independently so DST transitions (23h/25h days) are handled correctly.
+ */
+export function getEpochBoundsForDate(dateStr: string, tz?: string): { start: number; end: number } {
+  const [y, m, d] = dateStr.split("-").map(Number);
+
+  if (!tz || tz === "UTC") {
+    const utcMidnightSecs = Date.UTC(y, m - 1, d) / 1000;
+    return { start: utcMidnightSecs, end: utcMidnightSecs + 86400 };
+  }
+
+  const start = midnightEpoch(y, m, d, tz);
+  // Compute next day's midnight independently (handles DST transitions)
+  const nextDay = new Date(Date.UTC(y, m - 1, d + 1));
+  const end = midnightEpoch(nextDay.getUTCFullYear(), nextDay.getUTCMonth() + 1, nextDay.getUTCDate(), tz);
+
+  return { start, end };
 }
 
 /** Format seconds as digital clock: "2:30" */


### PR DESCRIPTION
## Summary
- Add `userTimezone` to auth context — lazily fetched from D1 only when routes need it (no extra query for heartbeat/user endpoints)
- All 5 authenticated endpoints (`/summaries`, `/stats/:range`, `/status_bar/today`, `/all_time_since_today`, `/durations`) fall back to profile timezone when `?timezone=` is omitted
- `/durations` now computes epoch boundaries in the user's timezone via `getEpochBoundsForDate()` — both start and end boundaries computed independently to handle DST transitions (23h/25h days)
- `/status_bar/today` KV cache key now includes timezone to prevent cross-TZ cache collisions
- `Intl.DateTimeFormat` instances cached in `epochFormatterCache` to avoid per-call re-creation
- Add `docs/timezone-behavior.md` documenting timezone behavior and known limitations

Closes #28. Addresses #29 (documentation only, full fix deferred to Milestone 4).

## PR2 of 2 (SpecKit 2-PR Workflow)
Spec + schema changes were merged in PR #83. This PR contains the implementation.

## Test plan
- [ ] Set user timezone to `Asia/Tokyo`, query `/summaries?range=Today` without `?timezone=` — date range should be anchored to JST
- [ ] Query with explicit `?timezone=America/New_York` — should override profile timezone
- [ ] Query with invalid `?timezone=Mars/Olympus` — should return 400
- [ ] Verify `/durations?date=2025-01-15` returns timezone-correct epoch boundaries for non-UTC user
- [ ] Verify `/durations` across a DST transition date (e.g. `2025-03-09` in `America/New_York`) produces a 23h window, not 24h
- [ ] Verify heartbeat POST does not trigger a timezone D1 query (no performance regression)
- [ ] Verify `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)