### PR TITLE
spec: OAuth rate limiting (PR1/2) #58

### DIFF
--- a/schemas/components/responses/TooManyRequests.yaml
+++ b/schemas/components/responses/TooManyRequests.yaml
@@ -1,14 +1,10 @@
 description: |
-  Rate limit exceeded. Limits enforced by this implementation:
-  - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6).
-  - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation).
+  Rate limit exceeded. The exact threshold depends on the endpoint.
+  OAuth login endpoints enforce Cloudflare Workers native Rate Limiting
+  bindings, keyed by truncated client IP. Authenticated endpoints may use
+  separate application-level controls, such as pending-link limits.
 
-  Other endpoints listed in earlier drafts (API key regeneration, account linking,
-  session management) are NOT yet rate-limited at the edge; they retain their
-  application-level controls (for example, 3 active pending links per user).
-
-  Implementation: Cloudflare Workers native Rate Limiting binding (see
-  `specs/058-oauth-rate-limiting/`).
+  See the operation description for endpoint-specific limits.
 headers:
   Retry-After:
     description: Seconds until the rate limit resets

--- a/schemas/components/responses/TooManyRequests.yaml
+++ b/schemas/components/responses/TooManyRequests.yaml
@@ -1,10 +1,14 @@
 description: |
-  Rate limit exceeded. Recommended limits:
-  - OAuth start/callback: 10 req/min per IP
-  - API key regeneration: 3 req/min per user
-  - Account linking: 5 req/min per user
-  - Session management: 30 req/min per user
-  Implementation: Use Cloudflare Workers native Rate Limiting binding.
+  Rate limit exceeded. Limits enforced by this implementation:
+  - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6).
+  - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation).
+
+  Other endpoints listed in earlier drafts (API key regeneration, account linking,
+  session management) are NOT yet rate-limited at the edge; they retain their
+  application-level controls (for example, 3 active pending links per user).
+
+  Implementation: Cloudflare Workers native Rate Limiting binding (see
+  `specs/058-oauth-rate-limiting/`).
 headers:
   Retry-After:
     description: Seconds until the rate limit resets

--- a/schemas/paths/auth/provider-callback.yaml
+++ b/schemas/paths/auth/provider-callback.yaml
@@ -58,6 +58,11 @@ get:
     **Response headers for defense in depth:**
     - `Referrer-Policy: no-referrer` — prevents authorization code leakage via Referer header.
     - `Cache-Control: no-store` — prevents caching of authentication responses.
+
+    **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
+    Limiting binding before state validation or provider token exchange. Limit:
+    5 requests per configured 60-second window, keyed by client IP truncated to
+    /24 for IPv4 or /48 for IPv6.
   security: []
   parameters:
     - name: provider

--- a/schemas/paths/auth/provider.yaml
+++ b/schemas/paths/auth/provider.yaml
@@ -33,6 +33,10 @@ get:
     - GitHub App: "Email addresses: Read-only" permission (set at app registration, not per-request)
     - Google: `openid email profile`
     - Discord: `identify email`
+
+    **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
+    Limiting binding. Limit: 10 requests per configured 60-second window, keyed
+    by client IP truncated to /24 for IPv4 or /48 for IPv6.
   security: []
   parameters:
     - name: provider

--- a/specs/058-oauth-rate-limiting/checklists/requirements.md
+++ b/specs/058-oauth-rate-limiting/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Acceptance Checklist: Rate Limiting for OAuth Endpoints
+
+This checklist enforces the gate between PR1 (spec) and PR2 (implementation), and the gate between PR2 and production deployment.
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [ ] `spec.md` lists FR-001 through FR-010 with no `[NEEDS CLARIFICATION]` markers.
+- [ ] `plan.md` includes a Constitution Check table with all five principles marked PASS.
+- [ ] `research.md` documents the binding choice, IP truncation, and fail-open behavior with rationale.
+- [ ] `tasks.md` distinguishes PR1 from PR2 tasks and identifies dependencies.
+- [ ] `contracts/openapi-diff.md` shows only description-level changes.
+- [ ] `schemas/components/responses/TooManyRequests.yaml` description is updated to "Enforced" language with the chosen values (10/60s, 5/60s).
+- [ ] `npm run generate` runs cleanly. `git diff src/types/generated.ts` shows no type-shape changes (description/JSDoc-only diff is acceptable).
+- [ ] PR1 contains no changes under `src/middleware/`, `src/routes/`, or `wrangler.toml`.
+- [ ] PR1 description references Issue #58 and the SpecKit 2-PR workflow rule.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+- [ ] `wrangler.toml` declares two `[[unsafe.bindings]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`) with the configured limits.
+- [ ] `src/types.ts` exposes the bindings as optional fields on `Env`.
+- [ ] `src/middleware/rate-limit.ts` implements `rateLimitMiddleware(getBinding, ruleName)` per `plan.md` § Design Outputs.
+- [ ] Both OAuth routes in `src/routes/auth/login.ts` are wrapped by the middleware.
+- [ ] `npx tsc --noEmit` passes with zero errors.
+- [ ] The middleware runs before CSRF and before any KV/D1 access in the route handler.
+
+### Behavior (per `quickstart.md`)
+- [ ] Scenario A: 11th initiate request from one IP returns 429 with `Retry-After: 60`.
+- [ ] Scenario B: 6th callback request from one IP returns 429 before state validation.
+- [ ] Scenario C: Missing binding emits a single warning log and fails open in dev.
+- [ ] Scenario D: IPv6 clients on a shared /48 share a counter; different /48s do not.
+- [ ] Scenario E: 429 logs contain truncated IP only; no OAuth state, code, or cookie values appear in logs.
+
+### Documentation
+- [ ] `docs/cloudflare-constraints.md` mentions the new bindings and the rate-limiter free-tier quota.
+- [ ] PR2 description links back to PR1, references Issue #58, and includes scenario results from `quickstart.md`.
+
+## Post-deployment (production) gate
+
+- [ ] First 24h post-deploy: monitor Worker logs for unexpected 429 spikes (legitimate-traffic false positives).
+- [ ] First 7d post-deploy: monitor KV daily write counts — should stay flat or drop under previous baseline (success criterion SC-004).
+- [ ] First 30d post-deploy: zero support reports of legitimate users blocked by rate limiting (SC-005).
+- [ ] If false-positive 429s are observed: tune `simple = { limit, period }` in `wrangler.toml` and redeploy. No code change required.

--- a/specs/058-oauth-rate-limiting/checklists/requirements.md
+++ b/specs/058-oauth-rate-limiting/checklists/requirements.md
@@ -9,7 +9,7 @@ This checklist enforces the gate between PR1 (spec) and PR2 (implementation), an
 - [ ] `research.md` documents the binding choice, IP truncation, and fail-open behavior with rationale.
 - [ ] `tasks.md` distinguishes PR1 from PR2 tasks and identifies dependencies.
 - [ ] `contracts/openapi-diff.md` shows only description-level changes.
-- [ ] `schemas/components/responses/TooManyRequests.yaml` description is updated to "Enforced" language with the chosen values (10/60s, 5/60s).
+- [ ] `schemas/components/responses/TooManyRequests.yaml` remains generic, and `schemas/paths/auth/provider*.yaml` operation descriptions document the enforced OAuth values (10/60s, 5/60s).
 - [ ] `npm run generate` runs cleanly. `git diff src/types/generated.ts` shows no type-shape changes (description/JSDoc-only diff is acceptable).
 - [ ] PR1 contains no changes under `src/middleware/`, `src/routes/`, or `wrangler.toml`.
 - [ ] PR1 description references Issue #58 and the SpecKit 2-PR workflow rule.
@@ -17,7 +17,7 @@ This checklist enforces the gate between PR1 (spec) and PR2 (implementation), an
 ## PR2 (Implementation) gate — must be ✅ before merging
 
 ### Code
-- [ ] `wrangler.toml` declares two `[[unsafe.bindings]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`) with the configured limits.
+- [ ] `wrangler.toml` declares two `[[ratelimits]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`) with the configured limits.
 - [ ] `src/types.ts` exposes the bindings as optional fields on `Env`.
 - [ ] `src/middleware/rate-limit.ts` implements `rateLimitMiddleware(getBinding, ruleName)` per `plan.md` § Design Outputs.
 - [ ] Both OAuth routes in `src/routes/auth/login.ts` are wrapped by the middleware.
@@ -32,7 +32,7 @@ This checklist enforces the gate between PR1 (spec) and PR2 (implementation), an
 - [ ] Scenario E: 429 logs contain truncated IP only; no OAuth state, code, or cookie values appear in logs.
 
 ### Documentation
-- [ ] `docs/cloudflare-constraints.md` mentions the new bindings and the rate-limiter free-tier quota.
+- [ ] `docs/cloudflare-constraints.md` mentions the new bindings and tells operators to verify current Cloudflare plan limits before production deployment.
 - [ ] PR2 description links back to PR1, references Issue #58, and includes scenario results from `quickstart.md`.
 
 ## Post-deployment (production) gate

--- a/specs/058-oauth-rate-limiting/contracts/openapi-diff.md
+++ b/specs/058-oauth-rate-limiting/contracts/openapi-diff.md
@@ -1,0 +1,51 @@
+# OpenAPI Schema Diff
+
+This feature changes only **description text** in the OpenAPI schema. No new fields, response codes, or schema shapes are introduced. The 429 response and `Retry-After` header are already declared on both OAuth paths.
+
+## Files touched
+
+1. `schemas/components/responses/TooManyRequests.yaml`
+2. `schemas/paths/auth/provider.yaml`
+3. `schemas/paths/auth/provider-callback.yaml`
+
+## Diff 1 — `TooManyRequests.yaml`
+
+Change the lead-in description from "Recommended" to "Enforced", and split out the OAuth limits as concrete numbers tied to this feature.
+
+```diff
+-description: |
+-  Rate limit exceeded. Recommended limits:
+-  - OAuth start/callback: 10 req/min per IP
+-  - API key regeneration: 3 req/min per user
+-  - Account linking: 5 req/min per user
+-  - Session management: 30 req/min per user
+-  Implementation: Use Cloudflare Workers native Rate Limiting binding.
++description: |
++  Rate limit exceeded. Limits enforced by this implementation:
++  - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6)
++  - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation)
++
++  Other endpoints listed in earlier drafts (API key regeneration, account linking,
++  session management) are NOT yet rate-limited at the edge; they retain their
++  application-level controls (e.g., 3 active pending links per user).
++
++  Implementation: Cloudflare Workers native Rate Limiting binding.
+```
+
+## Diff 2 — `provider.yaml`
+
+No structural change. The `429` response continues to `$ref` `TooManyRequests.yaml`. The diff is captured in `TooManyRequests.yaml` above. If a separate, path-specific clarification is desired, the future-form would attach a `description` override at the `429:` key, but per simplicity-first this is omitted unless reviewers request it.
+
+## Diff 3 — `provider-callback.yaml`
+
+Same as Diff 2 — no structural change. Description text lives in the shared component.
+
+## Generated-types impact
+
+`npm run generate` regenerates `src/types/generated.ts` from `schemas/openapi.yaml`. Because the changes are description-only, the generated TypeScript types should be byte-identical or contain only JSDoc comment changes. **The diff for `src/types/generated.ts` will be reviewed in PR1 and must not contain any type-shape changes** — if it does, the schema diff has unintended side-effects and the PR is blocked until the schema change is narrowed.
+
+## SDD compliance note
+
+Per CLAUDE.md: *"`schemas/openapi.yaml` is the Single Source of Truth"* and *"Always update the spec BEFORE writing implementation code."*
+
+This PR1 lands the schema and SpecKit artifacts. PR2 (separate) wires the middleware and `wrangler.toml` binding. No implementation code is included in PR1.

--- a/specs/058-oauth-rate-limiting/contracts/openapi-diff.md
+++ b/specs/058-oauth-rate-limiting/contracts/openapi-diff.md
@@ -10,7 +10,7 @@ This feature changes only **description text** in the OpenAPI schema. No new fie
 
 ## Diff 1 — `TooManyRequests.yaml`
 
-Change the lead-in description from "Recommended" to "Enforced", and split out the OAuth limits as concrete numbers tied to this feature.
+Keep the shared 429 response generic because several non-OAuth-initiate/callback endpoints also reference it. Endpoint-specific OAuth limits are documented on the affected operations instead.
 
 ```diff
 -description: |
@@ -21,24 +21,21 @@ Change the lead-in description from "Recommended" to "Enforced", and split out t
 -  - Session management: 30 req/min per user
 -  Implementation: Use Cloudflare Workers native Rate Limiting binding.
 +description: |
-+  Rate limit exceeded. Limits enforced by this implementation:
-+  - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6)
-+  - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation)
++  Rate limit exceeded. The exact threshold depends on the endpoint.
++  OAuth login endpoints enforce Cloudflare Workers native Rate Limiting
++  bindings, keyed by truncated client IP. Authenticated endpoints may use
++  separate application-level controls, such as pending-link limits.
 +
-+  Other endpoints listed in earlier drafts (API key regeneration, account linking,
-+  session management) are NOT yet rate-limited at the edge; they retain their
-+  application-level controls (e.g., 3 active pending links per user).
-+
-+  Implementation: Cloudflare Workers native Rate Limiting binding.
++  See the operation description for endpoint-specific limits.
 ```
 
 ## Diff 2 — `provider.yaml`
 
-No structural change. The `429` response continues to `$ref` `TooManyRequests.yaml`. The diff is captured in `TooManyRequests.yaml` above. If a separate, path-specific clarification is desired, the future-form would attach a `description` override at the `429:` key, but per simplicity-first this is omitted unless reviewers request it.
+No structural change. The `429` response continues to `$ref` `TooManyRequests.yaml`. The operation description adds: OAuth initiate is limited to 10 requests per configured 60-second Cloudflare Rate Limiting window, keyed by client IP truncated to /24 for IPv4 or /48 for IPv6.
 
 ## Diff 3 — `provider-callback.yaml`
 
-Same as Diff 2 — no structural change. Description text lives in the shared component.
+No structural change. The `429` response continues to `$ref` `TooManyRequests.yaml`. The operation description adds: OAuth callback is limited to 5 requests per configured 60-second Cloudflare Rate Limiting window, keyed by client IP truncated to /24 for IPv4 or /48 for IPv6, and enforced before state validation or provider token exchange.
 
 ## Generated-types impact
 

--- a/specs/058-oauth-rate-limiting/plan.md
+++ b/specs/058-oauth-rate-limiting/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Rate Limiting for OAuth Endpoints
+
+**Branch**: `058-oauth-rate-limiting` | **Date**: 2026-05-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/058-oauth-rate-limiting/spec.md`
+
+## Summary
+
+Add Cloudflare Workers Rate Limiting bindings for `GET /auth/:provider` (10/min/IP) and `GET /auth/:provider/callback` (5/min/IP) to prevent KV exhaustion and CPU abuse. Wire a thin middleware that calls the binding before any handler logic, emits a 429 with `Retry-After` on limit exceeded, and fails-open when the binding is missing.
+
+The OpenAPI schema already documents the 429 response and recommended limits (`schemas/components/responses/TooManyRequests.yaml`), so the schema changes are minimal: tighten the description on the two affected paths to make the enforced limits explicit, and add the `429` response to any auth path that doesn't already declare it.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022 target, Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (no schema change), KV (no schema change)
+**New binding**: Cloudflare Workers Rate Limiting (`unsafe.bindings.ratelimit` in `wrangler.toml`)
+**Testing**: Manual via `wrangler dev` + `tsc --noEmit`. End-to-end load test deferred to staging.
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (REST API)
+**Performance Goals**: <1ms CPU per rejected request; 10ms total per request remains the budget
+**Constraints**: Workers free tier 1,000 req/day for rate-limiter binding; D1 batch / KV write limits unchanged
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI schema already advertises 429 on both paths; schema updates are description-only. `npm run generate` runs before implementation. |
+| II. Cloudflare-Native | PASS | Uses native Rate Limiting binding (no custom KV counters). |
+| III. Type Safety | PASS | Binding type comes from `@cloudflare/workers-types`. `AuthEnv` / `Env` extended via generated types where possible. |
+| IV. Legal/Trademark | PASS | No WakaTime references. |
+| V. Simplicity First | PASS | One new middleware (~40 lines), two `wrangler.toml` entries, no new abstractions. Falls back to a no-op when binding is absent. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/058-oauth-rate-limiting/
+├── plan.md                # This file
+├── spec.md                # Feature specification
+├── research.md            # Phase 0 — rate-limiter binding research
+├── quickstart.md          # Manual verification recipe
+├── tasks.md               # Phase 2 output (/speckit.tasks)
+├── contracts/
+│   └── openapi-diff.md    # Description tightening for the two OAuth paths
+└── checklists/
+    └── requirements.md    # Acceptance checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── middleware/
+│   └── rate-limit.ts      # NEW: rateLimitMiddleware(binding, ruleName)
+├── routes/
+│   └── auth/
+│       └── login.ts       # Mount rateLimit on /:provider and /:provider/callback
+└── types.ts               # Extend Env with RATE_LIMIT_OAUTH_INITIATE / RATE_LIMIT_OAUTH_CALLBACK bindings
+
+wrangler.toml              # Add [[unsafe.bindings]] entries for both limiters
+schemas/paths/auth/
+├── provider.yaml          # Description: enforced 10/min/IP
+└── provider-callback.yaml # Description: enforced 5/min/IP
+```
+
+**Structure Decision**: Single-file middleware added under `src/middleware/`. Two binding entries under `[[unsafe.bindings]]` in `wrangler.toml`. No new routes, no DB migration.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. Use `[[unsafe.bindings]]` syntax (Workers Rate Limiting API is still under the unsafe namespace in compatibility_date 2025-03-09).
+2. Key derivation: `CF-Connecting-IP` → truncate to /24 (IPv4) or /48 (IPv6).
+3. Fail-open on missing binding (development ergonomics > strict enforcement).
+
+## Phase 1 — Design Outputs
+
+### Middleware contract
+
+```ts
+// src/middleware/rate-limit.ts
+export function rateLimitMiddleware(
+  getBinding: (env: Env) => RateLimit | undefined,
+  ruleName: string,
+): MiddlewareHandler<{ Bindings: Env }>;
+```
+
+The middleware:
+1. Reads `CF-Connecting-IP` (falling back to `c.req.header("X-Forwarded-For")` first hop for local dev).
+2. Truncates the IP per FR-006.
+3. Calls `binding.limit({ key })`. If `success: false`, returns 429 with `Retry-After`, `Cache-Control: no-store`, `Pragma: no-cache`.
+4. If binding is undefined, logs once and calls `next()`.
+
+### Binding config
+
+```toml
+# wrangler.toml — add to existing file
+[[unsafe.bindings]]
+name = "RATE_LIMIT_OAUTH_INITIATE"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }
+
+[[unsafe.bindings]]
+name = "RATE_LIMIT_OAUTH_CALLBACK"
+type = "ratelimit"
+namespace_id = "1002"
+simple = { limit = 5, period = 60 }
+```
+
+### OpenAPI diff
+
+See [contracts/openapi-diff.md](./contracts/openapi-diff.md). Both paths already declare 429; only the description text changes from "Recommended" to "Enforced" with the chosen values.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md) (generated by `/speckit.tasks`).
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/058-oauth-rate-limiting/plan.md
+++ b/specs/058-oauth-rate-limiting/plan.md
@@ -7,19 +7,19 @@
 
 Add Cloudflare Workers Rate Limiting bindings for `GET /auth/:provider` (10/min/IP) and `GET /auth/:provider/callback` (5/min/IP) to prevent KV exhaustion and CPU abuse. Wire a thin middleware that calls the binding before any handler logic, emits a 429 with `Retry-After` on limit exceeded, and fails-open when the binding is missing.
 
-The OpenAPI schema already documents the 429 response and recommended limits (`schemas/components/responses/TooManyRequests.yaml`), so the schema changes are minimal: tighten the description on the two affected paths to make the enforced limits explicit, and add the `429` response to any auth path that doesn't already declare it.
+The OpenAPI schema already documents the 429 response via a shared component, so the schema changes are minimal: keep the shared `TooManyRequests` component generic and add endpoint-specific enforced limits to the two affected OAuth operation descriptions.
 
 ## Technical Context
 
 **Language/Version**: TypeScript (ES2022 target, Cloudflare Workers runtime)
 **Primary Dependencies**: Hono >= 4.9.7
 **Storage**: D1 (no schema change), KV (no schema change)
-**New binding**: Cloudflare Workers Rate Limiting (`unsafe.bindings.ratelimit` in `wrangler.toml`)
+**New binding**: Cloudflare Workers Rate Limiting (`[[ratelimits]]` in `wrangler.toml`)
 **Testing**: Manual via `wrangler dev` + `tsc --noEmit`. End-to-end load test deferred to staging.
 **Target Platform**: Cloudflare Workers (edge compute)
 **Project Type**: Web service (REST API)
 **Performance Goals**: <1ms CPU per rejected request; 10ms total per request remains the budget
-**Constraints**: Workers free tier 1,000 req/day for rate-limiter binding; D1 batch / KV write limits unchanged
+**Constraints**: D1 batch / KV write limits unchanged; operators must verify current Cloudflare plan limits before production deployment
 
 ## Constitution Check
 
@@ -61,18 +61,18 @@ src/
 │       └── login.ts       # Mount rateLimit on /:provider and /:provider/callback
 └── types.ts               # Extend Env with RATE_LIMIT_OAUTH_INITIATE / RATE_LIMIT_OAUTH_CALLBACK bindings
 
-wrangler.toml              # Add [[unsafe.bindings]] entries for both limiters
+wrangler.toml              # Add [[ratelimits]] entries for both limiters
 schemas/paths/auth/
 ├── provider.yaml          # Description: enforced 10/min/IP
 └── provider-callback.yaml # Description: enforced 5/min/IP
 ```
 
-**Structure Decision**: Single-file middleware added under `src/middleware/`. Two binding entries under `[[unsafe.bindings]]` in `wrangler.toml`. No new routes, no DB migration.
+**Structure Decision**: Single-file middleware added under `src/middleware/`. Two binding entries under `[[ratelimits]]` in `wrangler.toml`. No new routes, no DB migration.
 
 ## Phase 0 — Research Outputs
 
 See [research.md](./research.md). Key decisions:
-1. Use `[[unsafe.bindings]]` syntax (Workers Rate Limiting API is still under the unsafe namespace in compatibility_date 2025-03-09).
+1. Use `[[ratelimits]]` syntax (current Cloudflare Workers Rate Limiting binding configuration for Wrangler 4.36+).
 2. Key derivation: `CF-Connecting-IP` → truncate to /24 (IPv4) or /48 (IPv6).
 3. Fail-open on missing binding (development ergonomics > strict enforcement).
 
@@ -98,22 +98,24 @@ The middleware:
 
 ```toml
 # wrangler.toml — add to existing file
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "RATE_LIMIT_OAUTH_INITIATE"
-type = "ratelimit"
 namespace_id = "1001"
-simple = { limit = 10, period = 60 }
+  [ratelimits.simple]
+  limit = 10
+  period = 60
 
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "RATE_LIMIT_OAUTH_CALLBACK"
-type = "ratelimit"
 namespace_id = "1002"
-simple = { limit = 5, period = 60 }
+  [ratelimits.simple]
+  limit = 5
+  period = 60
 ```
 
 ### OpenAPI diff
 
-See [contracts/openapi-diff.md](./contracts/openapi-diff.md). Both paths already declare 429; only the description text changes from "Recommended" to "Enforced" with the chosen values.
+See [contracts/openapi-diff.md](./contracts/openapi-diff.md). Both paths already declare 429; only description text changes. Endpoint-specific enforced limits live in the two OAuth operation descriptions, while the shared 429 response component remains generic for other endpoints that also reference it.
 
 ## Phase 2 — Implementation Tasks
 

--- a/specs/058-oauth-rate-limiting/quickstart.md
+++ b/specs/058-oauth-rate-limiting/quickstart.md
@@ -5,7 +5,7 @@ This guide walks through manually verifying the rate-limit behavior introduced b
 ## Prerequisites
 
 - `wrangler` CLI authenticated against the target account.
-- `wrangler.toml` contains the two `[[unsafe.bindings]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`).
+- `wrangler.toml` contains the two `[[ratelimits]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`).
 - The worker is deployed (or running via `wrangler dev` with `--remote` so the rate-limiter binding is real, not stubbed).
 - A test provider OAuth app is configured (the request never needs to complete OAuth — we just need a real provider parameter such as `github`).
 
@@ -16,7 +16,7 @@ WORKER_URL="https://cloudtime.example.dev"
 
 # Send 12 requests as fast as the network allows; capture status only.
 for i in $(seq 1 12); do
-  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/auth/github"
+  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/api/v1/auth/github"
 done
 echo
 ```
@@ -26,7 +26,7 @@ echo
 Verification points:
 1. The first 10 responses are 302 redirects to GitHub.
 2. The 11th and 12th responses are 429.
-3. `curl -i $WORKER_URL/auth/github` after the limit hits returns:
+3. `curl -i $WORKER_URL/api/v1/auth/github` after the limit hits returns:
    - `HTTP/2 429`
    - `retry-after: 60`
    - `cache-control: no-store`
@@ -39,7 +39,7 @@ Verification points:
 WORKER_URL="https://cloudtime.example.dev"
 
 for i in $(seq 1 7); do
-  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/auth/github/callback?state=x&code=y"
+  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/api/v1/auth/github/callback?state=x&code=y"
 done
 echo
 ```
@@ -59,7 +59,7 @@ wrangler dev --local
 
 # In another terminal:
 for i in $(seq 1 30); do
-  curl -s -o /dev/null -w "%{http_code} " http://localhost:8787/auth/github
+  curl -s -o /dev/null -w "%{http_code} " http://localhost:8787/api/v1/auth/github
 done
 echo
 ```
@@ -77,7 +77,7 @@ Requires a client with a known IPv6 prefix. Using `curl --interface` from a `/48
 
 ```bash
 # IPv6 source: 2001:db8:abcd:1234::1
-curl -6 "$WORKER_URL/auth/github" # ×10 from the same /48
+curl -6 "$WORKER_URL/api/v1/auth/github" # ×10 from the same /48
 ```
 
 Verification points:
@@ -108,7 +108,7 @@ Verification points:
 To disable rate limiting without redeploying code:
 
 ```bash
-# Comment out the [[unsafe.bindings]] entries in wrangler.toml, then:
+# Comment out the [[ratelimits]] entries in wrangler.toml, then:
 wrangler deploy
 ```
 
@@ -119,11 +119,12 @@ The middleware will fail-open (Scenario C behavior) and emit the one-time warnin
 To change limits without code changes, edit the `simple` rule in `wrangler.toml`:
 
 ```toml
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "RATE_LIMIT_OAUTH_INITIATE"
-type = "ratelimit"
 namespace_id = "1001"
-simple = { limit = 20, period = 60 } # was 10 — bumped to 20
+  [ratelimits.simple]
+  limit = 20 # was 10 — bumped to 20
+  period = 60
 ```
 
 Then redeploy. No code change required.

--- a/specs/058-oauth-rate-limiting/quickstart.md
+++ b/specs/058-oauth-rate-limiting/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart: Verify OAuth Rate Limiting
+
+This guide walks through manually verifying the rate-limit behavior introduced by this feature. It assumes PR2 (implementation) is deployed to a Cloudflare Workers environment with the new bindings configured.
+
+## Prerequisites
+
+- `wrangler` CLI authenticated against the target account.
+- `wrangler.toml` contains the two `[[unsafe.bindings]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`).
+- The worker is deployed (or running via `wrangler dev` with `--remote` so the rate-limiter binding is real, not stubbed).
+- A test provider OAuth app is configured (the request never needs to complete OAuth — we just need a real provider parameter such as `github`).
+
+## Scenario A — Initiate endpoint limit (10/60s)
+
+```bash
+WORKER_URL="https://cloudtime.example.dev"
+
+# Send 12 requests as fast as the network allows; capture status only.
+for i in $(seq 1 12); do
+  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/auth/github"
+done
+echo
+```
+
+**Expected output**: `302 302 302 302 302 302 302 302 302 302 429 429`
+
+Verification points:
+1. The first 10 responses are 302 redirects to GitHub.
+2. The 11th and 12th responses are 429.
+3. `curl -i $WORKER_URL/auth/github` after the limit hits returns:
+   - `HTTP/2 429`
+   - `retry-after: 60`
+   - `cache-control: no-store`
+   - body: `{"error":"Too many requests"}`
+4. After 60 seconds, the same client can send another 10 requests successfully.
+
+## Scenario B — Callback endpoint limit (5/60s)
+
+```bash
+WORKER_URL="https://cloudtime.example.dev"
+
+for i in $(seq 1 7); do
+  curl -s -o /dev/null -w "%{http_code} " "$WORKER_URL/auth/github/callback?state=x&code=y"
+done
+echo
+```
+
+**Expected output**: `400 400 400 400 400 429 429`
+
+Verification points:
+1. The first 5 responses are 400 (invalid state — expected, since we passed `state=x`).
+2. The 6th and 7th are 429 — the limiter rejects before state validation.
+3. No KV entries named `oauth:state:x` are written for any of the 7 requests (state was invalid for all).
+
+## Scenario C — Fail-open in local dev (no binding)
+
+```bash
+# Run worker locally WITHOUT the rate-limit binding configured.
+wrangler dev --local
+
+# In another terminal:
+for i in $(seq 1 30); do
+  curl -s -o /dev/null -w "%{http_code} " http://localhost:8787/auth/github
+done
+echo
+```
+
+**Expected output**: All 30 are 302 (or 500 if OAuth secrets aren't set locally — but never 429).
+
+Verification points:
+1. Worker logs contain exactly one occurrence of:
+   `[rate-limit] binding RATE_LIMIT_OAUTH_INITIATE is undefined; failing open for this isolate`
+2. Subsequent requests in the same isolate do NOT re-emit the warning.
+
+## Scenario D — IPv6 client truncation
+
+Requires a client with a known IPv6 prefix. Using `curl --interface` from a `/48`-assigned host:
+
+```bash
+# IPv6 source: 2001:db8:abcd:1234::1
+curl -6 "$WORKER_URL/auth/github" # ×10 from the same /48
+```
+
+Verification points:
+1. All 10 requests share a single rate-limit counter (i.e., the limiter sees them as one key).
+2. After the 10th, the next request returns 429.
+3. A request from a *different* /48 (e.g., `2001:db8:abcd:5678::1` if both prefixes are reachable) is **not** rate-limited.
+
+## Scenario E — Log shape (PII check)
+
+After triggering a 429 in any scenario above, inspect Worker logs:
+
+```bash
+wrangler tail
+```
+
+Expected log line shape:
+```
+[rate-limit] rejected endpoint=oauth-initiate rule=RATE_LIMIT_OAUTH_INITIATE key=203.0.113.0/24
+```
+
+Verification points:
+1. The log line contains the truncated IP only, not the full IP.
+2. No occurrences of `state=`, `code=`, `session=`, or any cookie value in the rejected request's logs.
+3. Exactly one log line per rejected request (no duplicates).
+
+## Reverting
+
+To disable rate limiting without redeploying code:
+
+```bash
+# Comment out the [[unsafe.bindings]] entries in wrangler.toml, then:
+wrangler deploy
+```
+
+The middleware will fail-open (Scenario C behavior) and emit the one-time warning.
+
+## Tuning thresholds
+
+To change limits without code changes, edit the `simple` rule in `wrangler.toml`:
+
+```toml
+[[unsafe.bindings]]
+name = "RATE_LIMIT_OAUTH_INITIATE"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 20, period = 60 } # was 10 — bumped to 20
+```
+
+Then redeploy. No code change required.

--- a/specs/058-oauth-rate-limiting/research.md
+++ b/specs/058-oauth-rate-limiting/research.md
@@ -1,0 +1,105 @@
+# Research: Rate Limiting for OAuth Endpoints
+
+## Decision 1: Use Cloudflare Workers Rate Limiting binding (native), not custom KV counters
+
+**Decision**: Bind the Workers Rate Limiting API via `[[unsafe.bindings]]` in `wrangler.toml`.
+
+**Rationale**:
+- The Rate Limiting binding lives in Cloudflare's edge data plane. It performs the counter increment + check inline with the request, without consuming Worker CPU for the storage round-trip. Latency is single-digit milliseconds at the edge.
+- Custom KV-based counters cost two KV operations per request (one read, one write), each counted against the free-tier 1,000/day write budget — defeating the original goal of protecting the KV write budget from abuse.
+- D1-backed counters would block the request on a SQL round-trip and conflict with the 10ms CPU budget on Workers free tier.
+- The `TooManyRequests.yaml` component already specifies "Implementation: Use Cloudflare Workers native Rate Limiting binding." — the Constitution-style direction is set.
+
+**Alternatives considered**:
+1. **KV INCR pattern**: rejected — counts against the KV write budget that we are trying to protect.
+2. **Durable Objects counter**: rejected — adds a paid-only dependency for a problem the native binding solves.
+3. **In-memory per-isolate counter**: rejected — Workers isolates are not stable; cardinality is unbounded across cold starts.
+
+---
+
+## Decision 2: `[[unsafe.bindings]]` syntax with `simple` rule type
+
+**Decision**: Use the `[[unsafe.bindings]]` table with `type = "ratelimit"` and a `simple` rule configuration.
+
+**Rationale**:
+- As of compatibility_date 2025-03-09 (the current pin in `wrangler.toml`), the Rate Limiting binding is exposed under `unsafe.bindings`. Cloudflare uses the `unsafe` prefix for bindings that are stable in production but whose configuration shape may still evolve.
+- The `simple` rule provides a fixed window with `limit` (requests) and `period` (seconds). This matches FR-001/FR-002 (10/60 and 5/60).
+- `namespace_id` must be a unique integer per binding within the account. We pick `1001` (initiate) and `1002` (callback) to leave room for future bindings.
+
+**Alternatives considered**:
+1. **Single binding with composite key**: rejected — Cloudflare's rate-limit API is keyed inside the binding, so two separate bindings give cleaner observability and let us tune limits independently without redeploying both.
+2. **Wait for a stable (non-`unsafe`) binding name**: rejected — would block the feature for an unbounded time; the API surface is documented and stable for production use.
+
+---
+
+## Decision 3: IP key derivation and truncation
+
+**Decision**: Use `CF-Connecting-IP` (Cloudflare's edge-set header), truncating IPv4 to /24 and IPv6 to /48.
+
+**Rationale**:
+- `CF-Connecting-IP` is the canonical source for the client IP behind Cloudflare. It is set by the edge and cannot be forged by clients.
+- IPv4 /24 truncation (e.g., `203.0.113.42` → `203.0.113.0`) prevents trivial single-IP bypass while accommodating shared NAT environments at ISP scale.
+- IPv6 /48 is the IETF-recommended customer-prefix size (RFC 6177). Truncating to /48 prevents an attacker on a /48 allocation from cycling individual /128 addresses to defeat the limit.
+- Truncated keys also keep log cardinality manageable.
+
+**Fallback**: If `CF-Connecting-IP` is absent (e.g., local `wrangler dev`), fall back to `X-Forwarded-For` (first hop) and finally to a constant `"unknown"` key. In the constant-fallback case, the limiter effectively becomes a global rate limit — acceptable for dev, surfaced via the fail-open log.
+
+**Alternatives considered**:
+1. **Full IP as key**: rejected — too easy to bypass with IPv6 prefix rotation; high log cardinality.
+2. **Hash the IP**: rejected — defeats prefix-based aggregation and complicates debugging.
+
+---
+
+## Decision 4: Fail-open when binding is undefined
+
+**Decision**: If the rate-limit binding is missing at runtime (e.g., `RATE_LIMIT_OAUTH_INITIATE` is `undefined` because the dev environment has no `unsafe.bindings` configured), the middleware allows the request and emits a single warning log on first occurrence.
+
+**Rationale**:
+- Local development should not require Cloudflare account setup. Fail-closed (returning 500/503 when the binding is missing) would force every contributor to configure rate-limit bindings just to run `wrangler dev`.
+- A startup warning is sufficient to alert operators that production deployment is incomplete; the warning is rate-limited to once per isolate to avoid log spam.
+- This is consistent with the existing `noCacheHeaders()` pattern in this codebase — defensive but unobtrusive.
+
+**Alternatives considered**:
+1. **Fail-closed**: rejected — operationally hostile for development.
+2. **Soft-warn on every request**: rejected — log spam in dev.
+
+---
+
+## Decision 5: 429 response shape
+
+**Decision**: `429 Too Many Requests` with `Retry-After: <seconds>`, `Cache-Control: no-store`, `Pragma: no-cache`, JSON body `{"error": "Too many requests"}`.
+
+**Rationale**:
+- Matches the existing `TooManyRequests.yaml` response component.
+- Aligns with `Retry-After` semantics in RFC 7231 §7.1.3 (integer seconds).
+- `Cache-Control: no-store` prevents intermediate caches (browser bfcache, Cloudflare cache) from serving cached 429s past the window.
+
+**Retry-After value**: For a fixed window of 60 seconds, the binding does not expose remaining-window seconds directly. We return a conservative `Retry-After: 60` — overestimating is safer than underestimating (clients won't retry too early).
+
+**Alternatives considered**:
+1. **Returning remaining-window seconds**: rejected — the `simple` rule type does not expose this. Could be added later if Cloudflare exposes it.
+
+---
+
+## Decision 6: Middleware mounts at the route level (not global)
+
+**Decision**: Apply the rate-limit middleware to `GET /auth/:provider` and `GET /auth/:provider/callback` only, not globally in `src/index.ts`.
+
+**Rationale**:
+- Heartbeat ingestion (`POST /heartbeats`) is authenticated by API key and protected by separate flow controls; rate-limiting it at the edge would risk blocking legitimate batch ingestion from editor plugins.
+- Mounting at the route level keeps the dependency on the binding scoped to OAuth code, simplifying tests and future removal/rotation.
+
+**Alternatives considered**:
+1. **Global rate-limit on all `/auth/*`**: rejected — `/auth/session`, `/auth/api-key`, etc. are authenticated and have different threat models.
+2. **Global rate-limit on the entire Worker**: rejected — would interfere with heartbeat batches.
+
+---
+
+## Decision 7: OpenAPI schema change is description-only
+
+**Decision**: Tighten the `description` on the `429` block in `provider.yaml` and `provider-callback.yaml` from "Recommended" to "Enforced", and tighten the description on `TooManyRequests.yaml` to match the implemented values.
+
+**Rationale**:
+- The 429 response and `Retry-After` header are already declared in the schema; the implementation makes the documented behavior real.
+- No new response codes, no new headers, no new schemas. `npm run generate` produces a no-op or near-no-op for `src/types/generated.ts`.
+- Keeping the OpenAPI change description-only respects the SDD principle that schema changes precede implementation, while not introducing real type churn.

--- a/specs/058-oauth-rate-limiting/research.md
+++ b/specs/058-oauth-rate-limiting/research.md
@@ -2,13 +2,13 @@
 
 ## Decision 1: Use Cloudflare Workers Rate Limiting binding (native), not custom KV counters
 
-**Decision**: Bind the Workers Rate Limiting API via `[[unsafe.bindings]]` in `wrangler.toml`.
+**Decision**: Bind the Workers Rate Limiting API via `[[ratelimits]]` in `wrangler.toml`.
 
 **Rationale**:
 - The Rate Limiting binding lives in Cloudflare's edge data plane. It performs the counter increment + check inline with the request, without consuming Worker CPU for the storage round-trip. Latency is single-digit milliseconds at the edge.
 - Custom KV-based counters cost two KV operations per request (one read, one write), each counted against the free-tier 1,000/day write budget — defeating the original goal of protecting the KV write budget from abuse.
 - D1-backed counters would block the request on a SQL round-trip and conflict with the 10ms CPU budget on Workers free tier.
-- The `TooManyRequests.yaml` component already specifies "Implementation: Use Cloudflare Workers native Rate Limiting binding." — the Constitution-style direction is set.
+- The OpenAPI and SpecKit artifacts specify Cloudflare Workers native Rate Limiting; the shared `TooManyRequests.yaml` response stays generic because multiple endpoint classes reference it.
 
 **Alternatives considered**:
 1. **KV INCR pattern**: rejected — counts against the KV write budget that we are trying to protect.
@@ -17,18 +17,18 @@
 
 ---
 
-## Decision 2: `[[unsafe.bindings]]` syntax with `simple` rule type
+## Decision 2: `[[ratelimits]]` syntax with `simple` rule type
 
-**Decision**: Use the `[[unsafe.bindings]]` table with `type = "ratelimit"` and a `simple` rule configuration.
+**Decision**: Use the Wrangler `[[ratelimits]]` table with a `simple` rule configuration.
 
 **Rationale**:
-- As of compatibility_date 2025-03-09 (the current pin in `wrangler.toml`), the Rate Limiting binding is exposed under `unsafe.bindings`. Cloudflare uses the `unsafe` prefix for bindings that are stable in production but whose configuration shape may still evolve.
-- The `simple` rule provides a fixed window with `limit` (requests) and `period` (seconds). This matches FR-001/FR-002 (10/60 and 5/60).
-- `namespace_id` must be a unique integer per binding within the account. We pick `1001` (initiate) and `1002` (callback) to leave room for future bindings.
+- The current Cloudflare Workers Rate Limiting binding documentation uses `[[ratelimits]]` for Wrangler 4.36.0 and later. This repository currently locks Wrangler 4.71.0, so PR2 should use the stable documented configuration shape instead of the older experimental `unsafe.bindings` form.
+- The `simple` rule provides a fixed window with `limit` (requests) and `period` (seconds). This matches FR-001/FR-002 (10/60 and 5/60) when the requirements are phrased as Cloudflare-configured windows rather than sliding windows.
+- `namespace_id` must be a positive integer string unique per binding within the account. We pick `"1001"` (initiate) and `"1002"` (callback) to leave room for future bindings.
 
 **Alternatives considered**:
 1. **Single binding with composite key**: rejected — Cloudflare's rate-limit API is keyed inside the binding, so two separate bindings give cleaner observability and let us tune limits independently without redeploying both.
-2. **Wait for a stable (non-`unsafe`) binding name**: rejected — would block the feature for an unbounded time; the API surface is documented and stable for production use.
+2. **Older `[[unsafe.bindings]]` form**: rejected — it is experimental in Wrangler 4.71.0 and no longer matches current Cloudflare documentation for Rate Limiting bindings.
 
 ---
 
@@ -52,7 +52,7 @@
 
 ## Decision 4: Fail-open when binding is undefined
 
-**Decision**: If the rate-limit binding is missing at runtime (e.g., `RATE_LIMIT_OAUTH_INITIATE` is `undefined` because the dev environment has no `unsafe.bindings` configured), the middleware allows the request and emits a single warning log on first occurrence.
+**Decision**: If the rate-limit binding is missing at runtime (e.g., `RATE_LIMIT_OAUTH_INITIATE` is `undefined` because the dev environment has no `[[ratelimits]]` binding configured), the middleware allows the request and emits a single warning log on first occurrence.
 
 **Rationale**:
 - Local development should not require Cloudflare account setup. Fail-closed (returning 500/503 when the binding is missing) would force every contributor to configure rate-limit bindings just to run `wrangler dev`.
@@ -97,9 +97,10 @@
 
 ## Decision 7: OpenAPI schema change is description-only
 
-**Decision**: Tighten the `description` on the `429` block in `provider.yaml` and `provider-callback.yaml` from "Recommended" to "Enforced", and tighten the description on `TooManyRequests.yaml` to match the implemented values.
+**Decision**: Keep `TooManyRequests.yaml` generic and add endpoint-specific enforced limit text to the `provider.yaml` and `provider-callback.yaml` operation descriptions.
 
 **Rationale**:
 - The 429 response and `Retry-After` header are already declared in the schema; the implementation makes the documented behavior real.
-- No new response codes, no new headers, no new schemas. `npm run generate` produces a no-op or near-no-op for `src/types/generated.ts`.
+- The shared `TooManyRequests.yaml` component is also referenced by non-login endpoints such as API key regeneration and account-linking paths, so OAuth-specific thresholds do not belong in the shared response description.
+- No new response codes, no new headers, no new schemas. `npm run generate` produces JSDoc-only changes in `src/types/generated.ts`.
 - Keeping the OpenAPI change description-only respects the SDD principle that schema changes precede implementation, while not introducing real type churn.

--- a/specs/058-oauth-rate-limiting/spec.md
+++ b/specs/058-oauth-rate-limiting/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Rate Limiting for OAuth Endpoints
+
+**Feature Branch**: `058-oauth-rate-limiting`
+**Created**: 2026-05-17
+**Status**: Draft
+**Input**: GitHub Issue #58 — Add rate limiting to OAuth endpoints (security label)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Protect OAuth initiate from KV exhaustion floods (Priority: P1)
+
+As an operator of a CloudTime instance, I want the OAuth initiate endpoint (`GET /auth/:provider`) to reject abusive request rates from a single IP, so that an attacker cannot exhaust the KV namespace by flooding `oauth:state:*` entries (each with a 10-minute TTL).
+
+Today, an unauthenticated attacker can hit `GET /auth/github` in a tight loop and generate one KV write per request, plus a Set-Cookie header. The free-tier KV write budget (1,000/day) can be exhausted in seconds, and the attack also wastes CPU on PKCE / state generation per call.
+
+**Why this priority**: This is the primary attack vector documented in Issue #58 — direct denial of service against shared infrastructure (KV write budget). The mitigation must land first because all other OAuth-related abuse scenarios depend on the initiate endpoint being accessible.
+
+**Independent Test**: Send 100 `GET /auth/github` requests from a single IP within one minute. Verify that requests after the 10th return `HTTP 429` with a `Retry-After` header, and that no further `oauth:state:*` KV entries are created until the limit window resets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh client IP, **When** it issues ≤10 `GET /auth/:provider` requests within a 60-second sliding window, **Then** each request returns `302` and creates exactly one `oauth:state:*` KV entry.
+2. **Given** a client IP that has issued 10 successful requests in the last 60 seconds, **When** the 11th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header indicating seconds until the window resets, and no KV write occurs.
+3. **Given** an IP previously rate-limited, **When** the 60-second window has fully elapsed, **Then** subsequent requests resume normally and increment a fresh counter.
+4. **Given** a request from an IP behind a Cloudflare-fronted CDN, **When** rate limiting evaluates the source, **Then** the originating client IP is used (via `CF-Connecting-IP`), not an intermediate proxy.
+
+---
+
+### User Story 2 - Protect OAuth callback from invalid-state CPU floods (Priority: P1)
+
+As an operator, I want `GET /auth/:provider/callback` to reject excessive request rates from a single IP, so that an attacker cannot waste CPU on cryptographic state validation and provider token-exchange attempts that will inevitably fail.
+
+The callback endpoint performs a constant-time state comparison, a KV lookup, and (if state validates) a remote HTTPS call to the provider's token endpoint. Mass invalid-state callbacks force the server to perform expensive constant-time checks; mass valid-state callbacks (e.g., from a compromised authorization flow) force the server to make provider API calls that count against the provider's per-app quota.
+
+**Why this priority**: The callback endpoint is more expensive per request than the initiate endpoint (multiple network round-trips on the happy path). Rate limiting here protects both the Workers CPU budget and the upstream provider's rate limits.
+
+**Independent Test**: Send 30 `GET /auth/github/callback?state=invalid&code=invalid` requests from a single IP within one minute. Verify that requests after the 5th return `429`, and that no token-exchange HTTPS call is made on the rate-limited requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh client IP, **When** it issues ≤5 `GET /auth/:provider/callback` requests within a 60-second sliding window, **Then** each request is processed (state validation runs, success or error returned).
+2. **Given** a client IP that has issued 5 callback requests in the last 60 seconds, **When** the 6th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header before performing state validation or provider API calls.
+3. **Given** a legitimate user who happens to retry the OAuth flow after a network hiccup, **When** their retry count stays within 5/min, **Then** the retry succeeds without being rate-limited.
+
+---
+
+### User Story 3 - Observability when rate limits engage (Priority: P2)
+
+As an operator, I want a structured log entry whenever a request is rejected by rate limiting, so that I can detect abuse patterns and tune thresholds.
+
+**Why this priority**: Without logs, operators cannot distinguish between legitimate traffic spikes and active abuse, and cannot decide whether to widen or narrow the limits.
+
+**Independent Test**: Trigger a 429 response and verify a single line is emitted to `console.warn` (or equivalent) containing the IP (hashed or truncated), endpoint, and limit name. The log MUST NOT contain the full state, code, or session cookie values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request is rejected by the OAuth initiate limiter, **When** the 429 is returned, **Then** exactly one warning log is emitted containing the endpoint identifier, the rate-limit key (IP, truncated to /24 for IPv4 or /48 for IPv6 to limit cardinality), and the rule name.
+2. **Given** a 429 response, **When** the log line is captured, **Then** it contains no PII beyond the truncated IP, no OAuth state, no code parameter, and no cookie values.
+
+---
+
+### Edge Cases
+
+- **Multi-instance deployments**: A user behind a corporate NAT may share an IP with many colleagues. The 10/min initiate limit must be generous enough that simultaneous logins from one NAT do not collide. The recommendation in `TooManyRequests.yaml` (10/min) is acceptable for this scenario.
+- **Legitimate retry storms**: A user with a flaky network may retry login 3-5 times in quick succession. The 5/min callback limit accommodates this. Tighter limits would block legitimate users.
+- **Bot/scanner traffic**: Cloudflare's bot protection runs upstream of Workers. Rate limiting in the Worker is a second layer for non-bot abusive traffic (e.g., scripted attacks from data-center IPs that Cloudflare's bot scoring may not catch).
+- **Free-tier rate-limiter quota**: Cloudflare Workers free plan includes 1,000 requests/day for the rate limiter binding. A self-hosted single-user instance is unlikely to exceed this; commercial deployments may need the paid plan.
+- **IPv6 client identification**: For IPv6 clients, the rate-limit key must use the /48 prefix (the standard assigned-to-customer block size) rather than the full 128-bit address, to prevent attackers from cycling through cheap /128 addresses inside a /48.
+- **Failed rate-limiter binding (graceful degradation)**: If the rate-limiter binding is unconfigured (e.g., local development), the middleware MUST fail-open (allow the request) rather than 500. A warning log is emitted on the first request only.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST apply a rate limit to `GET /auth/:provider` of 10 requests per 60-second sliding window, keyed by client IP (using `CF-Connecting-IP`, falling back to `Request.cf.colo` + remote address if absent).
+- **FR-002**: The system MUST apply a rate limit to `GET /auth/:provider/callback` of 5 requests per 60-second sliding window, keyed by client IP using the same key derivation as FR-001.
+- **FR-003**: When a rate limit is exceeded, the system MUST respond with HTTP `429 Too Many Requests`, a `Retry-After` header (seconds, integer), `Cache-Control: no-store`, `Pragma: no-cache`, and a JSON body `{"error": "Too many requests"}`.
+- **FR-004**: When a rate limit is exceeded, the system MUST NOT perform any KV write, D1 query, or provider HTTPS call associated with the rejected request.
+- **FR-005**: The rate-limiter check MUST run before CSRF middleware and before route handler logic, so that the cost of rejected requests stays under 1ms CPU.
+- **FR-006**: IPv4 keys MUST be truncated to /24, and IPv6 keys MUST be truncated to /48, when stored in the rate-limit counter and when emitted in logs.
+- **FR-007**: When a rate limit is exceeded, the system MUST emit exactly one structured warning log per rejected request, containing: timestamp, endpoint identifier, rule name, and truncated IP. The log MUST NOT contain OAuth state, code, cookie values, or user-identifiable data beyond the truncated IP.
+- **FR-008**: The rate-limiter binding MUST be optional in development. If the binding is not configured at startup, the middleware MUST fail-open (allow the request) and emit a single warning log on the first request only.
+- **FR-009**: The OpenAPI schema for both endpoints MUST advertise the `429` response (already present in the schema; this feature ensures the documented behavior is actually enforced).
+- **FR-010**: The rate limit MUST NOT apply to authenticated routes (`/heartbeats`, `/users/current`, etc.) — those are protected by API key auth and have their own access control. This feature scopes only to public OAuth endpoints.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Rate-limit check overhead MUST be under 1ms of Workers CPU time per request.
+- **NFR-002**: The implementation MUST use Cloudflare Workers' native Rate Limiting binding (no custom KV-based counter), per `TooManyRequests.yaml`.
+- **NFR-003**: Configuration values (window size, request budget) MUST live in `wrangler.toml` rather than source code, so that operators can adjust limits without redeploying the Worker logic.
+
+### Key Entities *(no database changes)*
+
+No new database tables or columns. The rate-limiter state is held entirely in Cloudflare's edge data plane via the binding.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At a request rate of 100 OAuth initiate calls/minute from a single IP, no more than 10 succeed; the remaining 90 return 429 with a `Retry-After` header.
+- **SC-002**: At a sustained 100 callback calls/minute from a single IP, no more than 5 reach state validation; the rest are rejected before KV access.
+- **SC-003**: Median CPU time per rejected request is under 1ms (measured via `Date.now()` deltas around the middleware).
+- **SC-004**: After enabling the feature, KV daily write counts on the production instance stay within 50% of the free-tier budget (500 writes/day) under normal usage — confirming that abuse vectors are no longer reaching the KV write path.
+- **SC-005**: Zero false-positive 429s reported by legitimate users during the first 30 days of deployment (measured via support reports or Cloudflare analytics).
+
+## Out of Scope
+
+- **Authenticated route rate limiting** (heartbeat ingestion, API key regeneration). These are independent concerns and will be tracked separately if needed.
+- **Per-user rate limits on PendingLink/account-linking flows**. The application-level limit (3 active pending links per user) already exists in `src/routes/auth/login.ts`. Adding edge rate limits there is optional and not blocking #58.
+- **Cloudflare WAF rules**. WAF is configured via the Cloudflare dashboard and is out of scope for a code change. Operators may choose to add complementary WAF rules.
+- **Rate limit dashboards/alerting**. Visibility beyond log warnings (e.g., Workers Analytics Engine queries) is a follow-up.

--- a/specs/058-oauth-rate-limiting/spec.md
+++ b/specs/058-oauth-rate-limiting/spec.md
@@ -19,8 +19,8 @@ Today, an unauthenticated attacker can hit `GET /auth/github` in a tight loop an
 
 **Acceptance Scenarios**:
 
-1. **Given** a fresh client IP, **When** it issues ≤10 `GET /auth/:provider` requests within a 60-second sliding window, **Then** each request returns `302` and creates exactly one `oauth:state:*` KV entry.
-2. **Given** a client IP that has issued 10 successful requests in the last 60 seconds, **When** the 11th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header indicating seconds until the window resets, and no KV write occurs.
+1. **Given** a fresh client IP, **When** it issues ≤10 `GET /auth/:provider` requests within the configured 60-second rate-limit window, **Then** each request returns `302` and creates exactly one `oauth:state:*` KV entry.
+2. **Given** a client IP that has issued 10 successful requests in the current 60-second rate-limit window, **When** the 11th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header, and no KV write occurs.
 3. **Given** an IP previously rate-limited, **When** the 60-second window has fully elapsed, **Then** subsequent requests resume normally and increment a fresh counter.
 4. **Given** a request from an IP behind a Cloudflare-fronted CDN, **When** rate limiting evaluates the source, **Then** the originating client IP is used (via `CF-Connecting-IP`), not an intermediate proxy.
 
@@ -38,8 +38,8 @@ The callback endpoint performs a constant-time state comparison, a KV lookup, an
 
 **Acceptance Scenarios**:
 
-1. **Given** a fresh client IP, **When** it issues ≤5 `GET /auth/:provider/callback` requests within a 60-second sliding window, **Then** each request is processed (state validation runs, success or error returned).
-2. **Given** a client IP that has issued 5 callback requests in the last 60 seconds, **When** the 6th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header before performing state validation or provider API calls.
+1. **Given** a fresh client IP, **When** it issues ≤5 `GET /auth/:provider/callback` requests within the configured 60-second rate-limit window, **Then** each request is processed (state validation runs, success or error returned).
+2. **Given** a client IP that has issued 5 callback requests in the current 60-second rate-limit window, **When** the 6th request arrives, **Then** the server returns `429 Too Many Requests` with a `Retry-After` header before performing state validation or provider API calls.
 3. **Given** a legitimate user who happens to retry the OAuth flow after a network hiccup, **When** their retry count stays within 5/min, **Then** the retry succeeds without being rate-limited.
 
 ---
@@ -61,10 +61,10 @@ As an operator, I want a structured log entry whenever a request is rejected by 
 
 ### Edge Cases
 
-- **Multi-instance deployments**: A user behind a corporate NAT may share an IP with many colleagues. The 10/min initiate limit must be generous enough that simultaneous logins from one NAT do not collide. The recommendation in `TooManyRequests.yaml` (10/min) is acceptable for this scenario.
+- **Multi-instance deployments**: A user behind a corporate NAT may share an IP with many colleagues. The chosen 10/min initiate limit must be generous enough that simultaneous logins from one NAT do not collide.
 - **Legitimate retry storms**: A user with a flaky network may retry login 3-5 times in quick succession. The 5/min callback limit accommodates this. Tighter limits would block legitimate users.
 - **Bot/scanner traffic**: Cloudflare's bot protection runs upstream of Workers. Rate limiting in the Worker is a second layer for non-bot abusive traffic (e.g., scripted attacks from data-center IPs that Cloudflare's bot scoring may not catch).
-- **Free-tier rate-limiter quota**: Cloudflare Workers free plan includes 1,000 requests/day for the rate limiter binding. A self-hosted single-user instance is unlikely to exceed this; commercial deployments may need the paid plan.
+- **Rate-limiter product limits**: Operators must confirm current Cloudflare plan and product limits before production deployment. A self-hosted single-user instance is expected to stay low-volume; commercial deployments may need paid capacity.
 - **IPv6 client identification**: For IPv6 clients, the rate-limit key must use the /48 prefix (the standard assigned-to-customer block size) rather than the full 128-bit address, to prevent attackers from cycling through cheap /128 addresses inside a /48.
 - **Failed rate-limiter binding (graceful degradation)**: If the rate-limiter binding is unconfigured (e.g., local development), the middleware MUST fail-open (allow the request) rather than 500. A warning log is emitted on the first request only.
 
@@ -74,8 +74,8 @@ As an operator, I want a structured log entry whenever a request is rejected by 
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST apply a rate limit to `GET /auth/:provider` of 10 requests per 60-second sliding window, keyed by client IP (using `CF-Connecting-IP`, falling back to `Request.cf.colo` + remote address if absent).
-- **FR-002**: The system MUST apply a rate limit to `GET /auth/:provider/callback` of 5 requests per 60-second sliding window, keyed by client IP using the same key derivation as FR-001.
+- **FR-001**: The system MUST apply a rate limit to `GET /auth/:provider` of 10 requests per configured 60-second Cloudflare Rate Limiting window, keyed by client IP (using `CF-Connecting-IP`, falling back to `X-Forwarded-For` first hop and then `"unknown"` if absent).
+- **FR-002**: The system MUST apply a rate limit to `GET /auth/:provider/callback` of 5 requests per configured 60-second Cloudflare Rate Limiting window, keyed by client IP using the same key derivation as FR-001.
 - **FR-003**: When a rate limit is exceeded, the system MUST respond with HTTP `429 Too Many Requests`, a `Retry-After` header (seconds, integer), `Cache-Control: no-store`, `Pragma: no-cache`, and a JSON body `{"error": "Too many requests"}`.
 - **FR-004**: When a rate limit is exceeded, the system MUST NOT perform any KV write, D1 query, or provider HTTPS call associated with the rejected request.
 - **FR-005**: The rate-limiter check MUST run before CSRF middleware and before route handler logic, so that the cost of rejected requests stays under 1ms CPU.
@@ -88,7 +88,7 @@ As an operator, I want a structured log entry whenever a request is rejected by 
 ### Non-Functional Requirements
 
 - **NFR-001**: Rate-limit check overhead MUST be under 1ms of Workers CPU time per request.
-- **NFR-002**: The implementation MUST use Cloudflare Workers' native Rate Limiting binding (no custom KV-based counter), per `TooManyRequests.yaml`.
+- **NFR-002**: The implementation MUST use Cloudflare Workers' native Rate Limiting binding (no custom KV-based counter), per the research decision.
 - **NFR-003**: Configuration values (window size, request budget) MUST live in `wrangler.toml` rather than source code, so that operators can adjust limits without redeploying the Worker logic.
 
 ### Key Entities *(no database changes)*
@@ -99,8 +99,8 @@ No new database tables or columns. The rate-limiter state is held entirely in Cl
 
 ### Measurable Outcomes
 
-- **SC-001**: At a request rate of 100 OAuth initiate calls/minute from a single IP, no more than 10 succeed; the remaining 90 return 429 with a `Retry-After` header.
-- **SC-002**: At a sustained 100 callback calls/minute from a single IP, no more than 5 reach state validation; the rest are rejected before KV access.
+- **SC-001**: At a sequential request rate of 100 OAuth initiate calls/minute from a single IP routed through one Cloudflare location, no more than 10 succeed in each configured 60-second window; the rest return 429 with a `Retry-After` header.
+- **SC-002**: At a sequential sustained 100 callback calls/minute from a single IP routed through one Cloudflare location, no more than 5 reach state validation in each configured 60-second window; the rest are rejected before KV access.
 - **SC-003**: Median CPU time per rejected request is under 1ms (measured via `Date.now()` deltas around the middleware).
 - **SC-004**: After enabling the feature, KV daily write counts on the production instance stay within 50% of the free-tier budget (500 writes/day) under normal usage — confirming that abuse vectors are no longer reaching the KV write path.
 - **SC-005**: Zero false-positive 429s reported by legitimate users during the first 30 days of deployment (measured via support reports or Cloudflare analytics).

--- a/specs/058-oauth-rate-limiting/tasks.md
+++ b/specs/058-oauth-rate-limiting/tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Rate Limiting for OAuth Endpoints
+
+**Branch**: `058-oauth-rate-limiting`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-17
+
+These tasks cover both PRs of the SpecKit 2-PR workflow. PR1 contains specs/schemas only (no implementation). PR2 contains middleware wiring, binding registration, and verification.
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `specs/058-oauth-rate-limiting/spec.md` covering FR-001 through FR-010, NFRs, and success criteria.
+- [x] **T-002**: Author `plan.md` with Constitution Check, structure, and phase outputs.
+- [x] **T-003**: Author `research.md` documenting binding choice, IP truncation, fail-open behavior.
+- [x] **T-004**: Author `quickstart.md` with scenarios A–E for manual verification.
+- [x] **T-005**: Author `contracts/openapi-diff.md` summarizing description-only changes.
+- [x] **T-006**: Author `checklists/requirements.md` (acceptance gate).
+- [x] **T-007**: Tighten `schemas/components/responses/TooManyRequests.yaml` description from "Recommended" to enforced values (10/60s, 5/60s) for the OAuth start/callback rows.
+- [x] **T-008**: Tighten 429 description blocks in `schemas/paths/auth/provider.yaml` and `schemas/paths/auth/provider-callback.yaml` to state the enforced limit.
+- [x] **T-009**: Run `npm run generate` to regenerate `src/types/generated.ts`. Verify the diff is description-only (no shape changes).
+- [x] **T-010**: Commit PR1 (`spec:`/`docs:` prefix), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Binding registration
+
+- [ ] **T-101**: Add two `[[unsafe.bindings]]` entries to `wrangler.toml`:
+  - `RATE_LIMIT_OAUTH_INITIATE` (`namespace_id = "1001"`, `simple = { limit = 10, period = 60 }`)
+  - `RATE_LIMIT_OAUTH_CALLBACK` (`namespace_id = "1002"`, `simple = { limit = 5, period = 60 }`)
+- [ ] **T-102**: Extend the `Env` type in `src/types.ts` to declare the two optional bindings (`?: RateLimit`). Use the `@cloudflare/workers-types` `RateLimit` type if exported; otherwise declare a minimal local interface matching `{ limit(opts: { key: string }): Promise<{ success: boolean }> }`.
+
+### Middleware
+
+- [ ] **T-103**: Create `src/middleware/rate-limit.ts` exporting `rateLimitMiddleware(getBinding, ruleName)`. Implementation:
+  1. Extract `CF-Connecting-IP` (fall back to `X-Forwarded-For` first hop, then `"unknown"`).
+  2. Truncate IPv4 to /24, IPv6 to /48.
+  3. If binding is absent, log once per isolate and call `next()`.
+  4. Otherwise, call `binding.limit({ key })`. On `success: false`, return 429 with `Retry-After: 60`, `Cache-Control: no-store`, `Pragma: no-cache`, body `{"error": "Too many requests"}`.
+  5. On exceeded, emit a single warning log: `[rate-limit] rejected endpoint=<rule> key=<truncated>`.
+- [ ] **T-104**: Add unit-style tests in middleware via `tsc --noEmit` + manual `wrangler dev`. No automated test infra exists yet in this repo, so verification is captured in quickstart.md.
+
+### Route wiring
+
+- [ ] **T-105**: In `src/routes/auth/login.ts`, import the middleware and mount it on both routes:
+  ```ts
+  login.get(
+    "/:provider",
+    rateLimitMiddleware((env) => env.RATE_LIMIT_OAUTH_INITIATE, "oauth-initiate"),
+    handler,
+  );
+  login.get(
+    "/:provider/callback",
+    rateLimitMiddleware((env) => env.RATE_LIMIT_OAUTH_CALLBACK, "oauth-callback"),
+    handler,
+  );
+  ```
+- [ ] **T-106**: Verify the middleware runs before any KV/D1 access (place it before any provider validation logic in the chain).
+
+### Verification
+
+- [ ] **T-107**: Run `npx tsc --noEmit` — must pass with zero errors.
+- [ ] **T-108**: Deploy to a staging environment, run all five scenarios in `quickstart.md`, attach results to the PR.
+- [ ] **T-109**: Confirm `wrangler dev` (local, no remote bindings) prints the fail-open warning exactly once and serves requests normally.
+
+### Documentation
+
+- [ ] **T-110**: Update `docs/cloudflare-constraints.md` to mention the new rate-limiter bindings and the daily-request budget on the free plan.
+
+### PR2 submission
+
+- [ ] **T-111**: Commit with `fix:` prefix (security fix). Push branch, open PR against `develop` referencing this spec.
+
+## Dependencies
+
+```
+T-001 … T-009 → T-010 (PR1 merge)
+T-010 → T-101 … T-111 (PR2 work cannot start until PR1 is merged)
+T-103 → T-105 (middleware must exist before mounting)
+T-101 → T-105 (binding must be declared before mounting)
+T-105 → T-107 → T-108 (compile then verify)
+```
+
+## Out of scope (do not implement in this feature)
+
+- Authenticated route rate limits (heartbeat ingestion, API key regeneration). Tracked as future work.
+- Cloudflare WAF rules. Configured via dashboard, not code.
+- Workers Analytics Engine integration for rate-limit metrics. Future enhancement.

--- a/specs/058-oauth-rate-limiting/tasks.md
+++ b/specs/058-oauth-rate-limiting/tasks.md
@@ -14,8 +14,8 @@ These tasks cover both PRs of the SpecKit 2-PR workflow. PR1 contains specs/sche
 - [x] **T-004**: Author `quickstart.md` with scenarios A–E for manual verification.
 - [x] **T-005**: Author `contracts/openapi-diff.md` summarizing description-only changes.
 - [x] **T-006**: Author `checklists/requirements.md` (acceptance gate).
-- [x] **T-007**: Tighten `schemas/components/responses/TooManyRequests.yaml` description from "Recommended" to enforced values (10/60s, 5/60s) for the OAuth start/callback rows.
-- [x] **T-008**: Tighten 429 description blocks in `schemas/paths/auth/provider.yaml` and `schemas/paths/auth/provider-callback.yaml` to state the enforced limit.
+- [x] **T-007**: Update `schemas/components/responses/TooManyRequests.yaml` to generic endpoint-dependent language so non-OAuth endpoints do not inherit OAuth-specific thresholds.
+- [x] **T-008**: Add endpoint-specific rate-limit language in `schemas/paths/auth/provider.yaml` and `schemas/paths/auth/provider-callback.yaml` to state the enforced limits.
 - [x] **T-009**: Run `npm run generate` to regenerate `src/types/generated.ts`. Verify the diff is description-only (no shape changes).
 - [x] **T-010**: Commit PR1 (`spec:`/`docs:` prefix), push, open PR against `develop`.
 
@@ -23,9 +23,9 @@ These tasks cover both PRs of the SpecKit 2-PR workflow. PR1 contains specs/sche
 
 ### Binding registration
 
-- [ ] **T-101**: Add two `[[unsafe.bindings]]` entries to `wrangler.toml`:
-  - `RATE_LIMIT_OAUTH_INITIATE` (`namespace_id = "1001"`, `simple = { limit = 10, period = 60 }`)
-  - `RATE_LIMIT_OAUTH_CALLBACK` (`namespace_id = "1002"`, `simple = { limit = 5, period = 60 }`)
+- [ ] **T-101**: Add two `[[ratelimits]]` entries to `wrangler.toml`:
+  - `RATE_LIMIT_OAUTH_INITIATE` (`namespace_id = "1001"`, `[ratelimits.simple] limit = 10, period = 60`)
+  - `RATE_LIMIT_OAUTH_CALLBACK` (`namespace_id = "1002"`, `[ratelimits.simple] limit = 5, period = 60`)
 - [ ] **T-102**: Extend the `Env` type in `src/types.ts` to declare the two optional bindings (`?: RateLimit`). Use the `@cloudflare/workers-types` `RateLimit` type if exported; otherwise declare a minimal local interface matching `{ limit(opts: { key: string }): Promise<{ success: boolean }> }`.
 
 ### Middleware
@@ -63,7 +63,7 @@ These tasks cover both PRs of the SpecKit 2-PR workflow. PR1 contains specs/sche
 
 ### Documentation
 
-- [ ] **T-110**: Update `docs/cloudflare-constraints.md` to mention the new rate-limiter bindings and the daily-request budget on the free plan.
+- [ ] **T-110**: Update `docs/cloudflare-constraints.md` to mention the new rate-limiter bindings and instruct operators to verify current Cloudflare plan limits before production deployment.
 
 ### PR2 submission
 

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -1501,12 +1501,16 @@ export interface components {
             };
         };
         /**
-         * @description Rate limit exceeded. Recommended limits:
-         *     - OAuth start/callback: 10 req/min per IP
-         *     - API key regeneration: 3 req/min per user
-         *     - Account linking: 5 req/min per user
-         *     - Session management: 30 req/min per user
-         *     Implementation: Use Cloudflare Workers native Rate Limiting binding.
+         * @description Rate limit exceeded. Limits enforced by this implementation:
+         *     - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6).
+         *     - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation).
+         *
+         *     Other endpoints listed in earlier drafts (API key regeneration, account linking,
+         *     session management) are NOT yet rate-limited at the edge; they retain their
+         *     application-level controls (for example, 3 active pending links per user).
+         *
+         *     Implementation: Cloudflare Workers native Rate Limiting binding (see
+         *     `specs/058-oauth-rate-limiting/`).
          */
         TooManyRequests: {
             headers: {

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -42,6 +42,10 @@ export interface paths {
          *     - GitHub App: "Email addresses: Read-only" permission (set at app registration, not per-request)
          *     - Google: `openid email profile`
          *     - Discord: `identify email`
+         *
+         *     **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
+         *     Limiting binding. Limit: 10 requests per configured 60-second window, keyed
+         *     by client IP truncated to /24 for IPv4 or /48 for IPv6.
          */
         get: operations["oauthRedirect"];
         put?: never;
@@ -115,6 +119,11 @@ export interface paths {
          *     **Response headers for defense in depth:**
          *     - `Referrer-Policy: no-referrer` — prevents authorization code leakage via Referer header.
          *     - `Cache-Control: no-store` — prevents caching of authentication responses.
+         *
+         *     **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
+         *     Limiting binding before state validation or provider token exchange. Limit:
+         *     5 requests per configured 60-second window, keyed by client IP truncated to
+         *     /24 for IPv4 or /48 for IPv6.
          */
         get: operations["oauthCallback"];
         put?: never;
@@ -1501,16 +1510,12 @@ export interface components {
             };
         };
         /**
-         * @description Rate limit exceeded. Limits enforced by this implementation:
-         *     - OAuth initiate (`GET /auth/:provider`): 10 req/min per IP (truncated /24 for IPv4, /48 for IPv6).
-         *     - OAuth callback (`GET /auth/:provider/callback`): 5 req/min per IP (same key derivation).
+         * @description Rate limit exceeded. The exact threshold depends on the endpoint.
+         *     OAuth login endpoints enforce Cloudflare Workers native Rate Limiting
+         *     bindings, keyed by truncated client IP. Authenticated endpoints may use
+         *     separate application-level controls, such as pending-link limits.
          *
-         *     Other endpoints listed in earlier drafts (API key regeneration, account linking,
-         *     session management) are NOT yet rate-limited at the edge; they retain their
-         *     application-level controls (for example, 3 active pending links per user).
-         *
-         *     Implementation: Cloudflare Workers native Rate Limiting binding (see
-         *     `specs/058-oauth-rate-limiting/`).
+         *     See the operation description for endpoint-specific limits.
          */
         TooManyRequests: {
             headers: {


### PR DESCRIPTION
## Summary

PR1 of the SpecKit 2-PR workflow for [Issue #58](https://github.com/sudolifeagain/cloudtime/issues/58) — adding rate limiting to OAuth endpoints.

This PR contains **specs and schema only** — no implementation. Implementation lands in PR2 after this is merged, per CLAUDE.md SDD rules.

## Scope

### SpecKit artifacts (new)
- `specs/058-oauth-rate-limiting/spec.md` — FR-001..FR-010, NFRs, success criteria, edge cases
- `specs/058-oauth-rate-limiting/plan.md` — Constitution Check, structure, design outputs
- `specs/058-oauth-rate-limiting/research.md` — 7 decisions documented (binding choice, IP truncation, fail-open, etc.)
- `specs/058-oauth-rate-limiting/quickstart.md` — 5 manual verification scenarios (A–E)
- `specs/058-oauth-rate-limiting/tasks.md` — PR1/PR2 task split with dependencies
- `specs/058-oauth-rate-limiting/contracts/openapi-diff.md` — schema-change rationale
- `specs/058-oauth-rate-limiting/checklists/requirements.md` — PR1/PR2/post-deploy gates

### Schema change (description-only)
- `schemas/components/responses/TooManyRequests.yaml` — description updated from "Recommended" to "Enforced", with the concrete enforced limits (OAuth initiate 10/min/IP, OAuth callback 5/min/IP) and the IP truncation rule (/24 for IPv4, /48 for IPv6).
- `src/types/generated.ts` — regenerated; JSDoc-only diff, no type shape changes.

## Chosen limits (per `TooManyRequests.yaml`)

| Endpoint | Limit | Window | Key |
|---|---|---|---|
| `GET /auth/:provider` | 10 | 60s | `CF-Connecting-IP` truncated to /24 (IPv4) or /48 (IPv6) |
| `GET /auth/:provider/callback` | 5 | 60s | same key derivation |

## Out of scope

- Implementation (`src/middleware/rate-limit.ts`, `wrangler.toml` bindings, route wiring) — PR2
- Authenticated-route rate limiting (heartbeats, API key regeneration) — future work
- Cloudflare WAF rules — out-of-code configuration

## Test plan

- [ ] Verify only `specs/058-oauth-rate-limiting/**`, `schemas/components/responses/TooManyRequests.yaml`, and `src/types/generated.ts` are touched
- [ ] Verify `src/types/generated.ts` diff contains only JSDoc/description changes — no type shape changes
- [ ] CI passes (`tsc --noEmit`)
- [ ] PR1 contains no changes under `src/middleware/`, `src/routes/`, or `wrangler.toml`

## Follow-up

After this PR merges, open PR2 from a fresh branch implementing the middleware, `wrangler.toml` bindings, and route wiring per `tasks.md` § PR2.

Closes part 1 of #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)