### PR TITLE
docs: note SameSite=Lax constraint for future POST-mode OAuth callbacks #53

### DIFF
--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -128,9 +128,9 @@ that point:
 1. **Switch the affected cookies to `SameSite=None; Secure`** — required when
    adopting a POST-mode callback. `Secure` is mandatory for `SameSite=None`;
    the `__Host-` prefix already enforces it. Note that `SameSite=None` removes
-   the browser's built-in CSRF defense, so the state cookie's CSRF role
-   becomes entirely dependent on the server-side store comparison
-   (`oauth:state:*` in KV) — keep that intact.
+   the browser's built-in CSRF defense, so keep both CSRF checks intact:
+   compare the request `state` against the state cookie, then consume the
+   matching server-side KV entry (`oauth:state:*`).
 2. **Continue using only GET-mode callbacks.** Document any new provider as
    GET-only at the design stage so the cookie attributes do not need to change.
 

--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -112,6 +112,31 @@ Controlled by `INSTANCE_MODE` environment variable:
 | Revocation | DELETE /auth/session removes from DB |
 | Cleanup | Cron purges expired sessions hourly |
 
+### Note: `SameSite=Lax` and POST-mode OAuth callbacks (Issue #53)
+
+The OAuth `state` cookie and session cookie both use `SameSite=Lax`. Browsers
+send `Lax` cookies on top-level cross-site **GET** navigations but **not** on
+cross-site **POST** requests. All three providers we support today (GitHub,
+Google, Discord) use GET callbacks, so this is not an issue in the current
+implementation.
+
+If a future provider uses OpenID Connect `response_mode=form_post` (or any
+other cross-site POST callback), the `Lax` cookie will not accompany the
+request and CSRF state validation will fail. Two mitigations are possible at
+that point:
+
+1. **Switch the affected cookies to `SameSite=None; Secure`** — required when
+   adopting a POST-mode callback. `Secure` is mandatory for `SameSite=None`;
+   the `__Host-` prefix already enforces it. Note that `SameSite=None` removes
+   the browser's built-in CSRF defense, so the state cookie's CSRF role
+   becomes entirely dependent on the server-side store comparison
+   (`oauth:state:*` in KV) — keep that intact.
+2. **Continue using only GET-mode callbacks.** Document any new provider as
+   GET-only at the design stage so the cookie attributes do not need to change.
+
+This is a forward-looking note. Until a POST-mode provider is added, no code
+change is required.
+
 ## API Key Format
 
 ```

--- a/schemas/paths/auth/provider.yaml
+++ b/schemas/paths/auth/provider.yaml
@@ -67,6 +67,13 @@ get:
             Short-lived HttpOnly cookie containing the `state` value for CSRF validation
             on callback. Attributes: HttpOnly, Secure, SameSite=Lax, Max-Age=600, Path=/.
             SameSite=Lax is required because the OAuth callback is a cross-site navigation.
+
+            Note: `SameSite=Lax` cookies are NOT sent on cross-site POST requests, so this
+            attribute is only safe for providers that use a GET-mode callback (GitHub,
+            Google, Discord — all currently supported). Adopting a future provider that
+            uses POST-mode callbacks (e.g., OpenID Connect `response_mode=form_post`)
+            will require switching the affected cookies to `SameSite=None; Secure`.
+            See docs/auth-design.md § Session Security for details (Issue #53).
           schema:
             type: string
     '400':

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -1627,6 +1627,13 @@ export interface operations {
                      * @description Short-lived HttpOnly cookie containing the `state` value for CSRF validation
                      *     on callback. Attributes: HttpOnly, Secure, SameSite=Lax, Max-Age=600, Path=/.
                      *     SameSite=Lax is required because the OAuth callback is a cross-site navigation.
+                     *
+                     *     Note: `SameSite=Lax` cookies are NOT sent on cross-site POST requests, so this
+                     *     attribute is only safe for providers that use a GET-mode callback (GitHub,
+                     *     Google, Discord — all currently supported). Adopting a future provider that
+                     *     uses POST-mode callbacks (e.g., OpenID Connect `response_mode=form_post`)
+                     *     will require switching the affected cookies to `SameSite=None; Secure`.
+                     *     See docs/auth-design.md § Session Security for details (Issue #53).
                      */
                     "Set-Cookie"?: string;
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

Documentation-only PR addressing [Issue #53](https://github.com/sudolifeagain/cloudtime/issues/53). Adds a forward-looking note that the OAuth state and session cookies use `SameSite=Lax`, which works for all currently supported providers (GitHub, Google, Discord — all GET callbacks) but would silently break if a future provider used OpenID Connect `response_mode=form_post` or any other cross-site POST callback.

No code, behavior, or schema-shape changes. The note exists so that future contributors hit the constraint at the design step instead of via a broken CSRF check.

## Changes

| File | Change |
|---|---|
| `docs/auth-design.md` | New § Session Security subsection explaining the constraint and two mitigation options (`SameSite=None; Secure` or stay GET-only) |
| `schemas/paths/auth/provider.yaml` | Short note appended to the state-cookie Set-Cookie description |
| `src/types/generated.ts` | Regenerated — JSDoc-only diff |

Total: 3 files, +39 lines, 0 deletions.

## Test plan

- [x] `npm run generate` runs cleanly; `src/types/generated.ts` diff is description-only
- [x] No code under `src/middleware/`, `src/routes/`, or `src/utils/` is touched
- [x] No `wrangler.toml` changes
- [ ] CI passes

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)