### PR TITLE
docs: backfill SpecKit artifacts for issue #60

### DIFF
--- a/specs/060-remove-callback-apikey/checklists/requirements.md
+++ b/specs/060-remove-callback-apikey/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Remove API Key from OAuth Callback Response
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/060-remove-callback-apikey/contracts/callback-response.md
+++ b/specs/060-remove-callback-apikey/contracts/callback-response.md
@@ -1,0 +1,67 @@
+# Contract: OAuth Callback Response
+
+## Before (current)
+
+```
+GET /:provider/callback → 200
+
+{
+  "data": {
+    "user": { ... },
+    "api_key": "ck_...",       ← REMOVED
+    "is_new_user": true,
+    "pending_link": { ... }
+  }
+}
+```
+
+## After (target)
+
+```
+GET /:provider/callback → 200
+
+New user:
+{
+  "data": {
+    "user": { ... },
+    "is_new_user": true
+  }
+}
+
+Existing user:
+{
+  "data": {
+    "user": { ... },
+    "is_new_user": false
+  }
+}
+
+Pending link:
+{
+  "data": {
+    "pending_link": { ... }
+  }
+}
+```
+
+## Changes
+
+| Field | Before | After |
+|-------|--------|-------|
+| `data.api_key` | Present on new user creation (`ck_...` plaintext) | Removed entirely |
+| `data.user` | Unchanged | Unchanged |
+| `data.is_new_user` | Unchanged | Unchanged |
+| `data.pending_link` | Unchanged | Unchanged |
+
+## API key retrieval (existing endpoint, no changes)
+
+```
+POST /auth/api-key → 200
+(requires session cookie)
+
+{
+  "data": {
+    "api_key": "ck_..."
+  }
+}
+```

--- a/specs/060-remove-callback-apikey/plan.md
+++ b/specs/060-remove-callback-apikey/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Remove API Key from OAuth Callback Response
+
+**Branch**: `060-remove-callback-apikey` | **Date**: 2026-03-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/060-remove-callback-apikey/spec.md`
+
+## Summary
+
+Remove the `api_key` field from the OAuth callback (`GET /:provider/callback`) response to prevent credential exposure in GET responses. The API key is still generated and stored (as a hash) during account creation, but the plaintext is discarded instead of being returned. Users obtain their API key via the existing authenticated `POST /api-key` endpoint.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7, openapi-typescript
+**Storage**: Cloudflare D1 (SQLite) — no schema changes needed
+**Testing**: Manual endpoint testing, `npx tsc --noEmit` for type checking
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (API)
+**Performance Goals**: <10ms CPU per request (Workers free tier)
+**Constraints**: No new dependencies, no database migration
+**Scale/Scope**: Single-user mode, minimal change footprint
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Spec change (remove `api_key` from callback response schema) committed before implementation. Commit order: spec → generate → implement. |
+| II. Cloudflare-Native | PASS | No new D1 tables or queries. No additional CPU cost. |
+| III. Type Safety | PASS | Schema change goes through `npm run generate`. Route handler uses generated types. |
+| IV. Legal/Trademark | PASS | No third-party references. |
+| V. Simplicity First | PASS | Removing a field — net simplification. No new abstractions. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/060-remove-callback-apikey/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── callback-response.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+schemas/
+└── paths/
+    └── auth/
+        └── provider-callback.yaml  # Updated: remove api_key from response schema
+
+src/
+├── routes/
+│   └── auth/
+│       └── login.ts                # Updated: remove api_key from response object
+└── types/
+    └── generated.ts                # Regenerated
+```
+
+**Structure Decision**: Existing single-project structure. Two files modified (one spec, one implementation) plus regenerated types.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/060-remove-callback-apikey/quickstart.md
+++ b/specs/060-remove-callback-apikey/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Remove API Key from OAuth Callback Response
+
+## Prerequisites
+
+- Node.js, npm installed
+- Wrangler CLI configured
+- CloudTime project cloned, on `060-remove-callback-apikey` branch
+
+## SDD Workflow
+
+### Step 1: Update OpenAPI Spec
+
+Edit `schemas/paths/auth/provider-callback.yaml`:
+
+1. Remove `api_key` property from the `200` response schema
+2. Update the `description` to remove the paragraph about returning the API key on first-time creation
+
+Commit: `spec: remove api_key from OAuth callback response schema`
+
+### Step 2: Regenerate Types
+
+```bash
+npm run generate
+```
+
+Commit: `chore: regenerate types`
+
+### Step 3: Update Route Handler
+
+Edit `src/routes/auth/login.ts`:
+
+1. Remove `api_key: apiKeyPlaintext` from the new-user response object
+2. Remove the `apiKeyPlaintext` variable (or leave generation for hash storage, just don't return it)
+
+Commit: `fix: remove API key from OAuth callback response (Closes #60)`
+
+### Step 4: Validate
+
+```bash
+npx tsc --noEmit
+```
+
+### Step 5: Create PR
+
+```bash
+git push -u origin 060-remove-callback-apikey
+gh pr create --base develop
+```
+
+## Verification
+
+After completing the OAuth login flow as a new user, the response should:
+
+1. Contain `user` and `is_new_user: true`
+2. NOT contain `api_key`
+3. Have a valid session cookie set
+
+The user can then call `POST /auth/api-key` with the session cookie to obtain their API key.

--- a/specs/060-remove-callback-apikey/research.md
+++ b/specs/060-remove-callback-apikey/research.md
@@ -1,0 +1,28 @@
+# Research: Remove API Key from OAuth Callback Response
+
+**Feature Branch**: `060-remove-callback-apikey`
+**Date**: 2026-03-11
+
+## Research Summary
+
+Minimal research needed — the change is well-scoped with no unknowns.
+
+## Decision 1: Where users obtain API keys after this change
+
+- **Decision**: Users call the existing `POST /api-key` endpoint (session-authenticated) to obtain or regenerate their API key.
+- **Rationale**: The endpoint already exists at `src/routes/auth/sessions.ts` and works correctly. It regenerates the key (replaces the hash) and returns the new plaintext. No new endpoint needed.
+- **Alternatives considered**:
+  - Store plaintext temporarily in KV for one-time retrieval — rejected as over-engineering (Principle V).
+  - New dedicated "reveal key" endpoint — rejected; `POST /api-key` already serves this purpose.
+
+## Decision 2: Keep or remove API key generation during user creation
+
+- **Decision**: Keep generating the API key hash during user creation.
+- **Rationale**: The `users.api_key_hash` column has a NOT NULL constraint. Removing key generation would require a schema migration to make the column nullable, which is unnecessary complexity for this change.
+- **Alternatives considered**:
+  - Make `api_key_hash` nullable and defer generation to `POST /api-key` — rejected; requires DB migration for no user-facing benefit.
+
+## Decision 3: Impact on existing `POST /api-key` behavior
+
+- **Decision**: No changes to `POST /api-key` endpoint.
+- **Rationale**: The endpoint regenerates (not reveals) the key. For a new user, calling it replaces the key created during signup with a fresh one. This is acceptable — the user never saw the original key anyway.

--- a/specs/060-remove-callback-apikey/spec.md
+++ b/specs/060-remove-callback-apikey/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: Remove API Key from OAuth Callback Response
+
+**Feature Branch**: `060-remove-callback-apikey`
+**Created**: 2026-03-11
+**Status**: Draft
+**Input**: issue#60の対応として、OAuth callbackのレスポンスからapi_keyフィールドを削除する
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - OAuth callback no longer exposes API key (Priority: P1)
+
+A new user completes the OAuth login flow for the first time. The system creates their account and establishes a session, but does NOT return the API key in the callback response. The API key is generated and stored (as a hash) during account creation, but the plaintext is never exposed in the GET callback response. The user retrieves their API key later via the authenticated `POST /api-key` endpoint (which regenerates the key).
+
+**Why this priority**: This is the core security improvement. GET responses are more susceptible to leakage (CDN debug logs, browser extensions, observability tools) than authenticated POST responses. Removing the API key from the callback eliminates this exposure vector entirely.
+
+**Independent Test**: Complete an OAuth login flow as a new user and verify the callback response does NOT contain an `api_key` field, while the user account is still created successfully with a valid session.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new user completing OAuth login, **When** the callback response is returned, **Then** the response contains `user` and `is_new_user: true` but does NOT contain an `api_key` field.
+2. **Given** an existing user completing OAuth login, **When** the callback response is returned, **Then** the response is unchanged (it already does not contain `api_key`).
+3. **Given** a new user who has just completed OAuth login, **When** they call `POST /api-key` with their session, **Then** they receive a valid API key that works for editor plugin authentication.
+
+---
+
+### Edge Cases
+
+- What happens if a new user never calls `POST /api-key`? The user has a session but no usable API key plaintext. The hashed key exists in the database from account creation, but the plaintext was never exposed. The user can generate a new key at any time via `POST /api-key`.
+- What happens to the API key generated during account creation? It is still generated and stored as a hash (ensuring the database record is complete), but the plaintext is discarded without being returned to the user.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The OAuth callback response MUST NOT include an `api_key` field for any response scenario (new user, existing user, or pending link).
+- **FR-002**: Account creation during OAuth callback MUST continue to generate and store an API key hash, ensuring the user record is complete.
+- **FR-003**: The existing `POST /api-key` endpoint MUST remain the sole method for users to obtain an API key plaintext.
+- **FR-004**: The API specification for the callback response MUST be updated to remove the `api_key` field and its description.
+- **FR-005**: The callback response description MUST be updated to remove any mention of returning the API key on first-time creation.
+
+### Key Entities
+
+- **OAuth Callback Response**: Response object returned after OAuth login. The `api_key` field is removed. Remaining fields: `user` (User object), `is_new_user` (boolean), `pending_link` (PendingLink object, conditional).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The OAuth callback response contains zero sensitive credentials (API keys, tokens, secrets) in any scenario.
+- **SC-002**: New users can successfully obtain a working API key via the existing authenticated endpoint after completing OAuth login.
+- **SC-003**: All existing OAuth login flows (new user, existing user, pending link) continue to function correctly without the `api_key` field.
+
+## Clarifications
+
+### Assumptions
+
+- The `POST /api-key` endpoint already exists and works correctly for session-authenticated users. No changes to this endpoint are needed.
+- The API key hash is still generated and stored during user creation to keep the database record consistent.
+- This change does not affect API key authentication for editor plugins — only the method by which users first obtain their key changes (dashboard settings page instead of callback response).

--- a/specs/060-remove-callback-apikey/tasks.md
+++ b/specs/060-remove-callback-apikey/tasks.md
@@ -1,0 +1,115 @@
+# Tasks: Remove API Key from OAuth Callback Response
+
+**Input**: Design documents from `/specs/060-remove-callback-apikey/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/
+
+**Tests**: Not requested — test tasks are omitted.
+
+**Organization**: Tasks are grouped by SpecKit 2-PR workflow. Per CLAUDE.md SDD rules, PR1 = spec + types (no implementation), PR2 = implementation (after PR1 merges).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify existing files and baseline.
+
+- [x] T001 Verify existing spec file is present and baseline is correct: `schemas/paths/auth/provider-callback.yaml`
+
+---
+
+## Phase 2: OpenAPI Spec Updates (PR1 — Spec + Types)
+
+**Purpose**: Update the OpenAPI spec and regenerate types. This entire phase is a single PR targeting `develop`. No implementation code.
+
+**CRITICAL**: All spec changes must be committed before any implementation. Commit order: spec changes → `npm run generate` → commit generated types.
+
+### Spec Changes
+
+- [x] T002 [P] Remove `api_key` property from the `200` response schema in `schemas/paths/auth/provider-callback.yaml`
+- [x] T003 [P] Update the `description` field in `schemas/paths/auth/provider-callback.yaml` to remove the paragraph about returning the API key on first-time user creation (line 62: "On first-time user creation, the response includes...")
+
+### Type Generation
+
+- [x] T004 Run `npm run generate` to regenerate `src/types/generated.ts` and verify no type errors with `npx tsc --noEmit`
+
+**Checkpoint**: PR1 ready — spec changes + regenerated types. Create PR targeting `develop`. No implementation code in this PR.
+
+---
+
+## Phase 3: User Story 1 — OAuth callback no longer exposes API key (Priority: P1)
+
+**Goal**: Remove the `api_key` field from the new-user response in the OAuth callback handler. The API key is still generated and stored as a hash, but the plaintext is discarded.
+
+**Independent Test**: Complete an OAuth login flow as a new user and verify the callback response does NOT contain an `api_key` field.
+
+### Implementation for User Story 1 (PR2)
+
+- [x] T005 [US1] Remove `api_key: apiKeyPlaintext` from the new-user response object in `src/routes/auth/login.ts` (the response at the end of the new-user creation path)
+- [x] T006 [US1] Remove the `apiKeyPlaintext` variable usage from the response — keep the `generateApiKey()` call and hash storage, only remove the plaintext from the returned JSON
+- [x] T007 [US1] Run `npx tsc --noEmit` to verify type checks pass after removing `api_key` from the response
+
+**Checkpoint**: US1 complete — OAuth callback no longer exposes API key in any response scenario.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation.
+
+- [x] T008 Verify the `POST /auth/api-key` endpoint still works correctly for key regeneration (no changes expected, just confirm)
+- [x] T009 Run `npx tsc --noEmit` to verify all type checks pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — can start immediately
+- **Phase 2 (OpenAPI Spec)**: Depends on Phase 1 — produces PR1
+- **Phase 3 (User Story 1)**: Depends on Phase 2 (PR1 must be merged first) — produces PR2
+- **Phase 4 (Polish)**: Depends on Phase 3
+
+### Within Phase 2
+
+- T002 and T003 can run in parallel (both modify `provider-callback.yaml` but different sections)
+- T004 must run after T002 and T003
+
+### PR Structure (per CLAUDE.md SpecKit 2-PR Workflow)
+
+- **PR1**: T001–T004 (spec + types, no implementation)
+- **PR2**: T005–T009 (implementation, after PR1 merges)
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1: Setup verification
+2. Complete Phase 2: OpenAPI spec + type generation (PR1)
+3. **MERGE PR1** into `develop`
+4. Complete Phase 3: User Story 1 (PR2)
+5. **STOP and VALIDATE**: Verify `api_key` is absent from callback response
+6. Complete Phase 4: Polish
+
+### PR Structure
+
+- **PR1**: T001–T004 (spec + types, no implementation)
+- **PR2**: T005–T009 (implementation, after PR1 merges)
+
+---
+
+## Notes
+
+- Implementation changes are in a **single file**: `src/routes/auth/login.ts`
+- Spec changes are in a **single file**: `schemas/paths/auth/provider-callback.yaml`
+- No database migration needed
+- No new npm dependencies required
+- Per CLAUDE.md: PRs target `develop`, never `master`


### PR DESCRIPTION
## Summary

- Backfills the SpecKit artifacts (`spec.md`, `plan.md`, `tasks.md`, `research.md`, `quickstart.md`, contracts, checklists) for the OAuth callback `api_key` removal feature shipped in PR #70.
- Per CLAUDE.md SDD rules (`schemas/openapi.yaml` is SSoT, spec lands in PR1 of the 2-PR workflow), these artifacts should have been committed alongside the implementation. They were authored locally but never pushed.
- Docs-only change — no implementation, no schema, no generated types touched.

## Test plan

- [ ] Verify only `specs/060-remove-callback-apikey/**` paths are added
- [ ] Verify content matches the merged behavior of PR #70 (callback response omits `api_key`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)