### PR TITLE
feat: enforce Google hosted domain restriction (PR2/2) #37

### DIFF
--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -141,6 +141,11 @@ OAuth access_tokens and refresh_tokens are encrypted before storage:
 ### Google
 - Scopes: `openid`, `email`, `profile`
 - User info endpoint: `GET https://www.googleapis.com/oauth2/v2/userinfo`
+- **Optional hosted domain restriction**: if `GOOGLE_HOSTED_DOMAIN` is set, the
+  authorization URL includes `hd=<domain>` as a UX hint and the callback
+  enforces the matching `hd` claim on the validated id_token. Tokens with no
+  `hd` claim (personal Google accounts) or a non-matching `hd` are rejected
+  with 403. See `specs/037-google-hosted-domain/`.
 
 ### Discord
 - Scopes: `identify`, `email`
@@ -158,4 +163,5 @@ GOOGLE_CLIENT_SECRET
 DISCORD_CLIENT_ID
 DISCORD_CLIENT_SECRET
 ENCRYPTION_KEY          # 64 hex chars (256 bits), AES-256 key for token encryption
+GOOGLE_HOSTED_DOMAIN    # Optional. Google Workspace primary domain to restrict logins to.
 ```

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -22,6 +22,7 @@ import {
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserInfo,
+  HostedDomainError,
   type OAuthProvider,
 } from "../../utils/oauth";
 import {
@@ -401,6 +402,9 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
       noCacheHeaders(),
     );
   } catch (err) {
+    if (err instanceof HostedDomainError) {
+      return c.json({ error: "Account domain not allowed" }, 403, noCacheHeaders());
+    }
     console.error("OAuth callback error:", err instanceof Error ? err.message : "Unknown error");
     return c.json({ error: "Internal server error" }, 500, noCacheHeaders());
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,13 @@ export interface Env {
   // If unset, derived from request Host header (safe behind Cloudflare, risky with custom proxies)
   APP_URL?: string;
 
+  // Optional Google Workspace hosted domain restriction. When set, the
+  // authorization URL includes `hd=<domain>` as a UX hint and the callback
+  // enforces the matching `hd` claim on the validated id_token. Tokens with
+  // no `hd` claim (personal Google accounts) or a non-matching `hd` are
+  // rejected with 403. See specs/037-google-hosted-domain/.
+  GOOGLE_HOSTED_DOMAIN?: string;
+
   // Rate-limit bindings (optional — middleware fails open when undefined)
   RATE_LIMIT_OAUTH_INITIATE?: RateLimit;
   RATE_LIMIT_OAUTH_CALLBACK?: RateLimit;

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -7,6 +7,13 @@ import type { Env } from "../types";
 
 // ─── Types ───────────────────────────────────────────────
 
+export class HostedDomainError extends Error {
+  constructor(message = "Google account domain not allowed") {
+    super(message);
+    this.name = "HostedDomainError";
+  }
+}
+
 export type OAuthProvider = "github" | "google" | "discord";
 
 const VALID_PROVIDERS = new Set<string>(["github", "google", "discord"]);
@@ -97,6 +104,7 @@ export function buildAuthorizeUrl(
       url.searchParams.set("code_challenge", codeChallenge);
       url.searchParams.set("code_challenge_method", "S256");
       if (nonce) url.searchParams.set("nonce", nonce);
+      if (env.GOOGLE_HOSTED_DOMAIN) url.searchParams.set("hd", env.GOOGLE_HOSTED_DOMAIN);
       return url.toString();
     }
     case "discord": {
@@ -492,6 +500,23 @@ async function validateGoogleIdToken(
     const expected = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
     if (expected !== payload.at_hash) {
       throw new Error("Google id_token at_hash mismatch");
+    }
+  }
+
+  // Optional hosted-domain restriction (Issue #37). The `hd` claim is signed
+  // and trustworthy at this point. Empty/absent claim is treated as mismatch
+  // when the env var is set so personal accounts cannot satisfy a Workspace
+  // restriction.
+  const requiredHd = env.GOOGLE_HOSTED_DOMAIN?.trim().toLowerCase();
+  if (requiredHd) {
+    const tokenHd =
+      typeof payload.hd === "string" ? payload.hd.trim().toLowerCase() : "";
+    if (tokenHd !== requiredHd) {
+      const reason = tokenHd ? "hd-mismatch" : "hd-missing";
+      console.warn(
+        `[google-hosted-domain] rejected rule=google-hosted-domain reason=${reason} expected=${requiredHd}`,
+      );
+      throw new HostedDomainError();
     }
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,6 +32,9 @@ INSTANCE_MODE = "single"
 # DISCORD_CLIENT_ID
 # DISCORD_CLIENT_SECRET
 # ENCRYPTION_KEY          - AES-256 key (64 hex chars) for encrypting OAuth tokens at rest
+# GOOGLE_HOSTED_DOMAIN    - Optional. Google Workspace primary domain (e.g. "example.com").
+#                           When set, Google logins are restricted to accounts whose id_token
+#                           `hd` claim matches this value. See specs/037-google-hosted-domain/.
 
 # OAuth rate limits — see specs/058-oauth-rate-limiting/
 # Operators must verify current Cloudflare plan limits before production deployment.


### PR DESCRIPTION
## Summary

PR2 of 2 for [Issue #37](https://github.com/sudolifeagain/cloudtime/issues/37) — implementation of the optional Google hosted domain restriction.

PR1 (#89, merged) added the SpecKit artifacts and `Forbidden` response schema. This PR wires the actual `hd`-claim verification and 403 emission.

## Behavior

When `GOOGLE_HOSTED_DOMAIN` is set:
1. `GET /api/v1/auth/google` appends `hd=<domain>` to the authorization URL (UX hint).
2. `GET /api/v1/auth/google/callback` verifies the validated `id_token` `hd` claim matches the configured domain (case-insensitive). On mismatch / missing claim, returns `403 Forbidden` with body `{"error":"Account domain not allowed"}` and no DB write.
3. The check runs **after** signature, `iss`, `aud`, `azp`, `nonce`, and `at_hash` validation — never before.

When the env var is unset (default), behavior is byte-identical to the previous implementation.

## Files

| File | Change |
|---|---|
| `src/types.ts` | Add optional `GOOGLE_HOSTED_DOMAIN` field to `Env` |
| `src/utils/oauth.ts` | Export new `HostedDomainError` class; add `hd` URL hint in `buildAuthorizeUrl`; add `hd` claim check in `validateGoogleIdToken` after `at_hash` validation |
| `src/routes/auth/login.ts` | First statement in callback `catch`: translate `HostedDomainError` to 403 (preserves FR-006's "exactly one structured warning log per rejection") |
| `wrangler.toml` | Comment documenting the optional secret |
| `docs/auth-design.md` | Google section + secret list updated |

Total diff: 5 files, +45 lines.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] No diff in GitHub or Discord OAuth branches (verified via `git diff`)
- [ ] **Scenario A** (matching domain): user from `<configured-domain>` logs in successfully, `hd=` present in authorize URL
- [ ] **Scenario B** (personal Gmail): callback returns 403, log line `reason=hd-missing`, no `users` row created
- [ ] **Scenario C** (different Workspace domain): callback returns 403, log line `reason=hd-mismatch`
- [ ] **Scenario D** (env var unset): byte-identical to pre-feature behavior
- [ ] **Scenario E** (mixed-case env var): case-insensitive match succeeds

Scenarios B–E require a deployed Worker with the Google provider configured; results will be attached as a PR comment after staging verification.

## Notes

- The `HostedDomainError` instance reaches the callback `catch` via the existing `validateGoogleIdToken` → `fetchUserInfo` → outer-try call chain, so no additional plumbing is needed.
- The log line in `validateGoogleIdToken` contains only the configured domain and a reason code (`hd-mismatch` / `hd-missing`). No user email, `id_token`, or `sub` is logged.

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)