### PR TITLE
fix: enforce OAuth rate limits via Cloudflare bindings (PR2/2) #58

### DIFF
--- a/docs/cloudflare-constraints.md
+++ b/docs/cloudflare-constraints.md
@@ -124,6 +124,30 @@ Queues are paid-only ($0.40/million messages) but provide reliable async process
 | Caching | KV for auth + status bar | KV for auth + status bar + heartbeat buffer |
 | CPU budget | Keep per-request under 10ms | 30s budget, more room |
 
+## Rate Limiting on OAuth Endpoints
+
+Cloudflare Workers' native Rate Limiting binding protects the OAuth login surface
+from abuse (KV exhaustion, CPU floods). Two bindings are declared in `wrangler.toml`:
+
+| Binding | Endpoint | Limit | Window | Key |
+|---|---|---|---|---|
+| `RATE_LIMIT_OAUTH_INITIATE` | `GET /api/v1/auth/:provider` | 10 | 60s | client IP truncated to /24 (IPv4) or /48 (IPv6) |
+| `RATE_LIMIT_OAUTH_CALLBACK` | `GET /api/v1/auth/:provider/callback` | 5 | 60s | same key derivation |
+
+The middleware (`src/middleware/rate-limit.ts`) reads `CF-Connecting-IP`,
+falls back to `X-Forwarded-For` first hop, and finally to `"unknown"`. When the
+binding is unconfigured (typical for `wrangler dev --local`), the middleware
+fails open and emits a single warning per isolate.
+
+**Operator action before production deploy**: confirm the current Cloudflare
+plan supports the configured Rate Limiting bindings. The free tier includes
+a usage-capped allowance for the Workers Rate Limiting API; commercial
+deployments may need a paid plan. Adjust `limit`/`period` in `wrangler.toml`
+without code changes.
+
+See `specs/058-oauth-rate-limiting/` for the full spec, design, and
+verification scenarios.
+
 ## Implementation Notes
 
 - Start with the simplest approach (direct D1 batch insert, simple Cron aggregation)

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -3,12 +3,46 @@ import type { Env, RateLimit } from "../types";
 
 const warned = new WeakSet<object>();
 
+function stripIpDecoration(ip: string): string {
+  const trimmed = ip.trim();
+  if (trimmed.startsWith("[") && trimmed.includes("]")) {
+    return trimmed.slice(1, trimmed.indexOf("]"));
+  }
+  return trimmed;
+}
+
+function normalizeHextet(group: string): string | undefined {
+  if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return undefined;
+  return parseInt(group, 16).toString(16);
+}
+
+function truncateIpv6(ip: string): string | undefined {
+  const withoutZone = stripIpDecoration(ip).split("%", 1)[0].toLowerCase();
+  const compressed = withoutZone.split("::");
+  if (compressed.length > 2) return undefined;
+
+  const head = compressed[0] ? compressed[0].split(":") : [];
+  const prefix: string[] = [];
+
+  for (const group of head.slice(0, 3)) {
+    const normalized = normalizeHextet(group);
+    if (!normalized) return undefined;
+    prefix.push(normalized);
+  }
+
+  if (prefix.length < 3 && compressed.length === 2) {
+    while (prefix.length < 3) prefix.push("0");
+  }
+
+  if (prefix.length !== 3) return undefined;
+  return `${prefix.join(":")}::/48`;
+}
+
 function truncateIp(ip: string): string {
   if (ip.includes(":")) {
-    const groups = ip.split(":");
-    return `${groups.slice(0, 3).join(":")}::/48`;
+    return truncateIpv6(ip) ?? ip;
   }
-  const parts = ip.split(".");
+  const parts = stripIpDecoration(ip).split(".");
   if (parts.length !== 4) return ip;
   return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
 }
@@ -28,6 +62,7 @@ function getClientIp(headers: Headers): string {
 
 export function rateLimitMiddleware(
   getBinding: (env: Env) => RateLimit | undefined,
+  endpointName: string,
   ruleName: string,
 ) {
   return createMiddleware<{ Bindings: Env }>(async (c, next) => {
@@ -36,7 +71,7 @@ export function rateLimitMiddleware(
     if (!binding) {
       if (!warned.has(c.env as object)) {
         warned.add(c.env as object);
-        console.warn(`[rate-limit] binding for ${ruleName} is undefined; failing open for this isolate`);
+        console.warn(`[rate-limit] binding ${ruleName} is undefined; failing open for this isolate`);
       }
       return next();
     }
@@ -46,7 +81,7 @@ export function rateLimitMiddleware(
 
     if (success) return next();
 
-    console.warn(`[rate-limit] rejected endpoint=${ruleName} key=${key}`);
+    console.warn(`[rate-limit] rejected endpoint=${endpointName} rule=${ruleName} key=${key}`);
     return c.json({ error: "Too many requests" }, 429, {
       "Retry-After": "60",
       "Cache-Control": "no-store",

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,0 +1,56 @@
+import { createMiddleware } from "hono/factory";
+import type { Env, RateLimit } from "../types";
+
+const warned = new WeakSet<object>();
+
+function truncateIp(ip: string): string {
+  if (ip.includes(":")) {
+    const groups = ip.split(":");
+    return `${groups.slice(0, 3).join(":")}::/48`;
+  }
+  const parts = ip.split(".");
+  if (parts.length !== 4) return ip;
+  return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+}
+
+function getClientIp(headers: Headers): string {
+  const cfip = headers.get("CF-Connecting-IP");
+  if (cfip) return cfip.trim();
+
+  const xff = headers.get("X-Forwarded-For");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  return "unknown";
+}
+
+export function rateLimitMiddleware(
+  getBinding: (env: Env) => RateLimit | undefined,
+  ruleName: string,
+) {
+  return createMiddleware<{ Bindings: Env }>(async (c, next) => {
+    const binding = getBinding(c.env);
+
+    if (!binding) {
+      if (!warned.has(c.env as object)) {
+        warned.add(c.env as object);
+        console.warn(`[rate-limit] binding for ${ruleName} is undefined; failing open for this isolate`);
+      }
+      return next();
+    }
+
+    const key = truncateIp(getClientIp(c.req.raw.headers));
+    const { success } = await binding.limit({ key });
+
+    if (success) return next();
+
+    console.warn(`[rate-limit] rejected endpoint=${ruleName} key=${key}`);
+    return c.json({ error: "Too many requests" }, 429, {
+      "Retry-After": "60",
+      "Cache-Control": "no-store",
+      Pragma: "no-cache",
+    });
+  });
+}

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -5,6 +5,7 @@
  */
 import { Hono } from "hono";
 import type { Env } from "../../types";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import {
   sha256Hex,
   generateCodeVerifier,
@@ -37,8 +38,17 @@ import { getRedirectUri, noCacheHeaders } from "./helpers";
 
 const login = new Hono<{ Bindings: Env }>();
 
+const oauthInitiateRateLimit = rateLimitMiddleware(
+  (env) => env.RATE_LIMIT_OAUTH_INITIATE,
+  "oauth-initiate",
+);
+const oauthCallbackRateLimit = rateLimitMiddleware(
+  (env) => env.RATE_LIMIT_OAUTH_CALLBACK,
+  "oauth-callback",
+);
+
 // GET /:provider (initiate OAuth login)
-login.get("/:provider", async (c) => {
+login.get("/:provider", oauthInitiateRateLimit, async (c) => {
   const provider = c.req.param("provider");
   if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400, noCacheHeaders());
 
@@ -62,7 +72,7 @@ login.get("/:provider", async (c) => {
 });
 
 // GET /:provider/callback (OAuth callback — most complex)
-login.get("/:provider/callback", async (c) => {
+login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
   const provider = c.req.param("provider");
   if (!isValidProvider(provider)) return c.json({ error: "Invalid provider" }, 400, noCacheHeaders());
 

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -41,10 +41,12 @@ const login = new Hono<{ Bindings: Env }>();
 const oauthInitiateRateLimit = rateLimitMiddleware(
   (env) => env.RATE_LIMIT_OAUTH_INITIATE,
   "oauth-initiate",
+  "RATE_LIMIT_OAUTH_INITIATE",
 );
 const oauthCallbackRateLimit = rateLimitMiddleware(
   (env) => env.RATE_LIMIT_OAUTH_CALLBACK,
   "oauth-callback",
+  "RATE_LIMIT_OAUTH_CALLBACK",
 );
 
 // GET /:provider (initiate OAuth login)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,18 @@ export interface Env {
   // Public origin for OAuth redirect URIs (e.g., "https://time.example.com")
   // If unset, derived from request Host header (safe behind Cloudflare, risky with custom proxies)
   APP_URL?: string;
+
+  // Rate-limit bindings (optional — middleware fails open when undefined)
+  RATE_LIMIT_OAUTH_INITIATE?: RateLimit;
+  RATE_LIMIT_OAUTH_CALLBACK?: RateLimit;
+}
+
+// Minimal shape of Cloudflare Workers Rate Limiting binding. The official
+// `@cloudflare/workers-types` v4 does not export this name yet (still under
+// the unsafe namespace at compatibility_date 2025-03-09), so we declare the
+// surface we actually call.
+export interface RateLimit {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
 }
 
 // Hono environment with authenticated user context

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,3 +32,19 @@ INSTANCE_MODE = "single"
 # DISCORD_CLIENT_ID
 # DISCORD_CLIENT_SECRET
 # ENCRYPTION_KEY          - AES-256 key (64 hex chars) for encrypting OAuth tokens at rest
+
+# OAuth rate limits — see specs/058-oauth-rate-limiting/
+# Operators must verify current Cloudflare plan limits before production deployment.
+[[ratelimits]]
+name = "RATE_LIMIT_OAUTH_INITIATE"
+namespace_id = "1001"
+  [ratelimits.simple]
+  limit = 10
+  period = 60
+
+[[ratelimits]]
+name = "RATE_LIMIT_OAUTH_CALLBACK"
+namespace_id = "1002"
+  [ratelimits.simple]
+  limit = 5
+  period = 60


### PR DESCRIPTION
## Summary

PR2 of 2 for [Issue #58](https://github.com/sudolifeagain/cloudtime/issues/58) — implementation that wires the Cloudflare Workers Rate Limiting binding into the two unauthenticated OAuth login routes.

PR1 (#87, merged) contained the spec, plan, research, and OpenAPI description updates. This PR adds the code that enforces the documented behavior.

## What changes

| Path | Limit | Window | Key |
|---|---|---|---|
| `GET /api/v1/auth/:provider` | 10 | 60s | client IP truncated to /24 (IPv4) or /48 (IPv6) |
| `GET /api/v1/auth/:provider/callback` | 5 | 60s | same key derivation |

### Files
- **`wrangler.toml`** — two `[[ratelimits]]` entries (`RATE_LIMIT_OAUTH_INITIATE`, `RATE_LIMIT_OAUTH_CALLBACK`)
- **`src/types.ts`** — `Env` extended with optional `RateLimit` bindings + minimal `RateLimit` interface (workers-types v4 does not yet export this name)
- **`src/middleware/rate-limit.ts`** — new middleware (~55 LoC): client IP extraction, truncation, fail-open, 429 emission
- **`src/routes/auth/login.ts`** — mount the middleware on both OAuth routes; runs **before** any KV write or D1 access
- **`docs/cloudflare-constraints.md`** — operator guidance and pre-deploy checklist note

### Behavior
- Client IP from `CF-Connecting-IP` → `X-Forwarded-For` first hop → `"unknown"`.
- Limit exceeded → `429 Too Many Requests` with `Retry-After: 60`, `Cache-Control: no-store`, `Pragma: no-cache`, body `{"error":"Too many requests"}`.
- Single structured warning log per rejection: `[rate-limit] rejected endpoint=<endpoint> rule=<binding> key=<truncated>`. No PII beyond the truncated IP.
- Missing binding → fail open + one warning per isolate (local dev convenience).

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] **Scenario A** (per `specs/058-oauth-rate-limiting/quickstart.md`): 11th initiate request from one IP returns 429 with `Retry-After: 60`
- [ ] **Scenario B**: 6th callback request from one IP returns 429 before state validation (no KV `oauth:state:*` write)
- [ ] **Scenario C**: `wrangler dev --local` without bindings → fail-open + one warning, no 429s
- [ ] **Scenario D**: requests from the same IPv6 /48 share a counter
- [ ] **Scenario E**: 429 log contains truncated IP only, no `state=`, `code=`, or cookie values

Manual scenarios B–E require deployment to a staging environment with the bindings provisioned in the Cloudflare account; results will be attached as a comment after staging verification.

## Notes

- Operators must verify their Cloudflare plan supports the configured Rate Limiting bindings before production deploy. See `docs/cloudflare-constraints.md` § Rate Limiting on OAuth Endpoints.
- `RateLimit` interface is declared locally because `@cloudflare/workers-types` v4 does not yet export it at compatibility_date 2025-03-09. Replace with the upstream type once available.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
