### PR TITLE
feat: add Vitest + Workers test infrastructure (60 tests, CI)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  pull_request:
+    branches: [develop, master]
+  push:
+    branches: [develop, master]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,13 @@
 - **PR1 (Spec + Design)**: SpecKit artifacts (`specs/`), OpenAPI spec (`schemas/`), generated types (`src/types/generated.ts`). No implementation code.
 - **PR2 (Implementation)**: Route handlers and business logic. Only after PR1 is merged.
 - Never mix spec changes and implementation in the same PR
+
+## Testing
+- `npm test` runs Vitest inside the Workers runtime via `@cloudflare/vitest-pool-workers`.
+- `npm run typecheck` runs `tsc --noEmit` for project + tests.
+- Unit-style tests live next to the area they cover under `tests/`:
+  - `tests/security/` — pure logic (crypto, rate-limit IP keying, OAuth utilities).
+  - `tests/aggregation/` — timezone bucketing, summary/duration builders.
+  - `tests/integration/` — endpoint tests with real in-memory D1 (`SELF` / `worker.fetch`).
+- The Workers test pool runs `tests/setup.ts` once per file to load `src/db/schema.sql`. Helpers in `tests/helpers/fixtures.ts` mint users + API keys without going through OAuth.
+- CI runs both `typecheck` and `test` on every PR (`.github/workflows/test.yml`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@cloudflare/vitest-pool-workers": "^0.16.6",
         "@cloudflare/workers-types": "^4.20250309.0",
         "@redocly/cli": "^2.20.4",
-        "@vitest/coverage-v8": "^4.1.6",
         "openapi-typescript": "^7.6.1",
         "typescript": "^5.7.0",
         "vitest": "^4.1.6",
@@ -45,6 +44,8 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -65,6 +66,8 @@
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -91,6 +94,8 @@
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -105,6 +110,8 @@
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1399,6 +1406,8 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -1628,6 +1637,8 @@
       "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
@@ -1640,6 +1651,8 @@
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1650,7 +1663,9 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2283,7 +2298,9 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/http2-client": {
       "version": "1.3.5",
@@ -2342,6 +2359,8 @@
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2352,6 +2371,8 @@
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -2367,6 +2388,8 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2380,6 +2403,8 @@
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -2813,6 +2838,8 @@
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
@@ -2825,6 +2852,8 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,13 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.16.6",
         "@cloudflare/workers-types": "^4.20250309.0",
         "@redocly/cli": "^2.20.4",
+        "@vitest/coverage-v8": "^4.1.6",
         "openapi-typescript": "^7.6.1",
         "typescript": "^5.7.0",
+        "vitest": "^4.1.6",
         "wrangler": "^4.0.0"
       }
     },
@@ -36,6 +39,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -44,6 +57,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -56,25 +85,49 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -82,10 +135,107 @@
         }
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.6.tgz",
+      "integrity": "sha512-dt8LyDZCqJe95orS0eVmFnKFk7qkUTn1XjM2ppcTJJe67PJK9gt2VzBGk4gS64cxPk7uKoJ201kVtHPq5rQnNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260515.0",
+        "wrangler": "4.92.0",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260515.1.tgz",
+      "integrity": "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260515.1.tgz",
+      "integrity": "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260515.1.tgz",
+      "integrity": "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260515.1.tgz",
+      "integrity": "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260301.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260301.1.tgz",
-      "integrity": "sha512-Q0wMJ4kcujXILwQKQFc1jaYamVsNvjuECzvRrTI8OxGFMx2yq9aOsswViE4X1gaS2YQQ5u0JGwuGi5WdT1Lt7A==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260515.1.tgz",
+      "integrity": "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==",
       "cpu": [
         "x64"
       ],
@@ -100,9 +250,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260307.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260307.1.tgz",
-      "integrity": "sha512-0PvWLVVD6Q64V/XhollYtc8H35Vxm2rZi8bkZbEr3lK+mNgd2FBBVhlZ6A3saAUq3giRF4US/UfU/3a8i1PEcg==",
+      "version": "4.20260517.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260517.1.tgz",
+      "integrity": "sha512-OjavgX6VpYoWlKg2xPgLKIhBeiJvNdwFVK8E1P6hF02wh1oEt1sZpTzbp9kdohprqjXo6UVqs7/AuIH0wxIcbw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -117,6 +267,40 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -244,6 +428,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -466,6 +669,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -821,6 +1034,270 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -840,6 +1317,49 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -872,6 +1392,123 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -975,6 +1612,46 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1036,6 +1713,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1070,6 +1757,13 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1126,6 +1820,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1262,6 +1963,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -1321,6 +2029,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1337,6 +2055,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1402,12 +2130,45 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreach": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1517,6 +2278,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http2-client": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
@@ -1564,6 +2332,58 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -1679,6 +2499,267 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -1716,6 +2797,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -1737,16 +2856,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260301.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260301.1.tgz",
-      "integrity": "sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==",
+      "version": "4.20260515.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260515.0.tgz",
+      "integrity": "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.18.2",
-        "workerd": "1.20260301.1",
+        "undici": "7.24.8",
+        "workerd": "1.20260515.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1754,7 +2873,7 @@
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -2015,6 +3134,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/openapi-sampler": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.1.tgz",
@@ -2126,9 +3256,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2405,6 +3535,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2565,6 +3729,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-websocket": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
@@ -2644,6 +3815,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stickyfill": {
       "version": "1.1.1",
@@ -2784,6 +3969,50 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2857,9 +4086,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2914,6 +4143,248 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2932,6 +4403,23 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -2940,9 +4428,9 @@
       "license": "MIT"
     },
     "node_modules/workerd": {
-      "version": "1.20260301.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260301.1.tgz",
-      "integrity": "sha512-oterQ1IFd3h7PjCfT4znSFOkJCvNQ6YMOyZ40YsnO3nrSpgB4TbJVYWFOnyJAw71/RQuupfVqZZWKvsy8GO3fw==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260515.1.tgz",
+      "integrity": "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2953,41 +4441,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260301.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260301.1",
-        "@cloudflare/workerd-linux-64": "1.20260301.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260301.1",
-        "@cloudflare/workerd-windows-64": "1.20260301.1"
+        "@cloudflare/workerd-darwin-64": "1.20260515.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260515.1",
+        "@cloudflare/workerd-linux-64": "1.20260515.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260515.1",
+        "@cloudflare/workerd-windows-64": "1.20260515.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.71.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.71.0.tgz",
-      "integrity": "sha512-j6pSGAncOLNQDRzqtp0EqzYj52CldDP7uz/C9cxVrIgqa5p+cc0b4pIwnapZZAGv9E1Loa3tmPD0aXonH7KTkw==",
+      "version": "4.92.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.92.0.tgz",
+      "integrity": "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.15.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260301.1",
+        "miniflare": "4.20260515.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1"
+        "workerd": "1.20260515.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260226.1"
+        "@cloudflare/workers-types": "^4.20260515.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,20 @@
     "lint:api": "redocly lint schemas/openapi.yaml",
     "db:init": "wrangler d1 execute cloudtime-db --local --file=./src/db/schema.sql",
     "db:init:remote": "wrangler d1 execute cloudtime-db --remote --file=./src/db/schema.sql",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.6",
     "@cloudflare/workers-types": "^4.20250309.0",
     "@redocly/cli": "^2.20.4",
+    "@vitest/coverage-v8": "^4.1.6",
     "openapi-typescript": "^7.6.1",
     "typescript": "^5.7.0",
+    "vitest": "^4.1.6",
     "wrangler": "^4.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,12 @@
     "tail": "wrangler tail",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.6",
     "@cloudflare/workers-types": "^4.20250309.0",
     "@redocly/cli": "^2.20.4",
-    "@vitest/coverage-v8": "^4.1.6",
     "openapi-typescript": "^7.6.1",
     "typescript": "^5.7.0",
     "vitest": "^4.1.6",

--- a/tests/aggregation/summary-builder.test.ts
+++ b/tests/aggregation/summary-builder.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateDimension,
+  buildSummary,
+  type SummaryRow,
+} from "../../src/utils/summary-builder";
+
+function row(partial: Partial<SummaryRow>): SummaryRow {
+  return {
+    date: "2026-03-14",
+    project: null,
+    language: null,
+    editor: null,
+    operating_system: null,
+    category: null,
+    branch: null,
+    machine: null,
+    total_seconds: 0,
+    ...partial,
+  };
+}
+
+describe("aggregateDimension", () => {
+  it("sums total_seconds by dimension value", () => {
+    const rows: SummaryRow[] = [
+      row({ project: "cloudtime", total_seconds: 1200 }),
+      row({ project: "cloudtime", total_seconds: 600 }),
+      row({ project: "side-project", total_seconds: 300 }),
+    ];
+
+    const result = aggregateDimension(rows, "project", 2100);
+
+    expect(result.map((r) => [r.name, r.total_seconds])).toEqual([
+      ["cloudtime", 1800],
+      ["side-project", 300],
+    ]);
+  });
+
+  it("sorts items by total_seconds descending", () => {
+    const rows: SummaryRow[] = [
+      row({ language: "Go", total_seconds: 100 }),
+      row({ language: "TypeScript", total_seconds: 500 }),
+      row({ language: "Python", total_seconds: 300 }),
+    ];
+
+    const result = aggregateDimension(rows, "language", 900);
+
+    expect(result.map((r) => r.name)).toEqual(["TypeScript", "Python", "Go"]);
+  });
+
+  it("collapses null/empty dimension values to 'Unknown'", () => {
+    const rows: SummaryRow[] = [
+      row({ project: null, total_seconds: 100 }),
+      row({ project: "", total_seconds: 50 }),
+      row({ project: "real", total_seconds: 200 }),
+    ];
+
+    const result = aggregateDimension(rows, "project", 350);
+
+    expect(result.map((r) => [r.name, r.total_seconds])).toEqual([
+      ["real", 200],
+      ["Unknown", 150],
+    ]);
+  });
+
+  it("computes percent against the grand total, rounded to 2 decimals", () => {
+    const rows: SummaryRow[] = [
+      row({ language: "TypeScript", total_seconds: 1500 }),
+      row({ language: "Go", total_seconds: 500 }),
+    ];
+
+    const result = aggregateDimension(rows, "language", 2000);
+
+    expect(result[0].percent).toBe(75);
+    expect(result[1].percent).toBe(25);
+  });
+
+  it("returns percent=0 when grand total is zero", () => {
+    const result = aggregateDimension(
+      [row({ language: "TypeScript", total_seconds: 0 })],
+      "language",
+      0,
+    );
+    expect(result[0].percent).toBe(0);
+  });
+});
+
+describe("buildSummary", () => {
+  it("returns grand_total derived from summing rows", () => {
+    const rows: SummaryRow[] = [
+      row({ project: "p", total_seconds: 1800 }),
+      row({ project: "p", total_seconds: 1800 }),
+    ];
+
+    const summary = buildSummary("2026-03-14", rows, "Asia/Tokyo");
+
+    expect(summary.grand_total.total_seconds).toBe(3600);
+    expect(summary.grand_total.digital).toBe("1:00");
+    expect(summary.grand_total.text).toBe("1 hr");
+    expect(summary.grand_total.hours).toBe(1);
+    expect(summary.grand_total.minutes).toBe(0);
+  });
+
+  it("populates all seven dimension keys", () => {
+    const summary = buildSummary("2026-03-14", [
+      row({
+        project: "cloudtime",
+        language: "TypeScript",
+        editor: "VSCode",
+        operating_system: "macOS",
+        category: "coding",
+        branch: "main",
+        machine: "laptop",
+        total_seconds: 600,
+      }),
+    ]);
+
+    expect(summary.projects?.[0].name).toBe("cloudtime");
+    expect(summary.languages?.[0].name).toBe("TypeScript");
+    expect(summary.editors?.[0].name).toBe("VSCode");
+    expect(summary.operating_systems?.[0].name).toBe("macOS");
+    expect(summary.categories?.[0].name).toBe("coding");
+    expect(summary.branches?.[0].name).toBe("main");
+    expect(summary.machines?.[0].name).toBe("laptop");
+  });
+
+  it("records the timezone in range.timezone (defaulting to UTC when unset)", () => {
+    const tokyo = buildSummary("2026-03-14", [], "Asia/Tokyo");
+    expect(tokyo.range.timezone).toBe("Asia/Tokyo");
+
+    const utc = buildSummary("2026-03-14", []);
+    expect(utc.range.timezone).toBe("UTC");
+  });
+
+  it("returns zero grand_total for empty rows", () => {
+    const summary = buildSummary("2026-03-14", []);
+    expect(summary.grand_total.total_seconds).toBe(0);
+    expect(summary.grand_total.digital).toBe("0:00");
+    expect(summary.grand_total.text).toBe("0 secs");
+  });
+});

--- a/tests/aggregation/time-format.test.ts
+++ b/tests/aggregation/time-format.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDigital,
+  formatHumanReadable,
+  getDateForTimestamp,
+  getEpochBoundsForDate,
+  isValidTimezone,
+} from "../../src/utils/time-format";
+
+describe("isValidTimezone", () => {
+  it("accepts known IANA zones", () => {
+    expect(isValidTimezone("UTC")).toBe(true);
+    expect(isValidTimezone("Asia/Tokyo")).toBe(true);
+    expect(isValidTimezone("America/New_York")).toBe(true);
+  });
+
+  it("rejects nonsense values", () => {
+    expect(isValidTimezone("Mars/Olympus")).toBe(false);
+    expect(isValidTimezone("not a tz")).toBe(false);
+  });
+});
+
+describe("getDateForTimestamp", () => {
+  it("returns YYYY-MM-DD in UTC when no timezone is given", () => {
+    // 2026-03-14 16:00 UTC
+    const epoch = Date.UTC(2026, 2, 14, 16, 0, 0) / 1000;
+    expect(getDateForTimestamp(epoch)).toBe("2026-03-14");
+  });
+
+  it("buckets across the UTC day boundary into the user's local date — Asia/Tokyo", () => {
+    // 2026-03-13 23:30 UTC = 2026-03-14 08:30 JST (UTC+9)
+    const epoch = Date.UTC(2026, 2, 13, 23, 30, 0) / 1000;
+    expect(getDateForTimestamp(epoch, "Asia/Tokyo")).toBe("2026-03-14");
+    expect(getDateForTimestamp(epoch, "UTC")).toBe("2026-03-13");
+  });
+
+  it("buckets across the UTC day boundary into the user's local date — America/New_York", () => {
+    // 2026-03-14 02:00 UTC = 2026-03-13 22:00 EDT (UTC-4)
+    const epoch = Date.UTC(2026, 2, 14, 2, 0, 0) / 1000;
+    expect(getDateForTimestamp(epoch, "America/New_York")).toBe("2026-03-13");
+  });
+
+  it("falls back to UTC when the timezone is unknown", () => {
+    const epoch = Date.UTC(2026, 2, 14, 12, 0, 0) / 1000;
+    expect(getDateForTimestamp(epoch, "Mars/Olympus")).toBe("2026-03-14");
+  });
+});
+
+describe("getEpochBoundsForDate", () => {
+  it("returns 24-hour bounds for a UTC day", () => {
+    const { start, end } = getEpochBoundsForDate("2026-03-14", "UTC");
+    expect(end - start).toBe(86400);
+    expect(start).toBe(Date.UTC(2026, 2, 14) / 1000);
+  });
+
+  it("computes JST midnight bounds shifted 9 hours earlier than UTC", () => {
+    const { start, end } = getEpochBoundsForDate("2026-03-14", "Asia/Tokyo");
+    expect(end - start).toBe(86400);
+    // JST midnight of 2026-03-14 == 2026-03-13 15:00 UTC
+    expect(start).toBe(Date.UTC(2026, 2, 13, 15, 0, 0) / 1000);
+  });
+
+  it("returns a 23-hour day across the US spring-forward DST transition", () => {
+    // America/New_York 2026-03-08 is the second-Sunday spring-forward day.
+    // Local midnight to next midnight should span 23 hours of real time.
+    const { start, end } = getEpochBoundsForDate("2026-03-08", "America/New_York");
+    expect(end - start).toBe(23 * 3600);
+  });
+
+  it("returns a 25-hour day across the US fall-back DST transition", () => {
+    // America/New_York 2026-11-01 is the first-Sunday fall-back day.
+    const { start, end } = getEpochBoundsForDate("2026-11-01", "America/New_York");
+    expect(end - start).toBe(25 * 3600);
+  });
+});
+
+describe("formatDigital", () => {
+  it("formats seconds as H:MM", () => {
+    expect(formatDigital(0)).toBe("0:00");
+    expect(formatDigital(59)).toBe("0:00");
+    expect(formatDigital(60)).toBe("0:01");
+    expect(formatDigital(3600)).toBe("1:00");
+    expect(formatDigital(9000)).toBe("2:30");
+  });
+});
+
+describe("formatHumanReadable", () => {
+  it("returns '0 secs' for exactly zero", () => {
+    expect(formatHumanReadable(0)).toBe("0 secs");
+  });
+
+  it("pluralises hours and minutes correctly", () => {
+    expect(formatHumanReadable(3600)).toBe("1 hr");
+    expect(formatHumanReadable(7200)).toBe("2 hrs");
+    expect(formatHumanReadable(60)).toBe("1 min");
+    expect(formatHumanReadable(9000)).toBe("2 hrs 30 mins");
+  });
+
+  it("falls back to seconds only when sub-minute", () => {
+    expect(formatHumanReadable(45)).toBe("45 secs");
+    expect(formatHumanReadable(1)).toBe("1 sec");
+  });
+});

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -1,0 +1,33 @@
+/// <reference path="../node_modules/@cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts" />
+
+declare module "*.sql?raw" {
+  const content: string;
+  export default content;
+}
+
+// Augment the global Cloudflare.Env (from @cloudflare/workers-types) with the
+// project's actual bindings so `import { env } from "cloudflare:test"` /
+// `cloudflare:workers` are typed correctly inside tests.
+declare global {
+  namespace Cloudflare {
+    interface Env {
+      DB: D1Database;
+      KV: KVNamespace;
+      GITHUB_CLIENT_ID: string;
+      GITHUB_CLIENT_SECRET: string;
+      GOOGLE_CLIENT_ID: string;
+      GOOGLE_CLIENT_SECRET: string;
+      DISCORD_CLIENT_ID: string;
+      DISCORD_CLIENT_SECRET: string;
+      ENCRYPTION_KEY: string;
+      INSTANCE_MODE?: string;
+      ENVIRONMENT?: string;
+      APP_URL?: string;
+      GOOGLE_HOSTED_DOMAIN?: string;
+      RATE_LIMIT_OAUTH_INITIATE?: import("../src/types").RateLimit;
+      RATE_LIMIT_OAUTH_CALLBACK?: import("../src/types").RateLimit;
+    }
+  }
+}
+
+export {};

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,84 @@
+/**
+ * Test fixtures that seed the in-memory D1 used by vitest-pool-workers.
+ * Helpers mint deterministic users with API keys / session tokens so
+ * integration tests can authenticate without going through OAuth.
+ */
+import { env } from "cloudflare:test";
+import { generateApiKey, generateSessionToken, sha256Hex } from "../../src/utils/crypto";
+
+export interface SeededUser {
+  userId: string;
+  username: string;
+  apiKey: string;
+  apiKeyHash: string;
+}
+
+export interface SeededSession extends SeededUser {
+  sessionToken: string;
+  sessionTokenHash: string;
+}
+
+/**
+ * Insert a fresh user row with a generated API key and return both the
+ * plaintext key (for use in Authorization headers) and the user_id.
+ */
+export async function seedUser(
+  overrides: Partial<{
+    username: string;
+    email: string | null;
+    timezone: string;
+    emailVerified: boolean;
+  }> = {},
+): Promise<SeededUser> {
+  const userId = crypto.randomUUID();
+  const username = overrides.username ?? `testuser_${userId.slice(0, 8)}`;
+  const { plaintext: apiKey, hash: apiKeyHash } = await generateApiKey();
+
+  await env.DB.prepare(
+    `INSERT INTO users (id, username, email, email_verified, timezone, api_key_hash, created_at, modified_at)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+  )
+    .bind(
+      userId,
+      username,
+      overrides.email ?? `${username}@example.test`,
+      overrides.emailVerified === false ? 0 : 1,
+      overrides.timezone ?? "UTC",
+      apiKeyHash,
+    )
+    .run();
+
+  return { userId, username, apiKey, apiKeyHash };
+}
+
+/**
+ * Seed a user and create an active session for them. Used by tests that
+ * exercise session-cookie protected routes.
+ */
+export async function seedUserWithSession(
+  overrides?: Parameters<typeof seedUser>[0],
+): Promise<SeededSession> {
+  const user = await seedUser(overrides);
+  const sessionToken = generateSessionToken();
+  const sessionTokenHash = await sha256Hex(sessionToken);
+
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at, last_active_at)
+     VALUES (?, ?, ?, datetime('now'), datetime('now', '+7 days'), datetime('now'))`,
+  )
+    .bind(crypto.randomUUID(), user.userId, sessionTokenHash)
+    .run();
+
+  return { ...user, sessionToken, sessionTokenHash };
+}
+
+/**
+ * Reset all rows from the listed tables. Useful between tests that share
+ * state. vitest-pool-workers isolates storage per test file, but within a
+ * file you may want to start fresh between cases.
+ */
+export async function truncate(...tables: string[]): Promise<void> {
+  for (const table of tables) {
+    await env.DB.prepare(`DELETE FROM ${table}`).run();
+  }
+}

--- a/tests/integration/heartbeats.test.ts
+++ b/tests/integration/heartbeats.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration tests for POST /api/v1/users/current/heartbeats and the bulk
+ * variant. Uses a real in-memory D1 (vitest-pool-workers) and exercises the
+ * authMiddleware via API key bearer authentication.
+ */
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice" });
+});
+
+afterEach(async () => {
+  await truncate("heartbeats", "user_projects", "users");
+  // KV cache from the auth middleware would otherwise outlive the user row.
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function callWorker(path: string, init: RequestInit): Promise<Response> {
+  const ctx = createExecutionContext();
+  const req = new Request(`https://test.cloudtime.dev${path}`, init);
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authHeader(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+const TIME_2026_03_14_10_00_UTC = Date.UTC(2026, 2, 14, 10, 0, 0) / 1000;
+
+describe("POST /api/v1/users/current/heartbeats — single", () => {
+  it("rejects requests without authentication with 401", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entity: "main.ts", type: "file", time: TIME_2026_03_14_10_00_UTC }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid API keys with 401", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader("ck_definitely_not_a_real_key"),
+      },
+      body: JSON.stringify({ entity: "main.ts", type: "file", time: TIME_2026_03_14_10_00_UTC }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a heartbeat row with 201 + data envelope on a valid request", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: JSON.stringify({
+        entity: "src/index.ts",
+        type: "file",
+        time: TIME_2026_03_14_10_00_UTC,
+        project: "cloudtime",
+        language: "TypeScript",
+        is_write: true,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { id: string; entity: string } };
+    expect(body.data.entity).toBe("src/index.ts");
+    expect(body.data.id).toMatch(/^[0-9a-f-]{36}$/i);
+
+    const row = await env.DB.prepare(
+      "SELECT user_id, entity, project, language, is_write FROM heartbeats WHERE id = ?",
+    )
+      .bind(body.data.id)
+      .first<{ user_id: string; entity: string; project: string; language: string; is_write: number }>();
+
+    expect(row).toMatchObject({
+      user_id: user.userId,
+      entity: "src/index.ts",
+      project: "cloudtime",
+      language: "TypeScript",
+      is_write: 1,
+    });
+  });
+
+  it("returns 400 on malformed JSON", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when entity is missing", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: JSON.stringify({ type: "file", time: TIME_2026_03_14_10_00_UTC }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/v1/users/current/heartbeats.bulk", () => {
+  it("inserts multiple heartbeats and returns per-item responses", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: JSON.stringify([
+        { entity: "a.ts", type: "file", time: TIME_2026_03_14_10_00_UTC },
+        { entity: "b.ts", type: "file", time: TIME_2026_03_14_10_00_UTC + 30 },
+      ]),
+    });
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      responses: Array<[{ data: { id: string } | null; error: string | null }, number]>;
+    };
+    expect(body.responses).toHaveLength(2);
+    expect(body.responses[0][1]).toBe(201);
+    expect(body.responses[1][1]).toBe(201);
+    expect(body.responses[0][0].data?.id).toMatch(/^[0-9a-f-]{36}$/i);
+
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM heartbeats WHERE user_id = ?",
+    )
+      .bind(user.userId)
+      .first<{ c: number }>();
+    expect(count?.c).toBe(2);
+  });
+
+  it("returns per-item 400 for invalid heartbeats while still inserting valid ones", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: JSON.stringify([
+        { entity: "good.ts", type: "file", time: TIME_2026_03_14_10_00_UTC },
+        { entity: "", type: "file", time: TIME_2026_03_14_10_00_UTC }, // missing entity
+        { entity: "good2.ts", type: "file", time: TIME_2026_03_14_10_00_UTC + 60 },
+      ]),
+    });
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      responses: Array<[{ data: unknown; error: string | null }, number]>;
+    };
+    expect(body.responses[0][1]).toBe(201);
+    expect(body.responses[1][1]).toBe(400);
+    expect(body.responses[1][0].error).toBeTruthy();
+    expect(body.responses[2][1]).toBe(201);
+
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM heartbeats WHERE user_id = ?",
+    )
+      .bind(user.userId)
+      .first<{ c: number }>();
+    expect(count?.c).toBe(2);
+  });
+
+  it("rejects bulk batches larger than 25 items with 400", async () => {
+    const batch = Array.from({ length: 26 }, (_, i) => ({
+      entity: `f${i}.ts`,
+      type: "file" as const,
+      time: TIME_2026_03_14_10_00_UTC + i,
+    }));
+
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: JSON.stringify(batch),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty array body with 400", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(user.apiKey),
+      },
+      body: "[]",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/users/current/heartbeats", () => {
+  it("returns the heartbeats inserted by the same API key, isolated per user", async () => {
+    // Insert one heartbeat for our user, and one for a second user
+    const other = await seedUser({ username: "bob" });
+
+    await env.DB.batch([
+      env.DB
+        .prepare(
+          "INSERT INTO heartbeats (id, user_id, entity, type, time, is_write) VALUES (?, ?, ?, ?, ?, 0)",
+        )
+        .bind(crypto.randomUUID(), user.userId, "alice.ts", "file", TIME_2026_03_14_10_00_UTC),
+      env.DB
+        .prepare(
+          "INSERT INTO heartbeats (id, user_id, entity, type, time, is_write) VALUES (?, ?, ?, ?, ?, 0)",
+        )
+        .bind(crypto.randomUUID(), other.userId, "bob.ts", "file", TIME_2026_03_14_10_00_UTC),
+    ]);
+
+    const res = await callWorker(
+      "/api/v1/users/current/heartbeats?date=2026-03-14",
+      { headers: authHeader(user.apiKey) },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { entity: string }[] };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].entity).toBe("alice.ts");
+
+    await env.KV.delete(`apikey:${other.apiKeyHash}`);
+  });
+
+  it("returns 400 when date query parameter is missing", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      headers: authHeader(user.apiKey),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/security/crypto.test.ts
+++ b/tests/security/crypto.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  base64url,
+  decryptToken,
+  encryptToken,
+  generateApiKey,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateNonce,
+  generateSessionToken,
+  generateState,
+  sha256Hex,
+  timingSafeEqual,
+} from "../../src/utils/crypto";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("sha256Hex", () => {
+  it("produces 64 lowercase hex chars matching a known vector", async () => {
+    // SHA-256("hello") well-known digest
+    expect(await sha256Hex("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+
+  it("produces 64 hex chars for arbitrary input", async () => {
+    expect(await sha256Hex("")).toMatch(/^[0-9a-f]{64}$/);
+    expect(await sha256Hex("a longer string with spaces")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("base64url", () => {
+  it("encodes binary input as URL-safe base64 with no padding", async () => {
+    const bytes = new Uint8Array([0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa]);
+    const encoded = base64url(bytes);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+  });
+});
+
+describe("PKCE generation", () => {
+  it("produces distinct verifiers across calls", () => {
+    const a = generateCodeVerifier();
+    const b = generateCodeVerifier();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a.length).toBeGreaterThan(30);
+  });
+
+  it("derives a stable code_challenge from a given verifier (S256)", async () => {
+    const verifier = generateCodeVerifier();
+    const c1 = await generateCodeChallenge(verifier);
+    const c2 = await generateCodeChallenge(verifier);
+    expect(c1).toBe(c2);
+    expect(c1).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives different challenges for different verifiers", async () => {
+    const c1 = await generateCodeChallenge(generateCodeVerifier());
+    const c2 = await generateCodeChallenge(generateCodeVerifier());
+    expect(c1).not.toBe(c2);
+  });
+});
+
+describe("state / session / nonce / api-key generators", () => {
+  it("returns distinct random tokens", () => {
+    expect(generateState()).not.toBe(generateState());
+    expect(generateSessionToken()).not.toBe(generateSessionToken());
+    expect(generateNonce()).not.toBe(generateNonce());
+  });
+
+  it("generateApiKey returns ck_-prefixed plaintext and matching sha256 hash", async () => {
+    const { plaintext, hash } = await generateApiKey();
+    expect(plaintext).toMatch(/^ck_[A-Za-z0-9_-]+$/);
+    expect(hash).toBe(await sha256Hex(plaintext));
+  });
+});
+
+describe("AES-256-GCM encryptToken / decryptToken", () => {
+  it("round-trips plaintext when the same key + context is used", async () => {
+    const enc = await encryptToken("super-secret-token", TEST_KEY, "user-123:google");
+    const dec = await decryptToken(enc, TEST_KEY, "user-123:google");
+    expect(dec).toBe("super-secret-token");
+  });
+
+  it("uses a fresh IV per encryption (ciphertexts differ for the same plaintext)", async () => {
+    const a = await encryptToken("x", TEST_KEY, "ctx");
+    const b = await encryptToken("x", TEST_KEY, "ctx");
+    expect(a).not.toBe(b);
+  });
+
+  it("fails to decrypt when the AAD context does not match", async () => {
+    const enc = await encryptToken("x", TEST_KEY, "user-A:google");
+    await expect(decryptToken(enc, TEST_KEY, "user-B:google")).rejects.toThrow();
+  });
+
+  it("rejects malformed key lengths", async () => {
+    await expect(encryptToken("x", "tooshort", "ctx")).rejects.toThrow(
+      /64 hex characters/,
+    );
+  });
+
+  it("rejects malformed encrypted payload", async () => {
+    await expect(decryptToken("not-a-valid-payload", TEST_KEY, "ctx")).rejects.toThrow();
+  });
+});
+
+describe("timingSafeEqual", () => {
+  it("returns true for identical strings", async () => {
+    expect(await timingSafeEqual("hello", "hello")).toBe(true);
+  });
+
+  it("returns false for different strings of the same length", async () => {
+    expect(await timingSafeEqual("hello", "world")).toBe(false);
+  });
+
+  it("returns false for strings of different lengths (after hashing they are still distinct)", async () => {
+    expect(await timingSafeEqual("a", "ab")).toBe(false);
+  });
+
+  it("returns true regardless of input length when the inputs are identical", async () => {
+    const longA = "x".repeat(10_000);
+    expect(await timingSafeEqual(longA, longA)).toBe(true);
+  });
+});

--- a/tests/security/rate-limit.test.ts
+++ b/tests/security/rate-limit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for src/middleware/rate-limit.ts. Mounts the middleware on a
+ * throwaway Hono app and observes the `key` argument passed to a
+ * fake RateLimit binding to verify IP truncation behaviour.
+ */
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { rateLimitMiddleware } from "../../src/middleware/rate-limit";
+import type { Env, RateLimit } from "../../src/types";
+
+interface FakeRateLimit extends RateLimit {
+  readonly keys: string[];
+}
+
+function fakeBinding(decision: { success: boolean }): FakeRateLimit {
+  const keys: string[] = [];
+  return {
+    keys,
+    async limit({ key }) {
+      keys.push(key);
+      return decision;
+    },
+  };
+}
+
+function buildApp(binding: RateLimit | undefined) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.get(
+    "/ping",
+    rateLimitMiddleware(() => binding, "test-endpoint", "TEST_RULE"),
+    (c) => c.json({ ok: true }),
+  );
+  return app;
+}
+
+const sharedEnv = {} as Env;
+
+async function call(
+  app: Hono<{ Bindings: Env }>,
+  headers: Record<string, string>,
+  env: Env = sharedEnv,
+) {
+  return app.request("/ping", { headers }, env);
+}
+
+describe("rate-limit middleware — IP key derivation", () => {
+  it("truncates IPv4 to /24 using CF-Connecting-IP", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    const res = await call(app, { "CF-Connecting-IP": "203.0.113.42" });
+
+    expect(res.status).toBe(200);
+    expect(binding.keys).toEqual(["203.0.113.0/24"]);
+  });
+
+  it("truncates IPv6 to /48 with lower-case normalisation", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    await call(app, { "CF-Connecting-IP": "2001:DB8:ABCD:1234::1" });
+
+    expect(binding.keys).toEqual(["2001:db8:abcd::/48"]);
+  });
+
+  it("derives a single /48 key from any /128 inside the same /48", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    await call(app, { "CF-Connecting-IP": "2001:db8:abcd:1234::1" });
+    await call(app, { "CF-Connecting-IP": "2001:db8:abcd:ffff:1:2:3:4" });
+
+    expect(new Set(binding.keys)).toEqual(new Set(["2001:db8:abcd::/48"]));
+  });
+
+  it("falls back to the first X-Forwarded-For hop when CF-Connecting-IP is absent", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    await call(app, {
+      "X-Forwarded-For": "198.51.100.7, 198.51.100.99, 10.0.0.1",
+    });
+
+    expect(binding.keys).toEqual(["198.51.100.0/24"]);
+  });
+
+  it("uses the literal \"unknown\" key when no IP header is present", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    await call(app, {});
+
+    expect(binding.keys).toEqual(["unknown"]);
+  });
+
+  it("strips IPv6 brackets and zone identifiers before truncation", async () => {
+    const binding = fakeBinding({ success: true });
+    const app = buildApp(binding);
+
+    await call(app, { "CF-Connecting-IP": "[2001:db8:abcd:1234::1]" });
+    await call(app, { "CF-Connecting-IP": "2001:db8:abcd:1234::1%eth0" });
+
+    expect(binding.keys).toEqual([
+      "2001:db8:abcd::/48",
+      "2001:db8:abcd::/48",
+    ]);
+  });
+});
+
+describe("rate-limit middleware — decision handling", () => {
+  it("calls next() and returns 200 when the binding reports success", async () => {
+    const app = buildApp(fakeBinding({ success: true }));
+
+    const res = await call(app, { "CF-Connecting-IP": "203.0.113.42" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 429 with Retry-After and no-store headers when the binding rejects", async () => {
+    const app = buildApp(fakeBinding({ success: false }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await call(app, { "CF-Connecting-IP": "203.0.113.42" });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    expect(await res.json()).toEqual({ error: "Too many requests" });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain("rejected");
+    expect(warnSpy.mock.calls[0][0]).toContain("203.0.113.0/24");
+
+    warnSpy.mockRestore();
+  });
+
+  it("fails open and warns exactly once per env when the binding is undefined", async () => {
+    const app = buildApp(undefined);
+    const env = {} as Env; // fresh env — first warning expected
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res1 = await call(app, { "CF-Connecting-IP": "203.0.113.42" }, env);
+    const res2 = await call(app, { "CF-Connecting-IP": "203.0.113.42" }, env);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    // WeakSet keyed on env: same env reference, so the warn happens once.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Vitest setup for vitest-pool-workers. Runs once per test file before
+ * any test, inside the Workers runtime. Initialises the test D1 with our
+ * production schema so tests can prepare/run queries directly against env.DB.
+ *
+ * Vite's `?raw` import keeps the SQL bundled at build time — there is no
+ * filesystem at runtime in a Worker.
+ */
+import { env } from "cloudflare:test";
+// @ts-expect-error — Vite ?raw import; types provided by vite-env.d.ts
+import schemaSql from "../src/db/schema.sql?raw";
+
+function splitStatements(sql: string): string[] {
+  // Strip line comments, then split on `;` at statement boundaries.
+  // D1 schema.sql in this project contains only simple CREATE TABLE /
+  // CREATE INDEX statements — no triggers, procedures, or embedded `;`.
+  return sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+const statements = splitStatements(schemaSql);
+for (const stmt of statements) {
+  await env.DB.prepare(stmt).run();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.mts"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
   "exclude": ["node_modules"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,30 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      main: "./src/index.ts",
+      miniflare: {
+        compatibilityDate: "2025-03-09",
+        d1Databases: ["DB"],
+        kvNamespaces: ["KV"],
+        bindings: {
+          INSTANCE_MODE: "single",
+          GITHUB_CLIENT_ID: "test-github-client-id",
+          GITHUB_CLIENT_SECRET: "test-github-client-secret",
+          GOOGLE_CLIENT_ID: "test-google-client-id",
+          GOOGLE_CLIENT_SECRET: "test-google-client-secret",
+          DISCORD_CLIENT_ID: "test-discord-client-id",
+          DISCORD_CLIENT_SECRET: "test-discord-client-secret",
+          ENCRYPTION_KEY:
+            "0000000000000000000000000000000000000000000000000000000000000000",
+          APP_URL: "https://test.cloudtime.dev",
+        },
+      },
+    }),
+  ],
+  test: {
+    setupFiles: ["./tests/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Introduces the project's first automated test suite — running inside the real Cloudflare Workers runtime via `@cloudflare/vitest-pool-workers` — plus the first CI workflow. Replaces the implicit "no test infrastructure" expectation in CLAUDE.md.

## Why this stack

Researched current Cloudflare guidance ([docs](https://developers.cloudflare.com/workers/testing/vitest-integration/), [Hono example](https://hono.dev/examples/cloudflare-vitest), [workers-sdk vitest-pool-workers fixtures](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples)) and chose Vitest + `@cloudflare/vitest-pool-workers` because:

- Tests execute against the real D1, KV, and rate-limit bindings via miniflare — no behaviour drift from production.
- Vite's `?raw` import lets us load `src/db/schema.sql` once per file with no extra fixture build step.
- Per-file isolated storage avoids cross-test pollution.

`@cloudflare/vitest-pool-workers@0.16` is ESM-only, so `vitest.config.mts` (not `.ts`) is required to avoid the externalize-deps loader.

## What lands

### Tooling
- `vitest.config.mts` — Workers pool wired with D1 (`DB`), KV (`KV`), stubbed OAuth secrets, `ENCRYPTION_KEY`, and `APP_URL`.
- `tests/setup.ts` — applies `src/db/schema.sql` once per file via `?raw` import.
- `tests/env.d.ts` — augments `Cloudflare.Env` so `cloudflare:test` and `cloudflare:workers` `env` imports are typed against project bindings.
- `tests/helpers/fixtures.ts` — `seedUser()` / `seedUserWithSession()` mint authenticated principals without going through OAuth.
- npm scripts: `test`, `test:watch`, `typecheck`.

### Coverage on day one (60 tests / 5 files)

| Area | File | Highlights |
|---|---|---|
| Security | `tests/security/rate-limit.test.ts` | IPv4 /24, IPv6 /48, header fallback, fail-open, 429 shape |
| Security | `tests/security/crypto.test.ts` | SHA-256 vector, PKCE, AES-256-GCM with AAD, timingSafeEqual |
| Aggregation | `tests/aggregation/time-format.test.ts` | UTC vs profile-TZ bucketing, 23h/25h DST days |
| Aggregation | `tests/aggregation/summary-builder.test.ts` | Dimension aggregation, percent rounding |
| Heartbeat | `tests/integration/heartbeats.test.ts` | Single + bulk POST, validation, user isolation, GET by date |

### CI
- `.github/workflows/test.yml` runs `npm run typecheck` then `npm test` on every PR/push to `develop` and `master`. Closes the "no checks reported" gap in PR review.

### CLAUDE.md
- New Testing section documenting test layout and commands.

## Out of scope (deliberate follow-ups)
- OAuth callback flow tests (need declarative HTTP mocking, MSW or imperative `vi.spyOn(globalThis, 'fetch')`).
- End-to-end cron aggregator tests against seeded heartbeats.
- Coverage thresholds in CI.

## Test plan

- [x] `npm test` passes locally: 60 tests / 5 files
- [x] `npm run typecheck` passes (zero errors across `src/**` and `tests/**`)
- [x] No production behaviour changes — only test files, config, devDeps, CI
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
