### PR TITLE
spec: Google hosted domain restriction (PR1/2) #37

### DIFF
--- a/schemas/components/responses/Forbidden.yaml
+++ b/schemas/components/responses/Forbidden.yaml
@@ -1,0 +1,14 @@
+description: |
+  The authenticated principal is recognized but not authorized for this resource.
+  Common reasons:
+  - Single-user mode: registration closed (`/auth/:provider/callback`).
+  - Google hosted domain restriction: the Google account's domain does not match
+    `GOOGLE_HOSTED_DOMAIN` (`/auth/google/callback`).
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Account domain not allowed

--- a/schemas/paths/auth/provider-callback.yaml
+++ b/schemas/paths/auth/provider-callback.yaml
@@ -135,5 +135,7 @@ get:
                       after authenticating with their existing account. Expires in 1 hour.
     '400':
       $ref: ../../components/responses/BadRequest.yaml
+    '403':
+      $ref: ../../components/responses/Forbidden.yaml
     '429':
       $ref: ../../components/responses/TooManyRequests.yaml

--- a/schemas/paths/auth/provider.yaml
+++ b/schemas/paths/auth/provider.yaml
@@ -34,6 +34,12 @@ get:
     - Google: `openid email profile`
     - Discord: `identify email`
 
+    **Optional per-deployment restrictions:**
+    - Google: if the operator sets `GOOGLE_HOSTED_DOMAIN`, the authorization URL
+      includes `hd=<domain>` as a UX hint and the callback enforces the matching
+      `hd` claim on the validated id_token. Tokens with no `hd` claim (personal
+      Google accounts) or a non-matching `hd` are rejected with 403.
+
     **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
     Limiting binding. Limit: 10 requests per configured 60-second window, keyed
     by client IP truncated to /24 for IPv4 or /48 for IPv6.

--- a/specs/037-google-hosted-domain/checklists/requirements.md
+++ b/specs/037-google-hosted-domain/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Acceptance Checklist: Optional Google Hosted Domain Restriction
+
+This checklist enforces the gate between PR1 (spec) and PR2 (implementation), and the gate between PR2 and production deployment.
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [ ] `spec.md` covers FR-001 through FR-008 with no `[NEEDS CLARIFICATION]` markers.
+- [ ] `plan.md` Constitution Check has all five principles marked PASS.
+- [ ] `research.md` documents the `hd`-vs-query-param distinction, case sensitivity, and fail-closed default.
+- [ ] `tasks.md` separates PR1 from PR2 tasks and lists dependencies.
+- [ ] `contracts/openapi-diff.md` shows additive changes (new `Forbidden.yaml`, `403` reference on the callback path, one description line on the initiate path).
+- [ ] `schemas/components/responses/Forbidden.yaml` exists and follows the shape of `Unauthorized.yaml` / `BadRequest.yaml`.
+- [ ] `schemas/paths/auth/provider-callback.yaml` references `Forbidden.yaml` under `'403'`.
+- [ ] `schemas/paths/auth/provider.yaml` description mentions `GOOGLE_HOSTED_DOMAIN`.
+- [ ] `npm run generate` runs cleanly. `git diff src/types/generated.ts` shows only additive changes (new 403 response type and operation entry).
+- [ ] PR1 contains no changes under `src/utils/oauth.ts`, `src/routes/auth/`, `src/types.ts`, or `wrangler.toml` beyond doc comments.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+- [ ] `src/types.ts` declares `GOOGLE_HOSTED_DOMAIN?: string` on `Env`.
+- [ ] `src/utils/oauth.ts` Google branch of `buildAuthorizeUrl` sets `hd=<env value>` only when the env var is truthy.
+- [ ] `src/utils/oauth.ts` exports `HostedDomainError` and throws it from `validateGoogleIdToken` after all other claim validations.
+- [ ] `src/routes/auth/login.ts` callback catch block returns 403 with `{"error": "Account domain not allowed"}` and `noCacheHeaders()` on `HostedDomainError`.
+- [ ] `wrangler.toml` documents the optional `GOOGLE_HOSTED_DOMAIN` variable as a comment.
+- [ ] `npx tsc --noEmit` passes with zero errors.
+- [ ] Diff for GitHub and Discord paths is empty (no accidental cross-provider impact).
+
+### Behavior (per `quickstart.md`)
+- [ ] Scenario A: matching-domain user logs in successfully.
+- [ ] Scenario B: personal Gmail user receives 403; no DB row created.
+- [ ] Scenario C: different Workspace domain receives 403 with `reason=hd-mismatch`.
+- [ ] Scenario D: env var unset ⇒ byte-identical to pre-feature behavior.
+- [ ] Scenario E: mixed-case `GOOGLE_HOSTED_DOMAIN` value matches a lowercase `hd` claim.
+
+### Documentation
+- [ ] PR2 description references Issue #37, links back to PR1, and includes scenario results.
+
+## Post-deployment gate
+
+- [ ] First 24h after enabling `GOOGLE_HOSTED_DOMAIN`: monitor `wrangler tail` for unexpected `hd-mismatch` or `hd-missing` warnings (expected only for non-org accounts).
+- [ ] First 7d: zero support reports of legitimate org users blocked.
+- [ ] Operator runbook captures the "adding env var locks out non-org users" behavior.

--- a/specs/037-google-hosted-domain/contracts/openapi-diff.md
+++ b/specs/037-google-hosted-domain/contracts/openapi-diff.md
@@ -1,0 +1,82 @@
+# OpenAPI Schema Diff
+
+This feature adds one shared response component (`Forbidden`), references it from the Google callback path, and adds a single description line to the Google initiate path. No other path is touched.
+
+## Files touched
+
+1. `schemas/components/responses/Forbidden.yaml` — **new** shared 403 response component.
+2. `schemas/paths/auth/provider-callback.yaml` — reference the new component as `'403'`.
+3. `schemas/paths/auth/provider.yaml` — one-line description addition referencing `GOOGLE_HOSTED_DOMAIN`.
+
+## Diff 1 — new `Forbidden.yaml`
+
+```yaml
+description: |
+  The authenticated principal is recognized but not authorized for this resource.
+  Common reasons:
+  - Single-user mode: registration closed (`/auth/:provider/callback`).
+  - Google hosted domain restriction: the Google account's domain does not match
+    `GOOGLE_HOSTED_DOMAIN` (`/auth/google/callback`).
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Account domain not allowed
+```
+
+Mirrors the shape of the existing `Unauthorized.yaml` / `BadRequest.yaml` components.
+
+## Diff 2 — `provider-callback.yaml`
+
+Add the `403` response to the existing `responses:` block. No other change.
+
+```diff
+   responses:
+     '200':
+       description: Authentication successful
+       …
+     '400':
+       $ref: ../../components/responses/BadRequest.yaml
++    '403':
++      $ref: ../../components/responses/Forbidden.yaml
+     '429':
+       $ref: ../../components/responses/TooManyRequests.yaml
+```
+
+(Note: a 403 was already returned by `src/routes/auth/login.ts` for single-user mode "Registration closed" but was not documented. This PR makes the existing-and-new behavior contract-true.)
+
+## Diff 3 — `provider.yaml`
+
+One-line addition in the operation `description` block, between the existing scope notes and the security-measures list. No structural change.
+
+```diff
+   description: |
+     Redirects the user to the OAuth provider's authorization page.
+
++    **Optional per-deployment restrictions:**
++    - Google: if the operator sets `GOOGLE_HOSTED_DOMAIN`, the authorization URL
++      includes `hd=<domain>` as a UX hint and the callback enforces the matching
++      `hd` claim on the validated id_token. Tokens with no `hd` claim (personal
++      Google accounts) or a non-matching `hd` are rejected with 403.
+
+     **Security measures applied by the server:**
+     - …
+```
+
+## Generated-types impact
+
+`npm run generate` regenerates `src/types/generated.ts`. Two changes are expected:
+
+1. A new exported component type for the `Forbidden` response (additive, no break).
+2. The `oauthCallback` operation gains a `403` entry under `responses` (additive, no break).
+
+Both are additive and do not break any existing import sites.
+
+## SDD compliance note
+
+Per CLAUDE.md: *"`schemas/openapi.yaml` is the Single Source of Truth"* and *"Always update the spec BEFORE writing implementation code."*
+
+PR1 lands schema + spec. PR2 lands the `Env` type extension, the two-line edit in `src/utils/oauth.ts`, and the `instanceof HostedDomainError` branch in `src/routes/auth/login.ts`. No implementation code in PR1.

--- a/specs/037-google-hosted-domain/plan.md
+++ b/specs/037-google-hosted-domain/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Optional Google Hosted Domain Restriction
+
+**Branch**: `037-google-hosted-domain` | **Date**: 2026-05-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/037-google-hosted-domain/spec.md`
+
+## Summary
+
+Add an optional `GOOGLE_HOSTED_DOMAIN` environment variable. When set, the system (a) appends `hd=<domain>` to the Google authorization URL as a UX hint, and (b) — security-load-bearing — validates that the verified `id_token`'s `hd` claim matches the configured domain. On mismatch, return `403 Forbidden` and short-circuit before any DB write.
+
+The change is fully backward-compatible: with the env var unset (the default), behavior is byte-identical to the current implementation.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7, `jose` (already in use for Google JWT verification)
+**Storage**: D1 (no schema change), KV (no schema change)
+**New binding**: None — `GOOGLE_HOSTED_DOMAIN` is a regular `[vars]` entry or Worker secret
+**Testing**: Manual via `wrangler dev` + `tsc --noEmit`. The `hd` claim shape is well-documented and stable.
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (REST API)
+**Performance Goals**: <1ms added validation per Google callback (single string comparison)
+**Constraints**: Single-domain only (multi-domain explicitly out of scope)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI schema updates land in PR1 (description + 403 response). `npm run generate` runs before implementation. |
+| II. Cloudflare-Native | PASS | No new bindings. Uses existing `jose` JWT verification path. |
+| III. Type Safety | PASS | `Env` extended via `src/types.ts`. No hand-edits to `src/types/generated.ts`. |
+| IV. Legal/Trademark | PASS | No WakaTime references. |
+| V. Simplicity First | PASS | ~30 LoC change in `src/utils/oauth.ts`, ~5 LoC in `src/types.ts`. No new abstractions. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-google-hosted-domain/
+├── plan.md                # This file
+├── spec.md                # Feature specification
+├── research.md            # Phase 0 — hd claim, case sensitivity, threat model
+├── quickstart.md          # Manual verification recipe
+├── tasks.md               # PR1/PR2 task split
+├── contracts/
+│   └── openapi-diff.md    # 403 response + description updates
+└── checklists/
+    └── requirements.md    # Acceptance gates
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── types.ts                       # Add GOOGLE_HOSTED_DOMAIN?: string to Env
+└── utils/
+    └── oauth.ts                   # Extend buildAuthorizeUrl (Google branch) and validateGoogleIdToken
+
+wrangler.toml                      # Document optional GOOGLE_HOSTED_DOMAIN
+schemas/paths/auth/
+├── provider.yaml                  # Description: mention GOOGLE_HOSTED_DOMAIN
+└── provider-callback.yaml         # Add 403 response for domain mismatch
+```
+
+**Structure Decision**: Touches only the Google branch of two functions in `src/utils/oauth.ts`. No new files, no new routes, no DB migration.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **`hd` claim is the security gate, `hd` URL param is a hint.** Server-side verification on the signed `id_token` is the only trustworthy check.
+2. **Case-insensitive comparison** using `toLowerCase()` on both sides. ASCII only — IDN domains are out of scope (no real-world Workspace IDN customers).
+3. **Missing `hd` claim** (personal accounts) must fail closed when the env var is set. Workspace accounts always emit the claim; absence is signal, not error.
+4. **Reject before DB writes** — the existing `validateGoogleIdToken` flow already runs before any DB write in the callback. We add the check inside that function so the rejection propagates naturally via the existing error-handling path.
+
+## Phase 1 — Design Outputs
+
+### Code changes
+
+**`src/types.ts`** — extend Env:
+```ts
+GOOGLE_HOSTED_DOMAIN?: string;
+```
+
+**`src/utils/oauth.ts`** — two surgical edits:
+
+1. In `buildAuthorizeUrl` (Google branch, ~line 90):
+   ```ts
+   if (env.GOOGLE_HOSTED_DOMAIN) url.searchParams.set("hd", env.GOOGLE_HOSTED_DOMAIN);
+   ```
+
+2. In `validateGoogleIdToken` (~line 454), after signature/iss/aud/azp/nonce/at_hash validation, before reading `sub`:
+   ```ts
+   const requiredHd = env.GOOGLE_HOSTED_DOMAIN?.trim().toLowerCase();
+   if (requiredHd) {
+     const tokenHd =
+       typeof payload.hd === "string" ? payload.hd.trim().toLowerCase() : "";
+     if (tokenHd !== requiredHd) {
+       const reason = tokenHd ? "hd-mismatch" : "hd-missing";
+       console.warn(`[google-hosted-domain] rejected rule=google-hosted-domain reason=${reason} expected=${requiredHd}`);
+       throw new HostedDomainError();
+     }
+   }
+   ```
+
+3. Introduce `class HostedDomainError extends Error` (module-local) so the callback handler in `src/routes/auth/login.ts` can distinguish this from generic OAuth errors and emit a `403` instead of `500`. Place the `instanceof HostedDomainError` check in the existing callback try/catch.
+
+### OpenAPI diff
+
+- `schemas/paths/auth/provider-callback.yaml` — add `'403': $ref ../../components/responses/Forbidden.yaml` (or inline body if `Forbidden.yaml` doesn't exist; will check during PR1).
+- `schemas/paths/auth/provider.yaml` — add a single line in `description` referring to `GOOGLE_HOSTED_DOMAIN`.
+
+See [contracts/openapi-diff.md](./contracts/openapi-diff.md) for exact wording.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/037-google-hosted-domain/plan.md
+++ b/specs/037-google-hosted-domain/plan.md
@@ -104,7 +104,7 @@ GOOGLE_HOSTED_DOMAIN?: string;
    }
    ```
 
-3. Introduce `class HostedDomainError extends Error` (module-local) so the callback handler in `src/routes/auth/login.ts` can distinguish this from generic OAuth errors and emit a `403` instead of `500`. Place the `instanceof HostedDomainError` check in the existing callback try/catch.
+3. Introduce `class HostedDomainError extends Error` (module-local) so the callback handler in `src/routes/auth/login.ts` can distinguish this from generic OAuth errors and emit a `403` instead of `500`. Place the `instanceof HostedDomainError` check as the first statement in the existing callback catch block, before the generic `console.error`, so hosted-domain rejections emit only the structured warning required by FR-006.
 
 ### OpenAPI diff
 

--- a/specs/037-google-hosted-domain/quickstart.md
+++ b/specs/037-google-hosted-domain/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Verify Google Hosted Domain Restriction
+
+This guide walks through manually verifying the `GOOGLE_HOSTED_DOMAIN` behavior introduced by this feature. It assumes PR2 (implementation) is deployed.
+
+## Prerequisites
+
+- Google Cloud Console project with two test users available:
+  - A Google Workspace user under `<your-test-domain>` (e.g., `alice@example-corp.com`)
+  - A personal Gmail account (e.g., `tester+personal@gmail.com`)
+- CloudTime deployed to a Cloudflare Worker with Google OAuth secrets configured.
+- `wrangler` CLI authenticated.
+
+## Scenario A — Restriction enabled, matching domain ⇒ success
+
+```bash
+wrangler secret put GOOGLE_HOSTED_DOMAIN  # enter: example-corp.com
+wrangler deploy
+```
+
+Open `https://<your-worker>/api/v1/auth/google` in a browser. Complete OAuth as `alice@example-corp.com`.
+
+**Expected**:
+1. The browser is redirected to `https://accounts.google.com/o/oauth2/v2/auth?...&hd=example-corp.com&...` — the `hd` hint is present.
+2. The Google account picker defaults to Workspace accounts.
+3. After consent, the callback returns 200 (or sets a session cookie + redirects, depending on flow).
+4. A `users` row is created (or matched, for repeat login).
+
+## Scenario B — Restriction enabled, non-matching domain ⇒ 403
+
+Stay logged into Google as `alice@example-corp.com` initially, but on the consent screen, switch to or sign in with a personal `tester+personal@gmail.com` account (the user has the right to override `hd`).
+
+**Expected**:
+1. Google still completes the authorization flow and redirects to the callback.
+2. The callback returns:
+   - `HTTP/2 403`
+   - `cache-control: no-store`
+   - body: `{"error":"Account domain not allowed"}`
+3. No row is created in `users` or `oauth_accounts`. Verify with:
+   ```bash
+   wrangler d1 execute cloudtime-db --remote --command="SELECT id, email FROM users WHERE email = 'tester+personal@gmail.com'"
+   ```
+   Expected: 0 rows.
+4. Worker logs (`wrangler tail`) show exactly one line of shape:
+   `[google-hosted-domain] rejected rule=google-hosted-domain reason=hd-missing expected=example-corp.com`
+   The log MUST NOT contain `tester+personal@gmail.com`, the `id_token`, or the Google `sub`.
+
+## Scenario C — Restriction enabled, different Workspace domain ⇒ 403
+
+If you have a second Workspace domain available (e.g., `bob@other-corp.com`), repeat Scenario B with that user.
+
+**Expected**:
+- Same `403` response.
+- Log line shows `reason=hd-mismatch` (not `hd-missing`) and `expected=example-corp.com`.
+
+## Scenario D — Restriction disabled (env var unset) ⇒ all logins accepted
+
+```bash
+wrangler secret delete GOOGLE_HOSTED_DOMAIN
+wrangler deploy
+```
+
+Repeat Scenario B with a personal Gmail account.
+
+**Expected**:
+1. The authorization URL does **not** contain `hd=` (URL inspectable via browser dev tools or `curl -I`).
+2. The callback returns 200 (or normal flow) and creates/matches a `users` row.
+3. Behavior is byte-identical to pre-feature behavior.
+
+## Scenario E — Case-insensitive comparison
+
+```bash
+wrangler secret put GOOGLE_HOSTED_DOMAIN  # enter: Example-Corp.COM (mixed case)
+wrangler deploy
+```
+
+Complete OAuth as `alice@example-corp.com`.
+
+**Expected**:
+- Login succeeds. Case-insensitive comparison treats `Example-Corp.COM` (config) and `example-corp.com` (token claim) as equal.
+
+## Scenario F — TypeScript compile check
+
+```bash
+npx tsc --noEmit
+```
+
+**Expected**: Exit code 0, no errors.
+
+## Reverting
+
+```bash
+wrangler secret delete GOOGLE_HOSTED_DOMAIN
+wrangler deploy
+```
+
+Or set to empty (functionally equivalent for the runtime check, but `delete` is cleaner).
+
+## Notes for operators
+
+- **You cannot retrofit this onto an existing instance with mixed-domain users.** Adding the env var after onboarding will silently block any user whose `hd` does not match. Communicate the change before rolling out.
+- **The single-user mode "Registration closed" 403 and the hosted-domain 403 share the same HTTP status but different error bodies.** Operators reading logs/responses should distinguish on body content.
+- **Multi-domain support is not provided.** If your organization owns multiple Workspace domains, place the Worker behind Cloudflare Access or another upstream filter and leave `GOOGLE_HOSTED_DOMAIN` unset.

--- a/specs/037-google-hosted-domain/research.md
+++ b/specs/037-google-hosted-domain/research.md
@@ -1,0 +1,100 @@
+# Research: Optional Google Hosted Domain Restriction
+
+## Decision 1: `hd` claim on the `id_token` is the security gate
+
+**Decision**: Server-side verification of the `hd` claim on the **validated** `id_token` is the only authoritative restriction. The `hd` query parameter on the authorization URL is treated as a UX hint only.
+
+**Rationale**:
+- The `hd` query parameter is consumed by Google's authorization page as a default selection. A user can manually edit the URL or start authorization from another entry point, so it cannot be relied on for access control.
+- The `hd` claim in the `id_token` is signed by Google's keys (RS256). After our existing JWT signature verification (`verifyGoogleJwt` via `jose`), the claim is trustworthy. We add the check after signature/iss/aud/azp/nonce/at_hash, never before.
+- For Workspace accounts, Google emits `hd: <primary domain>` in the `id_token`. For personal accounts, the `hd` claim is absent. Absence ≠ error; absence simply means "not a Workspace account."
+
+**Alternatives considered**:
+1. **Trust the `hd` query param**: rejected — trivially forgeable.
+2. **Validate the user's email domain instead of `hd`**: rejected — email domain can be aliased; `hd` is the canonical Workspace identifier and is what Google's own documentation recommends.
+
+---
+
+## Decision 2: Case-insensitive comparison, ASCII only
+
+**Decision**: Compare both sides with `toLowerCase()` on plain ASCII strings.
+
+**Rationale**:
+- DNS domains are case-insensitive by RFC 1035 §2.3.3. Google's `hd` claim is always lowercase, but allowing the operator to set `GOOGLE_HOSTED_DOMAIN=Company.COM` is operator-friendly.
+- `toLowerCase()` is locale-sensitive in theory (Turkish dotless I edge case) but harmless for ASCII-only domain strings. We do not perform any locale-sensitive normalization.
+- Internationalized Domain Names (IDN, e.g., `xn--bcher-kva.example`) are out of scope. Google Workspace customers using IDN are exceptionally rare; if encountered, the operator can configure the punycode form.
+
+**Alternatives considered**:
+1. **Strict case-sensitive comparison**: rejected — operator-hostile (`GOOGLE_HOSTED_DOMAIN=Company.com` failing silently is exactly the kind of trap we should avoid).
+2. **Full Unicode-aware normalization**: rejected — adds dependency and complexity for a non-existent customer cohort.
+
+---
+
+## Decision 3: Missing `hd` claim ⇒ 403 (fail closed)
+
+**Decision**: When `GOOGLE_HOSTED_DOMAIN` is set, a token with no `hd` claim (personal account) is treated as a domain mismatch and rejected with 403.
+
+**Rationale**:
+- The operator's intent in setting the env var is "only organization accounts." Personal Google accounts (no `hd` claim) are not organization accounts.
+- Fail-closed is the correct default for security restrictions.
+- The rejection reason distinguishes `hd-missing` vs `hd-mismatch` in logs so operators can see whether attempted abuse comes from personal accounts vs different Workspace domains.
+
+**Alternatives considered**:
+1. **Allow tokens with no `hd` claim**: rejected — defeats the purpose of the restriction.
+2. **Treat as 400 (client error)**: rejected — 403 is the standard response for "valid request, but principal not authorized." 400 implies a malformed request.
+
+---
+
+## Decision 4: Throw a dedicated error class, handle in the callback
+
+**Decision**: Introduce `class HostedDomainError extends Error` module-locally in `src/utils/oauth.ts`. The existing `try/catch` in `src/routes/auth/login.ts` adds an `instanceof HostedDomainError` branch returning 403.
+
+**Rationale**:
+- Keeps `validateGoogleIdToken` returning a uniform `ProviderUserInfo` or throwing — matches current style.
+- Avoids polluting `ProviderUserInfo` with a "rejected by policy" sentinel.
+- The catch site (`login.ts` callback) is the right layer to translate domain rejection into an HTTP response, alongside the existing OAuth-error / email-not-verified branches.
+
+**Alternatives considered**:
+1. **Return a sentinel value from `validateGoogleIdToken`**: rejected — pollutes return type.
+2. **Return early from the callback before calling `validateGoogleIdToken`**: rejected — we cannot inspect `hd` before signature verification, which lives inside `validateGoogleIdToken`.
+
+---
+
+## Decision 5: Place the check after all existing claim validation
+
+**Decision**: The `hd` check runs after `iss`, `aud`, `azp`, `nonce`, and `at_hash` validation, immediately before the `sub` read.
+
+**Rationale**:
+- Signature verification must complete first or the `hd` value isn't trustworthy.
+- Other claim validations are cheap and provide better attack signal: if any of those fail, the attacker is doing more sophisticated abuse than a domain bypass.
+- Putting `hd` last keeps the security ordering: structural validity → cryptographic validity → identity claims → authorization claims.
+
+**Alternatives considered**:
+1. **Run `hd` check first**: rejected — incorrect ordering (cannot trust unsigned claims).
+2. **Run between signature and `nonce`**: rejected — `nonce` mismatch is more critical (token replay) and should fail before policy checks.
+
+---
+
+## Decision 6: OpenAPI gains a `403` response on the callback path only
+
+**Decision**: Add `'403'` to `schemas/paths/auth/provider-callback.yaml`. The initiate path (`provider.yaml`) does not gain a 403 (the env var only changes the redirect URL, no rejection happens at initiate).
+
+**Rationale**:
+- 403 is only ever returned from the callback after `id_token` validation. The initiate endpoint cannot know the user's domain yet.
+- Single-user mode already returns 403 for "Registration closed" in `src/routes/auth/login.ts` — but that 403 is not currently documented in the OpenAPI schema for the callback path. Adding the response now covers both reasons (single-user closed + domain mismatch) cleanly.
+
+**Alternatives considered**:
+1. **Reuse 400 with a discriminator field**: rejected — 403 is semantically correct.
+
+---
+
+## Decision 7: Configuration via Worker var/secret, no `wrangler.toml` `[vars]` default
+
+**Decision**: Document `GOOGLE_HOSTED_DOMAIN` as a Worker variable that operators set via `wrangler secret put` or by adding to their environment's `[vars]` block. Do **not** add a default in committed `wrangler.toml`.
+
+**Rationale**:
+- The value is deployment-specific. Committing a default (even commented) risks operators copying it inadvertently.
+- Following the same pattern as the OAuth client IDs/secrets (documented in `wrangler.toml` as comments, set via `wrangler secret put`).
+
+**Alternatives considered**:
+1. **Add `GOOGLE_HOSTED_DOMAIN = ""` under `[vars]`**: rejected — empty string is indistinguishable from "intentionally disabled" vs "forgot to configure." Operators should set or omit, not blank.

--- a/specs/037-google-hosted-domain/spec.md
+++ b/specs/037-google-hosted-domain/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Optional Google Hosted Domain Restriction
+
+**Feature Branch**: `037-google-hosted-domain`
+**Created**: 2026-05-17
+**Status**: Draft
+**Input**: GitHub Issue #37 — Optional Google hosted domain restriction (security review item L4)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator restricts Google login to their Workspace domain (Priority: P1)
+
+As the operator of a CloudTime instance deployed for a single organization using Google Workspace, I want to restrict Google OAuth login to my organization's domain (e.g., `company.com`), so that random Google users outside my organization cannot create accounts on my instance.
+
+Today, Google OAuth on CloudTime accepts any verified Google account. In multi-user mode (a future state), this means any internet user with a Google account can register. Even in single-user mode, the *first* user to complete OAuth wins the seat — which is unsafe if the deployment URL leaks before the legitimate owner registers.
+
+**Why this priority**: This is the primary security improvement for organizational deployments. Without it, a CloudTime instance behind a publicly reachable URL has weak account-creation controls for the Google provider.
+
+**Independent Test**: Set `GOOGLE_HOSTED_DOMAIN=company.com`, complete OAuth as `alice@company.com` → succeeds. Complete OAuth as `bob@gmail.com` → returns 403. Verify no `users` row is created for the rejected account.
+
+**Acceptance Scenarios**:
+
+1. **Given** `GOOGLE_HOSTED_DOMAIN` is unset, **When** any verified Google user completes OAuth, **Then** the existing behavior is unchanged (account created or matched normally).
+2. **Given** `GOOGLE_HOSTED_DOMAIN=company.com`, **When** a user with an `id_token` carrying `hd: "company.com"` completes OAuth, **Then** account creation/login proceeds as normal.
+3. **Given** `GOOGLE_HOSTED_DOMAIN=company.com`, **When** a user with an `id_token` carrying `hd: "other.com"` completes OAuth, **Then** the server returns `403 Forbidden` with a JSON body `{"error": "Account domain not allowed"}` and no DB write occurs.
+4. **Given** `GOOGLE_HOSTED_DOMAIN=company.com`, **When** a user with an `id_token` missing the `hd` claim (e.g., personal `@gmail.com` account) completes OAuth, **Then** the server returns `403 Forbidden` — personal accounts cannot satisfy a Workspace-domain restriction.
+5. **Given** `GOOGLE_HOSTED_DOMAIN` contains uppercase characters (e.g., `Company.COM`), **When** the server reads the env var, **Then** comparison against the `hd` claim is case-insensitive.
+
+---
+
+### User Story 2 - Pass `hd` hint to Google's authorization page (Priority: P2)
+
+As an end user logging in from a configured organization, I want Google's authorization page to default to my Workspace account picker, so that I do not have to sift through my personal accounts.
+
+**Why this priority**: This is a UX improvement. The security-critical control is server-side `hd`-claim validation (User Story 1). The `hd` query parameter on the authorization URL is only a hint and is not security-load-bearing.
+
+**Independent Test**: Inspect the redirect URL emitted by `GET /api/v1/auth/google` when `GOOGLE_HOSTED_DOMAIN=company.com`. Verify the URL contains `&hd=company.com`. Repeat with the env var unset — the URL should not contain `hd`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `GOOGLE_HOSTED_DOMAIN=company.com`, **When** the server builds the Google authorization URL, **Then** the URL includes `hd=company.com` as a query parameter.
+2. **Given** `GOOGLE_HOSTED_DOMAIN` is unset, **When** the server builds the Google authorization URL, **Then** the URL does **not** include an `hd` parameter (current behavior).
+3. **Given** `GOOGLE_HOSTED_DOMAIN=Company.COM`, **When** the server builds the Google authorization URL, **Then** the URL includes the value in its original form (Google itself is case-insensitive on this hint).
+
+---
+
+### User Story 3 - Observability of domain-restricted rejections (Priority: P3)
+
+As an operator, I want a structured log entry whenever a Google login is rejected due to domain restriction, so that I can confirm the restriction is engaged and detect attempted abuse from outside the organization.
+
+**Independent Test**: Trigger an `hd`-mismatch rejection. Verify a single warning log is emitted containing the configured domain (truncated or hashed if PII concerns exist) and the rejection reason. The log MUST NOT contain the user's full email address or the `id_token` itself.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Google login is rejected for domain mismatch, **When** the 403 is returned, **Then** exactly one warning log is emitted recording the event: rule name, expected domain, and a brief reason (e.g., `hd-mismatch` or `hd-missing`).
+2. **Given** a 403 response, **When** the log is captured, **Then** it contains no full email address, no `id_token` payload, and no Google `sub` value.
+
+---
+
+### Edge Cases
+
+- **Wildcard / multi-domain organizations**: An operator with multiple Workspace domains (e.g., `company.com` and `company.co.uk`) cannot use a single `GOOGLE_HOSTED_DOMAIN` value. This feature deliberately supports only one domain. Multi-domain support is out of scope.
+- **Existing user is rejected after env var added**: An operator who adds `GOOGLE_HOSTED_DOMAIN` after onboarding users with personal Google accounts will silently lock those users out at next login. Documented as expected behavior — operators must understand this trade-off before configuring the restriction.
+- **`hd` present but value `gmail.com`**: Personal accounts have no `hd` claim (it is omitted from the `id_token`). If a future Google change ever emits `hd: gmail.com` for personal accounts, our case-insensitive comparison against `GOOGLE_HOSTED_DOMAIN` will reject those correctly.
+- **`hd` spoofing risk via authorization URL**: The `hd` query parameter on the authorization URL is purely a UX hint. A user who manually edits the URL or starts authorization from a different entry point can bypass the hint. The security control is the server-side `hd`-claim verification on the validated `id_token` — claim validation runs after JWT signature verification, so the claim cannot be forged.
+- **Single-user mode interaction**: In single-user mode, the existing first-user-wins gate already prevents most abuse. The hosted-domain restriction adds defense in depth: even before the first user registers, only domain-matching accounts can complete OAuth. Useful when the deploy URL is leaked before legitimate owner onboarding.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST read an optional `GOOGLE_HOSTED_DOMAIN` environment variable. When unset or empty, all current behavior is preserved (no domain restriction).
+- **FR-002**: When `GOOGLE_HOSTED_DOMAIN` is set and non-empty, the system MUST include `hd=<value>` as a query parameter when constructing the Google authorization URL.
+- **FR-003**: When `GOOGLE_HOSTED_DOMAIN` is set and non-empty, the system MUST verify the validated `id_token` contains a `hd` claim whose value matches the configured domain (case-insensitive comparison) before completing the callback.
+- **FR-004**: If the `hd`-claim verification fails (claim missing, claim value mismatched), the system MUST return `403 Forbidden` with a JSON body `{"error": "Account domain not allowed"}` and `Cache-Control: no-store`, and MUST NOT create or update any `users`, `oauth_accounts`, or `pending_links` row.
+- **FR-005**: The `hd`-claim verification MUST run **after** `id_token` signature, `iss`, `aud`, `azp`, `nonce`, and `at_hash` verification — never before. A failed signature must short-circuit before any claim inspection.
+- **FR-006**: The system MUST emit exactly one structured warning log per rejection containing: rule name (`google-hosted-domain`), reason (`hd-mismatch` or `hd-missing`), and the configured domain. The log MUST NOT contain the user's email, full `id_token`, or Google `sub`.
+- **FR-007**: The OpenAPI schema for `GET /api/v1/auth/google/callback` MUST advertise the `403` response with the error body shape above. The schema description for `GET /api/v1/auth/google` MUST note that the operator can configure a domain restriction via `GOOGLE_HOSTED_DOMAIN`.
+- **FR-008**: The restriction MUST apply to the `google` provider only. `github` and `discord` providers MUST be unaffected.
+
+### Non-Functional Requirements
+
+- **NFR-001**: The `hd`-claim comparison MUST be case-insensitive against the configured domain. The comparison MUST NOT use locale-sensitive comparison (e.g., Turkish dotless I) — use `toLowerCase()` on ASCII domain strings.
+- **NFR-002**: Configuration changes (`GOOGLE_HOSTED_DOMAIN` set/unset/changed) MUST take effect on the next request without code redeploy beyond `wrangler deploy`.
+- **NFR-003**: The added validation MUST add no measurable latency (<1ms) — it is a string comparison on already-validated JWT claims.
+
+### Key Entities *(no database changes)*
+
+No new database tables or columns. The configuration lives in `wrangler.toml` `[vars]` or as a Worker secret.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can enable the restriction by setting one env var without code change, and disable it by unsetting the var.
+- **SC-002**: With the restriction enabled, attempts from non-matching domains return 403 with zero DB writes (verified by querying `users` and `oauth_accounts` before and after).
+- **SC-003**: With the restriction disabled, behavior is byte-identical to the current implementation (no regression in existing OAuth flows).
+- **SC-004**: Total added code is under ~30 LoC in `src/utils/oauth.ts` plus ~5 LoC in `src/types.ts`.
+- **SC-005**: GitHub and Discord OAuth flows have zero changes in PR2 diff.
+
+## Out of Scope
+
+- **Multi-domain support** (e.g., a list of allowed domains). Operators with multi-domain organizations must use a different access control mechanism (e.g., Cloudflare Access in front of the Worker).
+- **Per-user-id allowlist**. CloudTime intentionally avoids maintaining a separate identity allowlist; access control is via OAuth provider only.
+- **`GOOGLE_HOSTED_DOMAIN` validation/sanitization at startup**. We trust the operator to set a valid domain; if they set an invalid one (e.g., `not a domain`), no Google account can satisfy the constraint and the system fails closed — the desired outcome.
+- **Migration of existing users on domain change**. If an operator changes `GOOGLE_HOSTED_DOMAIN` mid-deployment, existing users outside the new domain are simply locked out at next login. No automated cleanup of stale rows.
+- **GitHub/Discord equivalent restrictions**. GitHub does not expose a workspace concept; Discord's `guilds` scope could provide similar semantics but is a separate feature.

--- a/specs/037-google-hosted-domain/tasks.md
+++ b/specs/037-google-hosted-domain/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Optional Google Hosted Domain Restriction
+
+**Branch**: `037-google-hosted-domain`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-17
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` covering FR-001 through FR-008, NFRs, and success criteria.
+- [x] **T-002**: Author `plan.md` with Constitution Check, code-change sketch.
+- [x] **T-003**: Author `research.md` documenting `hd` claim semantics, case sensitivity, fail-closed default.
+- [x] **T-004**: Author `quickstart.md` with scenarios A–F.
+- [x] **T-005**: Author `contracts/openapi-diff.md` summarizing schema changes.
+- [x] **T-006**: Author `checklists/requirements.md` (acceptance gates for PR1, PR2, and post-deploy).
+- [ ] **T-007**: Update `schemas/paths/auth/provider-callback.yaml` — add `'403'` response for domain mismatch.
+- [ ] **T-008**: Update `schemas/paths/auth/provider.yaml` — mention `GOOGLE_HOSTED_DOMAIN` in operation description (one line).
+- [ ] **T-009**: Run `npm run generate` and verify `src/types/generated.ts` diff is description-only / type-shape additive (new 403 response type is acceptable).
+- [ ] **T-010**: Commit PR1 (`spec:` prefix), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Type changes
+
+- [ ] **T-101**: Add `GOOGLE_HOSTED_DOMAIN?: string;` to `Env` in `src/types.ts`.
+
+### Source changes (single file: `src/utils/oauth.ts`)
+
+- [ ] **T-102**: In `buildAuthorizeUrl` Google branch, after `nonce` line, append:
+  ```ts
+  if (env.GOOGLE_HOSTED_DOMAIN) url.searchParams.set("hd", env.GOOGLE_HOSTED_DOMAIN);
+  ```
+- [ ] **T-103**: Add `class HostedDomainError extends Error` at module scope (or near `validateGoogleIdToken`). Export it so the callback handler can `instanceof` against it.
+- [ ] **T-104**: In `validateGoogleIdToken`, after the `at_hash` block and before reading `payload.sub`, insert:
+  ```ts
+  const requiredHd = env.GOOGLE_HOSTED_DOMAIN?.trim().toLowerCase();
+  if (requiredHd) {
+    const tokenHd = typeof payload.hd === "string" ? payload.hd.trim().toLowerCase() : "";
+    if (tokenHd !== requiredHd) {
+      const reason = tokenHd ? "hd-mismatch" : "hd-missing";
+      console.warn(`[google-hosted-domain] rejected rule=google-hosted-domain reason=${reason} expected=${requiredHd}`);
+      throw new HostedDomainError("Google account domain not allowed");
+    }
+  }
+  ```
+
+### Callback handler change (`src/routes/auth/login.ts`)
+
+- [ ] **T-105**: In the outer `try/catch` of `GET /:provider/callback`, before the generic `Internal server error` branch, add:
+  ```ts
+  if (err instanceof HostedDomainError) {
+    return c.json({ error: "Account domain not allowed" }, 403, noCacheHeaders());
+  }
+  ```
+
+### Configuration documentation
+
+- [ ] **T-106**: Add a comment line in `wrangler.toml` near the existing OAuth secret comments documenting the optional `GOOGLE_HOSTED_DOMAIN` variable.
+- [ ] **T-107**: Update `docs/auth-design.md` (if a Google section exists) with a brief paragraph describing the restriction. If no suitable doc exists, link to the spec from `docs/cloudflare-constraints.md`.
+
+### Verification
+
+- [ ] **T-108**: `npx tsc --noEmit` — zero errors.
+- [ ] **T-109**: Manually verify scenarios A–E from `quickstart.md` on a staging Worker (or document why staging is unavailable).
+- [ ] **T-110**: Verify the GitHub and Discord callback paths produce byte-identical responses to pre-feature behavior (no accidental cross-provider impact).
+
+### PR2 submission
+
+- [ ] **T-111**: Commit with `feat:` prefix. Push, open PR against `develop` referencing #37 and PR1.
+
+## Dependencies
+
+```
+T-001 … T-009 → T-010 (PR1 merge)
+T-010 → T-101 … T-111
+T-101 → T-104 (Env type must exist before code reads env.GOOGLE_HOSTED_DOMAIN)
+T-103 → T-104 → T-105 (error class → throw site → catch site)
+T-104 → T-108 (compile check after main change)
+```
+
+## Out of scope (do not implement in this feature)
+
+- Multi-domain support (`GOOGLE_HOSTED_DOMAINS` plural).
+- GitHub/Discord equivalent restrictions.
+- Database-backed user allowlist.
+- Migration utilities for users who become locked out after domain change.

--- a/specs/037-google-hosted-domain/tasks.md
+++ b/specs/037-google-hosted-domain/tasks.md
@@ -12,10 +12,10 @@
 - [x] **T-004**: Author `quickstart.md` with scenarios A–F.
 - [x] **T-005**: Author `contracts/openapi-diff.md` summarizing schema changes.
 - [x] **T-006**: Author `checklists/requirements.md` (acceptance gates for PR1, PR2, and post-deploy).
-- [ ] **T-007**: Update `schemas/paths/auth/provider-callback.yaml` — add `'403'` response for domain mismatch.
-- [ ] **T-008**: Update `schemas/paths/auth/provider.yaml` — mention `GOOGLE_HOSTED_DOMAIN` in operation description (one line).
-- [ ] **T-009**: Run `npm run generate` and verify `src/types/generated.ts` diff is description-only / type-shape additive (new 403 response type is acceptable).
-- [ ] **T-010**: Commit PR1 (`spec:` prefix), push, open PR against `develop`.
+- [x] **T-007**: Update `schemas/paths/auth/provider-callback.yaml` — add `'403'` response for domain mismatch.
+- [x] **T-008**: Update `schemas/paths/auth/provider.yaml` — mention `GOOGLE_HOSTED_DOMAIN` in operation description (one line).
+- [x] **T-009**: Run `npm run generate` and verify `src/types/generated.ts` diff is description-only / type-shape additive (new 403 response type is acceptable).
+- [x] **T-010**: Commit PR1 (`spec:` prefix), push, open PR against `develop`.
 
 ## PR2 — Implementation (after PR1 merges)
 
@@ -45,7 +45,7 @@
 
 ### Callback handler change (`src/routes/auth/login.ts`)
 
-- [ ] **T-105**: In the outer `try/catch` of `GET /:provider/callback`, before the generic `Internal server error` branch, add:
+- [ ] **T-105**: In the outer `try/catch` of `GET /:provider/callback`, handle `HostedDomainError` as the first statement in the `catch`, before the generic `console.error` / `Internal server error` branch. This preserves FR-006's "exactly one structured warning log per rejection" requirement:
   ```ts
   if (err instanceof HostedDomainError) {
     return c.json({ error: "Account domain not allowed" }, 403, noCacheHeaders());

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -43,6 +43,12 @@ export interface paths {
          *     - Google: `openid email profile`
          *     - Discord: `identify email`
          *
+         *     **Optional per-deployment restrictions:**
+         *     - Google: if the operator sets `GOOGLE_HOSTED_DOMAIN`, the authorization URL
+         *       includes `hd=<domain>` as a UX hint and the callback enforces the matching
+         *       `hd` claim on the validated id_token. Tokens with no `hd` claim (personal
+         *       Google accounts) or a non-matching `hd` are rejected with 403.
+         *
          *     **Rate limiting:** Enforced at the Cloudflare edge with a native Rate
          *     Limiting binding. Limit: 10 requests per configured 60-second window, keyed
          *     by client IP truncated to /24 for IPv4 or /48 for IPv6.
@@ -1530,6 +1536,24 @@ export interface components {
                 };
             };
         };
+        /**
+         * @description The authenticated principal is recognized but not authorized for this resource.
+         *     Common reasons:
+         *     - Single-user mode: registration closed (`/auth/:provider/callback`).
+         *     - Google hosted domain restriction: the Google account's domain does not match
+         *       `GOOGLE_HOSTED_DOMAIN` (`/auth/google/callback`).
+         */
+        Forbidden: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @example Account domain not allowed */
+                    error?: string;
+                };
+            };
+        };
         /** @description Authentication required or invalid credentials */
         Unauthorized: {
             headers: {
@@ -1662,6 +1686,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            403: components["responses"]["Forbidden"];
             429: components["responses"]["TooManyRequests"];
         };
     };


### PR DESCRIPTION
## Summary

PR1 of the SpecKit 2-PR workflow for [Issue #37](https://github.com/sudolifeagain/cloudtime/issues/37) — optional Google hosted domain restriction.

This PR contains **specs and schema only** — no implementation. Implementation lands in PR2 after this is merged, per CLAUDE.md SDD rules.

## Scope

### SpecKit artifacts (new)
- `specs/037-google-hosted-domain/spec.md` — FR-001..FR-008, NFRs, success criteria, edge cases
- `specs/037-google-hosted-domain/plan.md` — Constitution Check, code-change sketch
- `specs/037-google-hosted-domain/research.md` — 7 decisions (`hd` claim vs URL param, case insensitivity, fail-closed default, etc.)
- `specs/037-google-hosted-domain/quickstart.md` — 6 manual verification scenarios
- `specs/037-google-hosted-domain/tasks.md` — PR1/PR2 task split
- `specs/037-google-hosted-domain/contracts/openapi-diff.md` — schema-change rationale
- `specs/037-google-hosted-domain/checklists/requirements.md` — acceptance gates

### Schema changes (additive)
- **`schemas/components/responses/Forbidden.yaml`** — new shared 403 response component. Covers both single-user-mode "Registration closed" (currently undocumented in OpenAPI) and the new Google hosted-domain restriction.
- **`schemas/paths/auth/provider-callback.yaml`** — declare `403` response on the callback path.
- **`schemas/paths/auth/provider.yaml`** — describe `GOOGLE_HOSTED_DOMAIN` behavior in the operation description.
- **`src/types/generated.ts`** — regenerated. Additive only: new `Forbidden` response component type and `403` entry on `oauthCallback`. No existing types modified.

## Behavior summary (for context — implementation in PR2)

When `GOOGLE_HOSTED_DOMAIN` is set:
1. `GET /api/v1/auth/google` appends `hd=<domain>` to the authorization URL as a UX hint.
2. `GET /api/v1/auth/google/callback` verifies the validated `id_token` `hd` claim matches the configured domain (case-insensitive). On mismatch or missing claim, returns `403 Forbidden` with body `{"error": "Account domain not allowed"}` and no DB write.
3. The `hd`-claim check runs **after** signature, `iss`, `aud`, `azp`, `nonce`, and `at_hash` validation.

When the env var is unset (default), behavior is byte-identical to the current implementation.

## Test plan

- [ ] Verify only `specs/037-google-hosted-domain/**`, `schemas/components/responses/Forbidden.yaml`, the two affected path YAMLs, and `src/types/generated.ts` are touched.
- [ ] Verify `src/types/generated.ts` diff is additive only (new component + new 403 entry, no existing types modified).
- [ ] CI passes (`tsc --noEmit`).
- [ ] PR1 contains no changes under `src/utils/`, `src/routes/`, `src/types.ts`, or `wrangler.toml`.

## Follow-up

After this PR merges, open PR2 from a fresh branch implementing the env var read, `hd` URL param, `hd` claim validation, and `HostedDomainError` plumbing per `tasks.md` § PR2.

Closes part 1 of #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)