### PR TITLE
spec: out-of-band email verification for PendingLink (PR1/2) #80

### DIFF
--- a/migrations/0002_pending_link_email_verification.sql
+++ b/migrations/0002_pending_link_email_verification.sql
@@ -1,0 +1,15 @@
+-- Out-of-band email verification for PendingLink approval (Issue #80).
+-- Adds two nullable columns to pending_links and an index for the verify
+-- endpoint lookup. Idempotent within a single instance because both column
+-- adds will fail if applied twice — guard with the migration framework, not
+-- with IF NOT EXISTS (which SQLite does not support on ALTER TABLE).
+
+ALTER TABLE pending_links ADD COLUMN email_verification_token_hash TEXT;
+ALTER TABLE pending_links ADD COLUMN email_verified_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
+  ON pending_links(email_verification_token_hash);
+
+-- No backfill. Pre-existing rows remain with NULL in both columns and can
+-- only be approved by re-triggering the OAuth merge flow under the new
+-- pipeline. PendingLink TTL is short (1 hour) so the window is bounded.

--- a/schemas/components/responses/Gone.yaml
+++ b/schemas/components/responses/Gone.yaml
@@ -1,0 +1,12 @@
+description: |
+  The resource exists but is no longer available. Used by single-use
+  verification flows where the token has been consumed, expired, or
+  never existed.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Token expired

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -68,6 +68,8 @@ paths:
     $ref: paths/auth/link-provider-callback.yaml
   /auth/link/approve/{pending_link_id}:
     $ref: paths/auth/link-approve.yaml
+  /auth/link/verify/{token}:
+    $ref: paths/auth/link-verify-token.yaml
   /auth/providers:
     $ref: paths/auth/providers.yaml
   /auth/providers/{provider}:

--- a/schemas/paths/auth/link-approve.yaml
+++ b/schemas/paths/auth/link-approve.yaml
@@ -36,6 +36,8 @@ post:
                     $ref: ../../components/schemas/User.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../components/responses/Forbidden.yaml
     '404':
       $ref: ../../components/responses/NotFound.yaml
     '410':

--- a/schemas/paths/auth/link-verify-token.yaml
+++ b/schemas/paths/auth/link-verify-token.yaml
@@ -1,0 +1,47 @@
+get:
+  operationId: verifyLinkEmailToken
+  tags:
+    - auth
+  summary: Out-of-band email verification for PendingLink
+  description: |
+    Verifies the recipient's inbox access for an outstanding PendingLink.
+    The token is single-use and embedded in a one-time email sent at
+    PendingLink creation.
+
+    On first successful hit within the token's TTL, the server marks the
+    underlying PendingLink row as email-verified. Subsequent hits, hits
+    against an expired row, and hits against an unknown token all return
+    410 Gone. The endpoint is public (no auth) because the recipient may
+    not have a CloudTime session in the browser used to open the email.
+
+    The state change occurs on GET because the token itself is the proof
+    of authorisation; this is acceptable for single-use tokens and is
+    intentionally compatible with mobile email clients that pre-fetch
+    links (pre-fetch consumes the token; user clicks then see 410 — this
+    behaviour is documented in the operator runbook).
+
+    See specs/080-out-of-band-email-verification/.
+  security: []
+  parameters:
+    - name: token
+      in: path
+      required: true
+      schema:
+        type: string
+      description: |
+        32-byte base64url-encoded one-time token. Plaintext appears only
+        in the email body; only the SHA-256 hash is persisted server-side.
+  responses:
+    '200':
+      description: Verification succeeded. Recipient should return to CloudTime to approve the merge.
+      content:
+        text/html:
+          schema:
+            type: string
+          example: |
+            <!doctype html><h1>Email verified</h1>
+            <p>Return to CloudTime and approve the account merge.</p>
+    '405':
+      description: Method Not Allowed — verify endpoint only accepts GET.
+    '410':
+      $ref: ../../components/responses/Gone.yaml

--- a/specs/080-out-of-band-email-verification/checklists/requirements.md
+++ b/specs/080-out-of-band-email-verification/checklists/requirements.md
@@ -28,8 +28,10 @@ This checklist enforces the gates between PR1 / PR2 / production deployment.
 - [ ] `src/utils/email/types.ts` exports `EmailMessage`, `EmailProvider`, `EmailNotConfiguredError`, `EmailSendError`.
 - [ ] `src/utils/email/resend.ts` posts to `https://api.resend.com/emails` with bearer auth and a 2-second `AbortSignal.timeout(2000)`.
 - [ ] `src/utils/email/index.ts` selects provider by `env.EMAIL_PROVIDER` and exposes a single `sendEmail(env, msg)` entry point.
+- [ ] `src/routes/auth/login.ts` checks `INSTANCE_MODE` before same-email PendingLink creation so single-user mode never sends email or writes `pending_links`.
 - [ ] `src/routes/auth/login.ts` sends the email **before** the PendingLink INSERT. Failure path rolls back (no row written).
 - [ ] `src/routes/auth/link.ts` has a new `GET /link/verify/:token` handler implemented via UPDATE-with-RETURNING.
+- [ ] `src/routes/auth/link.ts` or the top-level router returns 405 for non-GET `/link/verify/:token` before global CSRF can return 403.
 - [ ] `src/routes/auth/link.ts` `POST /link/approve/:pending_link_id` returns 403 when `email_verified_at` is NULL.
 - [ ] `src/utils/crypto.ts` exposes `generateVerificationToken()` returning `{plaintext, hash}`.
 - [ ] `npx tsc --noEmit` passes with zero errors.
@@ -44,8 +46,8 @@ This checklist enforces the gates between PR1 / PR2 / production deployment.
 - [ ] Scenario D: expired token returns 410 Gone.
 - [ ] Scenario E: invalid provider key rolls back the PendingLink and surfaces 502.
 - [ ] Scenario F: missing `EMAIL_PROVIDER` surfaces 503 and emits a single warning per isolate.
-- [ ] Scenario G: single-user mode behaviour is unchanged (no emails, verify endpoint always 410).
-- [ ] Scenario H: non-GET methods return 405.
+- [ ] Scenario G: single-user mode behaviour is unchanged (no PendingLink rows, no emails, no email-provider requirement, verify endpoint always 410).
+- [ ] Scenario H: non-GET methods return 405 even without an `Origin` header.
 
 ### Documentation
 

--- a/specs/080-out-of-band-email-verification/checklists/requirements.md
+++ b/specs/080-out-of-band-email-verification/checklists/requirements.md
@@ -1,0 +1,62 @@
+# Acceptance Checklist: Out-of-Band Email Verification for PendingLink
+
+This checklist enforces the gates between PR1 / PR2 / production deployment.
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [ ] `spec.md` covers FR-001..FR-012 and NFRs with no `[NEEDS CLARIFICATION]` markers.
+- [ ] `plan.md` Constitution Check has all five principles marked PASS.
+- [ ] `research.md` documents the 8 design decisions (provider, fail mode, token shape, GET semantics, TTL, response shape, selector explicitness, no-retry).
+- [ ] `data-model.md` describes the two new columns and explicitly states "no backfill" with rationale.
+- [ ] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [ ] `contracts/openapi-diff.md` shows additive-only schema changes (new path, new 410 component, 403 added to existing approve path).
+- [ ] `schemas/components/responses/Gone.yaml` exists and follows the shape of `Unauthorized.yaml` / `Forbidden.yaml`.
+- [ ] `schemas/paths/auth/link-verify-token.yaml` declares 200 / 405 / 410.
+- [ ] `schemas/paths/auth/link-approve.yaml` references `Forbidden.yaml` under `403`.
+- [ ] `schemas/openapi.yaml` wires the new path.
+- [ ] `migrations/0002_pending_link_email_verification.sql` exists, idempotent (`IF NOT EXISTS` on the index), backwards-compatible (columns are nullable).
+- [ ] `src/db/schema.sql` is updated so fresh deployments via `npm run db:init` include the new columns.
+- [ ] `npm run generate` runs cleanly. `git diff src/types/generated.ts` shows additive changes only.
+- [ ] PR1 contains no changes under `src/utils/email/`, `src/routes/auth/login.ts`, `src/routes/auth/link.ts`, or `src/types.ts`.
+- [ ] PR1 description references Issue #80 and the SpecKit 2-PR workflow.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/types.ts` declares `EMAIL_PROVIDER?: string`, `EMAIL_FROM?: string`, `RESEND_API_KEY?: string` on `Env`.
+- [ ] `src/utils/email/types.ts` exports `EmailMessage`, `EmailProvider`, `EmailNotConfiguredError`, `EmailSendError`.
+- [ ] `src/utils/email/resend.ts` posts to `https://api.resend.com/emails` with bearer auth and a 2-second `AbortSignal.timeout(2000)`.
+- [ ] `src/utils/email/index.ts` selects provider by `env.EMAIL_PROVIDER` and exposes a single `sendEmail(env, msg)` entry point.
+- [ ] `src/routes/auth/login.ts` sends the email **before** the PendingLink INSERT. Failure path rolls back (no row written).
+- [ ] `src/routes/auth/link.ts` has a new `GET /link/verify/:token` handler implemented via UPDATE-with-RETURNING.
+- [ ] `src/routes/auth/link.ts` `POST /link/approve/:pending_link_id` returns 403 when `email_verified_at` is NULL.
+- [ ] `src/utils/crypto.ts` exposes `generateVerificationToken()` returning `{plaintext, hash}`.
+- [ ] `npx tsc --noEmit` passes with zero errors.
+- [ ] `npm test` passes including new email and verify tests.
+- [ ] No diff in `src/middleware/`, `src/utils/oauth.ts`, or any GitHub/Discord-specific code path.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] Scenario A: happy path produces 200 on approve after verification.
+- [ ] Scenario B: approve without prior verification returns 403 with the documented body.
+- [ ] Scenario C: token replay returns 410 Gone.
+- [ ] Scenario D: expired token returns 410 Gone.
+- [ ] Scenario E: invalid provider key rolls back the PendingLink and surfaces 502.
+- [ ] Scenario F: missing `EMAIL_PROVIDER` surfaces 503 and emits a single warning per isolate.
+- [ ] Scenario G: single-user mode behaviour is unchanged (no emails, verify endpoint always 410).
+- [ ] Scenario H: non-GET methods return 405.
+
+### Documentation
+
+- [ ] `docs/auth-design.md` PendingLink section describes the verification step.
+- [ ] `docs/email-setup.md` exists with DNS prerequisites, Resend onboarding, deliverability test recipe.
+- [ ] PR2 description references PR1 and #80, attaches scenario results.
+
+## Post-deployment (production) gate
+
+- [ ] Operator confirms SPF/DKIM/DMARC pass on the configured `EMAIL_FROM` domain (mail-tester.com ≥ 9/10).
+- [ ] First 7 days post-deploy: zero PendingLink rows committed without a successful prior email send (verified by sampling logs for missing `[email] sent` lines vs row counts).
+- [ ] First 30 days: zero support reports of approval flows blocked because of stuck `email_verified_at IS NULL` rows after the user clicked the link (would indicate a UPDATE bug).
+- [ ] Resend dashboard: bounce + complaint rate remain ≤ 1% combined.
+- [ ] If false-positive 502s appear (provider transient errors), document the rate and consider Queue-based retry in a follow-up PR.

--- a/specs/080-out-of-band-email-verification/contracts/openapi-diff.md
+++ b/specs/080-out-of-band-email-verification/contracts/openapi-diff.md
@@ -1,0 +1,121 @@
+# OpenAPI Schema Diff
+
+## Files touched
+
+1. **New**: `schemas/components/responses/Gone.yaml`
+2. **New**: `schemas/paths/auth/link-verify-token.yaml`
+3. **Modified**: `schemas/openapi.yaml` — wire the new path
+4. **Modified**: `schemas/paths/auth/link-approve.yaml` — declare the 403 response (existing `Forbidden.yaml` reused)
+
+## Diff 1 — new `Gone.yaml`
+
+Shared 410 component for the verify endpoint's "token expired / already used / not found" responses.
+
+```yaml
+description: |
+  The resource exists but is no longer available. Used by single-use
+  verification flows where the token has been consumed, expired, or
+  never existed.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Token expired
+```
+
+## Diff 2 — new `link-verify-token.yaml`
+
+```yaml
+get:
+  operationId: verifyLinkEmailToken
+  tags:
+    - auth
+  summary: Out-of-band email verification for PendingLink
+  description: |
+    Verifies the recipient's inbox access for an outstanding PendingLink.
+    The token is single-use and embedded in a one-time email sent at
+    PendingLink creation.
+
+    On first successful hit within the token's TTL, the server marks the
+    underlying PendingLink row as email-verified. Subsequent hits, hits
+    against an expired row, and hits against an unknown token all return
+    410 Gone. The endpoint is public (no auth) because the recipient may
+    not have a CloudTime session in the browser used to open the email.
+
+    The state change occurs on GET because the token itself is the proof
+    of authorisation; this is acceptable for single-use tokens and is
+    intentionally compatible with mobile email clients that pre-fetch
+    links (pre-fetch consumes the token; user clicks then see 410 — this
+    behaviour is documented in the operator runbook).
+  security: []
+  parameters:
+    - name: token
+      in: path
+      required: true
+      schema:
+        type: string
+      description: |
+        32-byte base64url-encoded one-time token. Plaintext appears only
+        in the email body; only the SHA-256 hash is persisted server-side.
+  responses:
+    '200':
+      description: Verification succeeded. Recipient should return to CloudTime to approve the merge.
+      content:
+        text/html:
+          schema:
+            type: string
+          example: |
+            <!doctype html><h1>Email verified</h1>
+            <p>Return to CloudTime and approve the account merge.</p>
+    '405':
+      description: Method Not Allowed — verify endpoint only accepts GET.
+    '410':
+      $ref: ../../components/responses/Gone.yaml
+```
+
+## Diff 3 — `schemas/openapi.yaml`
+
+Add the new path under `paths:`. Insertion point sits next to the existing `link-approve` and `link-provider-callback` paths.
+
+```diff
+   /auth/link/approve/{pending_link_id}:
+     $ref: ./paths/auth/link-approve.yaml
++  /auth/link/verify/{token}:
++    $ref: ./paths/auth/link-verify-token.yaml
+   /auth/link/{provider}/callback:
+     $ref: ./paths/auth/link-provider-callback.yaml
+```
+
+## Diff 4 — `link-approve.yaml`
+
+Add the 403 response (reusing the existing `Forbidden.yaml` component introduced for the Google hosted-domain feature). The status semantics are now twofold ("registration closed" was already a possible 403 in the broader auth area; this adds "email verification required").
+
+```diff
+   responses:
+     '200':
+       $ref: ../../components/responses/Success.yaml   # or whatever is current
++    '403':
++      $ref: ../../components/responses/Forbidden.yaml
+     '404':
+       $ref: ../../components/responses/NotFound.yaml
+```
+
+The body shape under `Forbidden.yaml` already includes a generic `error: string`. The specific reason `"Email verification required"` is emitted at runtime; documenting all possible 403 reasons in the component would bloat the schema. The component description already enumerates major scenarios.
+
+## Generated-types impact
+
+`npm run generate` should produce additive changes only:
+- New `Gone` response component → new exported component type.
+- New `verifyLinkEmailToken` operation → new entry under `operations`.
+- 403 response added to `oauthLinkApprove` → operation type gains a `403` key.
+
+No existing exported types are renamed or removed.
+
+## SDD compliance note
+
+Per CLAUDE.md: *"`schemas/openapi.yaml` is the Single Source of Truth"* and *"Always update the spec BEFORE writing implementation code."*
+
+PR1 lands SpecKit artifacts, schema, migration SQL, and generated types. PR2 lands implementation. No runtime code in PR1.

--- a/specs/080-out-of-band-email-verification/data-model.md
+++ b/specs/080-out-of-band-email-verification/data-model.md
@@ -46,7 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
 
 ### Index rationale
 
-The verify endpoint performs a single point lookup on the hash:
+The verify endpoint hashes the URL token once and performs a single point lookup on the stored hash:
 
 ```sql
 UPDATE pending_links
@@ -58,6 +58,8 @@ RETURNING id
 ```
 
 Without the index the lookup is O(n) over all open PendingLinks. Volume is small (3 active per user), but the index is cheap and aligns with project precedent (`idx_pending_links_expires`).
+
+The application does not load `email_verification_token_hash` and compare it to user input in TypeScript. The token is unguessable, the plaintext is never stored, and D1 performs an indexed equality match on the SHA-256 hash.
 
 ## Migration
 

--- a/specs/080-out-of-band-email-verification/data-model.md
+++ b/specs/080-out-of-band-email-verification/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Out-of-Band Email Verification
+
+## Existing schema (relevant fragment)
+
+```sql
+CREATE TABLE IF NOT EXISTS pending_links (
+  id TEXT PRIMARY KEY,
+  existing_user_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  provider_user_id TEXT NOT NULL,
+  provider_username TEXT,
+  provider_email TEXT,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  access_token_encrypted TEXT,
+  refresh_token_encrypted TEXT,
+  token_expires_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL,
+  ...
+);
+```
+
+The existing `email_verified` column tracks the **OAuth provider's** verification claim and is set at row creation. It is NOT what gates approval after this feature.
+
+## Additions
+
+```sql
+ALTER TABLE pending_links ADD COLUMN email_verification_token_hash TEXT;
+ALTER TABLE pending_links ADD COLUMN email_verified_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
+  ON pending_links(email_verification_token_hash);
+```
+
+### Column semantics
+
+| Column | Type | Nullable | Set when | Read by |
+|---|---|---|---|---|
+| `email_verification_token_hash` | TEXT | Yes (legacy rows / single-user mode) | At PendingLink INSERT, SHA-256 of the URL token | Verify endpoint lookup |
+| `email_verified_at` | TEXT (SQL datetime string) | Yes | When verify endpoint successfully consumes the token | Approve endpoint gate; replay detection |
+
+### Distinction from existing fields
+
+- `email_verified` (existing) — claim from the OAuth provider; **boolean**, set on row creation. Used in the dual-verification gate that decides whether to create a PendingLink at all.
+- `email_verified_at` (new) — proof that the human recipient clicked the link from their inbox; **timestamp**, set lazily after the email round-trip. Used as the final gate before approve succeeds.
+
+### Index rationale
+
+The verify endpoint performs a single point lookup on the hash:
+
+```sql
+UPDATE pending_links
+SET email_verified_at = datetime('now')
+WHERE email_verification_token_hash = ?
+  AND email_verified_at IS NULL
+  AND expires_at > datetime('now')
+RETURNING id
+```
+
+Without the index the lookup is O(n) over all open PendingLinks. Volume is small (3 active per user), but the index is cheap and aligns with project precedent (`idx_pending_links_expires`).
+
+## Migration
+
+```sql
+-- migrations/0002_pending_link_email_verification.sql
+ALTER TABLE pending_links ADD COLUMN email_verification_token_hash TEXT;
+ALTER TABLE pending_links ADD COLUMN email_verified_at TEXT;
+CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
+  ON pending_links(email_verification_token_hash);
+```
+
+### Backfill policy
+
+**No backfill.** Pre-existing rows have `email_verified_at IS NULL` and therefore cannot be approved once this feature is live. Documented impact:
+
+- The window is bounded by `pending_links.expires_at` (≤ 1 hour by default).
+- Users with a pending row at deploy time receive a 403 on approve. They can recover by re-triggering OAuth login (which produces a new row + new verification email under the new flow).
+- This is acceptable because PendingLinks are short-lived and the worst-case is "user repeats login once."
+
+If desired in the future, an operator-initiated migration could optionally fill `email_verified_at` for legacy rows treating them as grandfathered, but the security posture argues against it.
+
+### Schema.sql synchronisation
+
+`src/db/schema.sql` is updated alongside the migration so fresh deployments via `npm run db:init` include the new columns and index without applying the migration file. This mirrors how `0001_add_email_verified.sql` is handled today.
+
+## Cleanup
+
+No new cleanup job. The existing cron purge
+
+```sql
+DELETE FROM pending_links WHERE expires_at < datetime('now')
+```
+
+removes rows whose tokens have therefore also expired. No orphan token state survives row deletion.
+
+## Tests touching the schema
+
+`tests/setup.ts` loads `src/db/schema.sql` via `?raw` import. Once schema.sql is updated, the existing setup pipeline picks up the new columns with no test-side changes.
+
+A fixture helper (added in PR2) will seed PendingLink rows with known token hashes so integration tests can assert verify/approve transitions without going through the full OAuth flow.

--- a/specs/080-out-of-band-email-verification/plan.md
+++ b/specs/080-out-of-band-email-verification/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Out-of-Band Email Verification for PendingLink Approval
+
+**Branch**: `080-out-of-band-email-verification` | **Date**: 2026-05-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/080-out-of-band-email-verification/spec.md`
+
+## Summary
+
+Adds a verification-by-email layer on top of the existing PendingLink merge flow. On PendingLink creation, the server sends a one-time-token email to the recipient. Clicking the link sets `email_verified_at` on the row. The approve endpoint becomes a no-op until that field is non-null.
+
+Email delivery is abstracted behind a single `sendEmail(...)` function with a provider selector keyed on `EMAIL_PROVIDER`. The initial PR ships only the **Resend** adapter; Cloudflare Email Service (binding-based) and AWS SES (REST + SigV4) are designed-for but deferred to follow-up PRs.
+
+In single-user mode (default), PendingLinks are never created, so this feature is inert. The verify endpoint exists unconditionally and returns 410 Gone for tokens that resolve to no row.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (new columns on `pending_links`), KV (no change)
+**New external dependency**: Resend REST API (`https://api.resend.com/emails`) — called via `fetch()`, no SDK
+**Testing**: Vitest + workers pool; outbound fetch mocked with `vi.spyOn(globalThis, 'fetch')`
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (REST API)
+**Performance Goals**: <2s budget for the email send; the OAuth callback waits on the send before returning
+**Constraints**: D1 single-statement transactions, Workers 10ms CPU budget on free tier (the send is mostly waiting on Resend, not CPU)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI schema updates land in PR1 (new `/auth/link/verify/:token` path, 410 Gone response). `npm run generate` runs before implementation. |
+| II. Cloudflare-Native | PASS | Resend is called via `fetch()` from Workers. No new bindings in this PR. Cloudflare Email Service binding adapter is designed for but follow-up. |
+| III. Type Safety | PASS | Provider interface lives in `src/utils/email/types.ts`. Generated types absorb the new path. No hand-edits to `src/types/generated.ts`. |
+| IV. Legal/Trademark | PASS | No WakaTime references. |
+| V. Simplicity First | PASS | One new endpoint, one new module (`src/utils/email/`), two new columns on `pending_links`. Single adapter at this stage. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/080-out-of-band-email-verification/
+├── plan.md                # This file
+├── spec.md                # Feature specification
+├── research.md            # Phase 0 — provider trade-offs, fail-mode choice
+├── data-model.md          # Phase 1 — pending_links column additions and migration
+├── quickstart.md          # Manual verification recipe
+├── tasks.md               # PR1/PR2 task split
+├── contracts/
+│   └── openapi-diff.md    # New /auth/link/verify path + 410 response component
+└── checklists/
+    └── requirements.md    # Acceptance gates
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── types.ts                            # Add EMAIL_PROVIDER, EMAIL_FROM, RESEND_API_KEY to Env
+├── utils/email/
+│   ├── index.ts                        # provider selector + sendEmail() public surface
+│   ├── types.ts                        # EmailMessage / EmailProvider interface
+│   └── resend.ts                       # Resend adapter (POST https://api.resend.com/emails)
+├── routes/auth/
+│   ├── link.ts                         # On approve: enforce email_verified_at; new verify GET
+│   └── login.ts                        # On PendingLink creation: generate token + send email
+└── db/schema.sql                       # ALTER TABLE pending_links — two columns
+
+migrations/
+└── 0002_pending_link_email_verification.sql
+
+schemas/paths/auth/
+└── link-verify-token.yaml              # NEW path
+
+schemas/components/responses/
+└── Gone.yaml                           # NEW shared 410 component
+```
+
+**Structure Decision**: Provider adapters live in `src/utils/email/`. Two new columns extend `pending_links` rather than introducing a separate verification-tokens table — the row-token mapping is 1:1 and the existing TTL/expiry semantics on `pending_links.expires_at` already cover both lifetimes.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Resend as default adapter** — best Workers DX, free tier covers expected volume (PendingLink emails are rare events even in multi-user mode).
+2. **Fail closed when provider misconfigured or send fails** — PendingLink row is not committed; OAuth callback returns 502/503. Better to refuse the merge than silently downgrade security.
+3. **Verify endpoint accepts GET, single-use** — first hit consumes the token; pre-fetch by mobile clients is acceptable collateral (documented in operator runbook).
+4. **Token stored as SHA-256 hash** — same pattern as session tokens and API keys.
+5. **Single-user mode unaffected** — the existing PendingLink-skipping branch in `src/routes/auth/login.ts` remains the gate; the verify endpoint is unconditionally mounted but inert.
+
+## Phase 1 — Design Outputs
+
+### Provider interface (`src/utils/email/types.ts`)
+
+```ts
+export interface EmailMessage {
+  to: string;             // single recipient
+  from: string;           // env.EMAIL_FROM
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<void>;
+}
+```
+
+### Provider selector (`src/utils/email/index.ts`)
+
+```ts
+export function getEmailProvider(env: Env): EmailProvider | null {
+  switch (env.EMAIL_PROVIDER) {
+    case "resend":  return new ResendProvider(env.RESEND_API_KEY!);
+    // case "cloudflare": ...  follow-up PR
+    // case "ses":        ...  follow-up PR
+    default:        return null;          // unconfigured ⇒ fail closed at call site
+  }
+}
+
+export async function sendEmail(env: Env, msg: EmailMessage): Promise<void> {
+  const provider = getEmailProvider(env);
+  if (!provider) throw new EmailNotConfiguredError();
+  await provider.send(msg);
+}
+```
+
+### Database changes
+
+```sql
+-- migrations/0002_pending_link_email_verification.sql
+ALTER TABLE pending_links ADD COLUMN email_verification_token_hash TEXT;
+ALTER TABLE pending_links ADD COLUMN email_verified_at TEXT;
+CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
+  ON pending_links(email_verification_token_hash);
+```
+
+Existing rows have NULL in both columns. Backfill is intentionally **not** performed — pre-feature PendingLinks cannot be approved unless the user re-triggers the OAuth flow (which generates a new token). Document this in the release notes; the impact window is small since PendingLinks have a 1-hour TTL.
+
+### OpenAPI surface change
+
+New path `schemas/paths/auth/link-verify-token.yaml`:
+- `GET /auth/link/verify/{token}` — `security: []` (public), 200/410/405 responses.
+
+New shared response component `schemas/components/responses/Gone.yaml`.
+
+`POST /auth/link/approve/{pending_link_id}` gains a 403 response (existing or augmented `Forbidden.yaml`).
+
+See [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+No constitution violations. The provider abstraction is a deliberate boundary (single function + single interface) that keeps complexity bounded.

--- a/specs/080-out-of-band-email-verification/plan.md
+++ b/specs/080-out-of-band-email-verification/plan.md
@@ -9,7 +9,7 @@ Adds a verification-by-email layer on top of the existing PendingLink merge flow
 
 Email delivery is abstracted behind a single `sendEmail(...)` function with a provider selector keyed on `EMAIL_PROVIDER`. The initial PR ships only the **Resend** adapter; Cloudflare Email Service (binding-based) and AWS SES (REST + SigV4) are designed-for but deferred to follow-up PRs.
 
-In single-user mode (default), PendingLinks are never created, so this feature is inert. The verify endpoint exists unconditionally and returns 410 Gone for tokens that resolve to no row.
+In single-user mode (default), PendingLinks must never be created, so this feature is inert. PR2 explicitly moves the instance-mode decision before same-email PendingLink creation to preserve that behavior. The verify endpoint exists unconditionally and returns 410 Gone for tokens that resolve to no row.
 
 ## Technical Context
 
@@ -63,8 +63,8 @@ src/
 │   ├── types.ts                        # EmailMessage / EmailProvider interface
 │   └── resend.ts                       # Resend adapter (POST https://api.resend.com/emails)
 ├── routes/auth/
-│   ├── link.ts                         # On approve: enforce email_verified_at; new verify GET
-│   └── login.ts                        # On PendingLink creation: generate token + send email
+│   ├── link.ts                         # On approve: enforce email_verified_at; verify GET + 405 method handling
+│   └── login.ts                        # Instance-mode gate; on PendingLink creation: generate token + send email
 └── db/schema.sql                       # ALTER TABLE pending_links — two columns
 
 migrations/
@@ -84,9 +84,9 @@ schemas/components/responses/
 See [research.md](./research.md). Key decisions:
 1. **Resend as default adapter** — best Workers DX, free tier covers expected volume (PendingLink emails are rare events even in multi-user mode).
 2. **Fail closed when provider misconfigured or send fails** — PendingLink row is not committed; OAuth callback returns 502/503. Better to refuse the merge than silently downgrade security.
-3. **Verify endpoint accepts GET, single-use** — first hit consumes the token; pre-fetch by mobile clients is acceptable collateral (documented in operator runbook).
-4. **Token stored as SHA-256 hash** — same pattern as session tokens and API keys.
-5. **Single-user mode unaffected** — the existing PendingLink-skipping branch in `src/routes/auth/login.ts` remains the gate; the verify endpoint is unconditionally mounted but inert.
+3. **Verify endpoint accepts GET, single-use** — first hit consumes the token; pre-fetch by mobile clients is acceptable collateral (documented in operator runbook). Non-GET methods on the verify path return 405 before global CSRF can convert them to 403.
+4. **Token stored as SHA-256 hash** — same pattern as session tokens and API keys; lookup is an indexed SQL equality match on the hash, not an application-level plaintext comparison.
+5. **Single-user mode unaffected** — PR2 moves/introduces the instance-mode gate before same-email PendingLink creation so the verify-email branch is never entered in default single-user mode; the verify endpoint is unconditionally mounted but inert.
 
 ## Phase 1 — Design Outputs
 
@@ -140,7 +140,7 @@ Existing rows have NULL in both columns. Backfill is intentionally **not** perfo
 ### OpenAPI surface change
 
 New path `schemas/paths/auth/link-verify-token.yaml`:
-- `GET /auth/link/verify/{token}` — `security: []` (public), 200/410/405 responses.
+- `GET /auth/link/verify/{token}` — `security: []` (public), 200/410/405 responses. PR2 must implement explicit non-GET method handling so the documented 405 survives the global CSRF middleware.
 
 New shared response component `schemas/components/responses/Gone.yaml`.
 

--- a/specs/080-out-of-band-email-verification/quickstart.md
+++ b/specs/080-out-of-band-email-verification/quickstart.md
@@ -53,7 +53,7 @@ In Scenario A, after step 6, open the same verify URL a second time.
 
 ## Scenario D — Token expiry
 
-Trigger a PendingLink as in Scenario A. Wait 60+ minutes. Open the verify URL.
+Trigger a PendingLink as in Scenario A. Wait until the row's `expires_at` has passed (default 60+ minutes). Open the verify URL.
 
 **Expected**:
 - 410 Gone, body `{"error": "Token expired"}` (the underlying row's `expires_at` has passed, so the token cannot be honoured).
@@ -82,7 +82,7 @@ Unset `EMAIL_PROVIDER`. Trigger a Google OAuth login for an email that matches a
 Switch the instance to `INSTANCE_MODE=single`. Confirm OAuth login flows still work for the owner. Visit `${APP_URL}/api/v1/auth/link/verify/anything`.
 
 **Expected**:
-- OAuth login: completes normally for the existing owner; no PendingLink is created.
+- OAuth login / provider-linking preserves the existing single-user semantics; no PendingLink is created, no email is sent, and no email-provider configuration is required for this branch.
 - Verify endpoint: 410 Gone, body `{"error": "Token not found"}`. No emails are sent.
 
 ## Scenario H — Method other than GET
@@ -91,7 +91,7 @@ Switch the instance to `INSTANCE_MODE=single`. Confirm OAuth login flows still w
 curl -X POST ${APP_URL}/api/v1/auth/link/verify/anything
 ```
 
-**Expected**: 405 Method Not Allowed.
+**Expected**: 405 Method Not Allowed, including when the request has no `Origin` header.
 
 ## Tuning operator runbook checks
 

--- a/specs/080-out-of-band-email-verification/quickstart.md
+++ b/specs/080-out-of-band-email-verification/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Verify Out-of-Band Email Verification
+
+This guide walks through manually verifying the email-verification step in the PendingLink approval flow once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+- Multi-user instance (`INSTANCE_MODE=multi`) — single-user mode does not use PendingLink.
+- Email provider configured. For the initial implementation:
+  - `EMAIL_PROVIDER=resend`
+  - `RESEND_API_KEY=<your Resend key>`
+  - `EMAIL_FROM=noreply@<your verified domain>` — domain must be added and DNS-verified in your Resend dashboard.
+- `APP_URL` is set to a publicly reachable origin (the verify link points here).
+- Two OAuth provider accounts that share an email address (e.g., a GitHub account and a Google account both bound to `alice@example.com`).
+
+## DNS prerequisites (one-time)
+
+Set up SPF, DKIM, and DMARC for `<your verified domain>` per Resend's domain verification flow. Verify deliverability with a test send before running these scenarios.
+
+## Scenario A — Happy path
+
+1. As `alice@example.com`, log in via GitHub. A user row is created.
+2. Log out.
+3. Log in via Google, again as `alice@example.com`. Server detects the email match and creates a PendingLink. The OAuth callback response contains the `pending_link.id`.
+4. Within ≤ 30 seconds, an email arrives at `alice@example.com`:
+   - From: `EMAIL_FROM`
+   - Subject: contains "Confirm CloudTime account link"
+   - Body: contains a single link `${APP_URL}/api/v1/auth/link/verify/<token>`
+5. Open the link in any browser (no session required).
+6. Browser shows a confirmation page: "Email verified. Return to CloudTime to approve the merge."
+7. Log into CloudTime as Alice (GitHub session). Call `POST /api/v1/auth/link/approve/<pending_link_id>`.
+
+**Expected**:
+- Step 4 server log includes one structured line: `[email] sent provider=resend pending_link=<uuid> recipient_domain=example.com`. No full email address in the log.
+- Step 6 D1 state: `pending_links.email_verified_at` is non-null.
+- Step 7 response: 200, merge completed; new `oauth_accounts` row links Google to Alice's user.
+
+## Scenario B — Approve before verification
+
+Skip step 5 in Scenario A. Immediately call `POST /api/v1/auth/link/approve/<pending_link_id>`.
+
+**Expected**:
+- 403 Forbidden, body `{"error": "Email verification required"}`.
+- No merge performed.
+- D1 state: `pending_links.email_verified_at` still null.
+
+## Scenario C — Token replay
+
+In Scenario A, after step 6, open the same verify URL a second time.
+
+**Expected**:
+- 410 Gone, body `{"error": "Token already used"}`.
+- `email_verified_at` remains unchanged (idempotent).
+
+## Scenario D — Token expiry
+
+Trigger a PendingLink as in Scenario A. Wait 60+ minutes. Open the verify URL.
+
+**Expected**:
+- 410 Gone, body `{"error": "Token expired"}` (the underlying row's `expires_at` has passed, so the token cannot be honoured).
+- The cron purge will eventually delete the row.
+
+## Scenario E — Email provider failure (transient)
+
+Temporarily set `RESEND_API_KEY` to an invalid value, then trigger a Google OAuth login for an email that matches an existing user.
+
+**Expected**:
+- OAuth callback response: 502 Bad Gateway, body `{"error": "Unable to send verification email; please try again later"}`.
+- D1 state: no new `pending_links` row exists.
+- Server log includes the provider error code (Resend's response body, sanitised).
+
+## Scenario F — Email provider not configured
+
+Unset `EMAIL_PROVIDER`. Trigger a Google OAuth login for an email that matches an existing user.
+
+**Expected**:
+- OAuth callback response: 503 Service Unavailable, body `{"error": "Email delivery not configured"}`.
+- D1 state: no new `pending_links` row exists.
+- Server log includes a one-time warning per isolate that email is unconfigured.
+
+## Scenario G — Single-user mode is unaffected
+
+Switch the instance to `INSTANCE_MODE=single`. Confirm OAuth login flows still work for the owner. Visit `${APP_URL}/api/v1/auth/link/verify/anything`.
+
+**Expected**:
+- OAuth login: completes normally for the existing owner; no PendingLink is created.
+- Verify endpoint: 410 Gone, body `{"error": "Token not found"}`. No emails are sent.
+
+## Scenario H — Method other than GET
+
+```bash
+curl -X POST ${APP_URL}/api/v1/auth/link/verify/anything
+```
+
+**Expected**: 405 Method Not Allowed.
+
+## Tuning operator runbook checks
+
+After running Scenarios A–H once successfully, add the deployment to your monitoring checklist:
+
+1. **Daily**: tail Worker logs filtered for `[email]` lines; any provider errors should be investigated.
+2. **Weekly**: check Resend dashboard for bounce/complaint rate. Sustained bounces over 1% suggest DNS or sender-reputation issues.
+3. **On every domain change**: re-run mail-tester.com against the configured `EMAIL_FROM` to confirm SPF/DKIM/DMARC alignment.

--- a/specs/080-out-of-band-email-verification/research.md
+++ b/specs/080-out-of-band-email-verification/research.md
@@ -54,8 +54,9 @@
 
 **Rationale**:
 - Email clients open links via GET. Forcing POST would require an intermediate "click here to verify" form, which adds friction and is hostile to mobile clients.
-- Token consumption is implemented via `UPDATE pending_links SET email_verified_at = datetime('now') WHERE email_verification_token_hash = ? AND email_verified_at IS NULL` returning `meta.changes`. If `changes == 0`, the row either does not exist or was already verified — both 410 cases.
+- Token consumption is implemented by hashing the URL token once, then running `UPDATE pending_links SET email_verified_at = datetime('now') WHERE email_verification_token_hash = ? AND email_verified_at IS NULL` against the indexed hash column. If `changes == 0`, the row either does not exist or was already verified — both 410 cases.
 - The endpoint is CSRF-safe by construction: it is purely state-change-on-GET, but the state change is gated on the unforgeable token itself.
+- Non-GET requests to the same path still need explicit method handling before global CSRF can reject form-like requests as 403; PR2 must preserve the documented 405 response.
 
 **Pre-fetch caveat**: Some mobile email clients pre-fetch links. The first pre-fetch consumes the token; the user's later click sees 410. This is an industry-wide constraint and is documented in the operator runbook. We accept it because the alternative (requiring user-initiated POST) breaks mobile email entirely.
 
@@ -67,7 +68,7 @@
 
 ## Decision 5: TTL aligned with PendingLink expiry (1 hour default)
 
-**Decision**: Token TTL equals the PendingLink's `expires_at` (default 1 hour). The token cannot outlive the row.
+**Decision**: Token TTL equals the PendingLink's `expires_at` (default 1 hour). The token cannot outlive the row and does not have an independent TTL configuration in PR2.
 
 **Rationale**:
 - Single TTL source of truth: when the PendingLink expires, the token also expires. Cleanup is automatic.
@@ -76,7 +77,7 @@
 
 **Alternatives considered**:
 1. **Independent token TTL**: rejected — doubles the lifecycle bookkeeping.
-2. **Configurable per-deployment TTL**: rejected for PR1 — `pending_links.expires_at` already encodes the lifetime; a separate env var would invite drift.
+2. **Configurable per-deployment token TTL**: rejected for PR2 — `pending_links.expires_at` already encodes the lifetime; a separate env var would invite drift.
 
 ---
 

--- a/specs/080-out-of-band-email-verification/research.md
+++ b/specs/080-out-of-band-email-verification/research.md
@@ -1,0 +1,122 @@
+# Research: Out-of-Band Email Verification for PendingLink Approval
+
+## Decision 1: Provider choice — Resend as the day-one adapter
+
+**Decision**: Ship a single provider adapter (Resend) in the initial PR. Design the interface so additional providers can be added without touching call sites.
+
+**Rationale**:
+- **Volume**: PendingLink emails are rare. Even a 100-user multi-user instance generates ~0-10 sends/month (only on account merge events). Every provider's free tier covers this trivially.
+- **Workers DX**: Resend exposes a flat REST API at `POST https://api.resend.com/emails` that `fetch()` can call directly with a bearer token. No SDK, no SigV4, no SMTP. Compatible with the 10ms CPU budget.
+- **Free tier durability**: 3,000 emails/month with no time limit (as of 2026-05). Free tier removals (SendGrid in 2025-05) make picking a tier-stable provider important.
+- **Self-hosted ethos**: Resend's API model lets operators bring their own API key without depending on a Cloudflare account upgrade.
+
+**Alternatives considered and deferred**:
+1. **Cloudflare Email Service** (binding `send_email`): currently public beta with API surface that may change before GA. Requires Workers Paid plan ($5/mo) even for free senders. Will add as a second adapter once it reaches GA.
+2. **AWS SES**: cheapest at scale ($0.10/1k) but requires SigV4 request signing in Workers (~150 LoC), sandbox-to-production application flow, and SNS bounce wiring. Worth supporting eventually for high-volume self-hosters; not the first adapter.
+3. **MailChannels**: deliberately excluded — the Cloudflare Workers integration was sunset 2024-08, current API has a credit-card-required free tier with restrictive limits.
+4. **SendGrid / Mailgun / Postmark**: all have either no free tier (SendGrid post-2025-05) or trial-only access (Mailgun). Operator burden is no lower than Resend.
+
+---
+
+## Decision 2: Fail closed on provider failure or misconfiguration
+
+**Decision**: When the configured provider returns an error, when no provider is configured, or when the send exceeds a 2-second budget, the system rolls back the PendingLink row and returns 502 (provider error) or 503 (unconfigured) to the user.
+
+**Rationale**:
+- The whole point of this feature is to harden merge approval. Silently downgrading to "no email check" defeats the security goal.
+- A failed send leaves the user with a clear error and a retry path (re-trigger OAuth). The alternative — committing the row without sending — produces an unrecoverable PendingLink the user cannot approve.
+- D1 transactional semantics: we generate the token, attempt the send, and only insert on success. If the send fails, no row exists and no token is leaked.
+
+**Alternatives considered**:
+1. **Fail open with a flag**: rejected — defeats the security model.
+2. **Queue the send via Cloudflare Queues**: rejected for PR1 — Queues adds a paid binding requirement and complicates failure attribution. May revisit if 2-second budgets become problematic.
+
+---
+
+## Decision 3: Token in URL, hash in DB
+
+**Decision**: Token is 32 random bytes encoded base64url. URL form: `${APP_URL}/api/v1/auth/link/verify/${token}`. Database stores SHA-256 hash of the token.
+
+**Rationale**:
+- 32 bytes (256 bits) of entropy makes the token unguessable inside the 1-hour TTL window even if all PendingLinks were active simultaneously.
+- Hash-only storage matches the project's existing conventions (`api_key_hash`, `sessions.token_hash`). DB compromise does not leak working tokens.
+- URL-borne tokens are visible to TLS-intermediating proxies and browser history. Acceptable trade-off because the token is single-use and short-lived; the email client (HTTPS to provider) is the most exposed link.
+
+**Alternatives considered**:
+1. **Token as a query parameter (`?token=...`) instead of path**: rejected — path segments are not logged by default in many proxies/CDNs, query strings frequently are. Path segment is the safer choice.
+2. **Encrypted token containing the pending_link_id**: rejected — adds complexity and a key-management burden for no security gain. Random token + DB lookup is the standard pattern.
+
+---
+
+## Decision 4: GET endpoint with single-use semantics
+
+**Decision**: `GET /auth/link/verify/:token` is the verification endpoint. First successful hit sets `email_verified_at`; subsequent hits return 410 Gone.
+
+**Rationale**:
+- Email clients open links via GET. Forcing POST would require an intermediate "click here to verify" form, which adds friction and is hostile to mobile clients.
+- Token consumption is implemented via `UPDATE pending_links SET email_verified_at = datetime('now') WHERE email_verification_token_hash = ? AND email_verified_at IS NULL` returning `meta.changes`. If `changes == 0`, the row either does not exist or was already verified — both 410 cases.
+- The endpoint is CSRF-safe by construction: it is purely state-change-on-GET, but the state change is gated on the unforgeable token itself.
+
+**Pre-fetch caveat**: Some mobile email clients pre-fetch links. The first pre-fetch consumes the token; the user's later click sees 410. This is an industry-wide constraint and is documented in the operator runbook. We accept it because the alternative (requiring user-initiated POST) breaks mobile email entirely.
+
+**Alternatives considered**:
+1. **Two-step flow: GET shows a confirmation page, POST consumes the token**: rejected — too much UX surface for a transactional verification flow.
+2. **Token consumed only on POST after a "Confirm" button click**: rejected — pre-fetch problem still exists if the page itself auto-posts; if not, mobile UX is poor.
+
+---
+
+## Decision 5: TTL aligned with PendingLink expiry (1 hour default)
+
+**Decision**: Token TTL equals the PendingLink's `expires_at` (default 1 hour). The token cannot outlive the row.
+
+**Rationale**:
+- Single TTL source of truth: when the PendingLink expires, the token also expires. Cleanup is automatic.
+- 1 hour is enough for a user to switch tabs, read email, and act, while short enough that compromised inboxes do not yield long-lived tokens.
+- Existing cron-purge of expired PendingLinks (`DELETE FROM pending_links WHERE expires_at < datetime('now')`) doubles as token cleanup.
+
+**Alternatives considered**:
+1. **Independent token TTL**: rejected — doubles the lifecycle bookkeeping.
+2. **Configurable per-deployment TTL**: rejected for PR1 — `pending_links.expires_at` already encodes the lifetime; a separate env var would invite drift.
+
+---
+
+## Decision 6: Confirmation response — minimal HTML
+
+**Decision**: The verify endpoint returns a small HTML page on success: a single sentence telling the user to return to CloudTime to approve, plus a link back to `APP_URL`. Failure cases return JSON.
+
+**Rationale**:
+- The user lands on this URL from an email client, often in a browser they may not have a CloudTime session in. A JSON response would feel broken.
+- HTML keeps the surface minimal (one `<h1>` and a `<p>`) and survives Content-Security-Policy `default-src 'none'` because it has no external resources.
+- Failure paths (410, 405) keep JSON to match the rest of the API; that response is consumed by curl-style retries during testing, not by humans.
+
+**Alternatives considered**:
+1. **JSON for both success and failure**: rejected — humans land on the success path, machines do not.
+2. **Redirect to a frontend route**: rejected — CloudTime has no frontend yet; the success page lives in the Worker.
+
+---
+
+## Decision 7: Provider selector via `EMAIL_PROVIDER` env var, not auto-detect
+
+**Decision**: Operators explicitly set `EMAIL_PROVIDER=resend` (or future values). Auto-detect from presence of `RESEND_API_KEY` is intentionally not supported.
+
+**Rationale**:
+- Explicit beats implicit. An operator who removes a Resend key intending to switch providers should not silently fall through to the next auto-detected adapter.
+- If `EMAIL_PROVIDER` is set but the matching credentials are missing (e.g., `EMAIL_PROVIDER=resend` without `RESEND_API_KEY`), the system fails closed on the next send attempt with a clear error.
+
+**Alternatives considered**:
+1. **Auto-detect by env var presence**: rejected — error-prone during operator transitions.
+
+---
+
+## Decision 8: No retry on transient send failures
+
+**Decision**: A single send attempt with a 2-second timeout. No automatic retry. Failure rolls back the PendingLink and surfaces the error to the user, who re-triggers via OAuth.
+
+**Rationale**:
+- Workers Queues (the obvious retry path) is a paid binding and adds operator burden.
+- The user who triggered the merge is in the loop; they can retry by attempting OAuth login again, which produces a fresh PendingLink and a fresh send.
+- Most transient failures (provider 5xx, network blip) are observable enough through the structured log that operators can investigate without an automated retry.
+
+**Alternatives considered**:
+1. **In-process retry with backoff**: rejected — Worker CPU budget too tight, retries consume budget that should serve other requests.
+2. **Queue-based async retry**: rejected for PR1; revisit if production data shows transient-failure rate is meaningful.

--- a/specs/080-out-of-band-email-verification/spec.md
+++ b/specs/080-out-of-band-email-verification/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Out-of-Band Email Verification for PendingLink Approval
+
+**Feature Branch**: `080-out-of-band-email-verification`
+**Created**: 2026-05-17
+**Status**: Draft
+**Input**: GitHub Issue #80 — Add out-of-band email verification for PendingLink approval
+
+## Background
+
+The current PendingLink flow (multi-user mode only) creates a merge candidate when a new OAuth login's verified email matches an existing user. Approval requires the existing user to log in and click "Approve" in the UI. Two defences are in place: manual user action, and dual `email_verified` checks against the OAuth provider.
+
+[Truffle Security research (January 2025)](https://trufflesecurity.com/blog/google-oauth-is-broken-sort-of) demonstrated that even `email_verified: true` from OAuth providers is not proof of legitimate ownership — Google Workspace domain takeover and admin-provisioned accounts both produce verified email claims without the individual ever verifying.
+
+This feature adds a **third layer of defence**: before approval can succeed, the system sends a one-time confirmation email to the existing user's address. The link in the email must be clicked from the recipient's inbox, proving they control the email account at the moment of merge.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Verified email recipient approves a merge (Priority: P1)
+
+As Alice (existing user, registered with `alice@example.com` via GitHub), I receive a confirmation email when someone — including myself — initiates a Google login that resolves to my email. I click the link in the email from my inbox, then proceed to approve the merge inside the CloudTime UI. The merge only completes after both steps succeed.
+
+**Why this priority**: This is the core security improvement. Without it, an attacker who controls a Workspace domain previously associated with my email can produce a `email_verified: true` token without ever having access to my inbox. Requiring inbox access closes that gap.
+
+**Independent Test**: With email provider configured and multi-user mode enabled, complete a Google login for `alice@example.com` while Alice already exists via GitHub. Verify an email is sent, the link contains a unique token, clicking the link records `email_verified_at` on the `pending_links` row, and the approval endpoint then succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PendingLink is created and the email provider succeeds, **When** the email is sent and Alice clicks the verify link within the token TTL, **Then** the PendingLink's `email_verified_at` is set and Alice's subsequent `POST /auth/link/approve/:pending_link_id` returns 200.
+2. **Given** a PendingLink with `email_verified_at` not yet set, **When** Alice calls `POST /auth/link/approve/:pending_link_id`, **Then** the server returns 403 with body `{"error": "Email verification required"}` and the merge is **not** completed.
+3. **Given** a verification token is consumed once successfully, **When** the same token URL is opened again, **Then** the server returns 410 Gone with body `{"error": "Token already used"}`.
+4. **Given** a verification token has expired (configurable TTL, default 1 hour), **When** the link is opened, **Then** the server returns 410 Gone with body `{"error": "Token expired"}`.
+5. **Given** a PendingLink is itself expired, **When** the verify endpoint is opened, **Then** the server returns 410 Gone (verification cannot resurrect an expired PendingLink).
+
+---
+
+### User Story 2 - Operator configures and validates the email provider (Priority: P1)
+
+As an operator deploying CloudTime in multi-user mode, I configure my email provider once (Resend or Cloudflare Email Service), set the sender address, and verify deliverability by triggering a test merge.
+
+**Why this priority**: Without a working provider, multi-user mode cannot create merge candidates safely. The deployment guide must produce a working pipeline on the first try.
+
+**Independent Test**: Set `EMAIL_PROVIDER=resend`, `RESEND_API_KEY=...`, `EMAIL_FROM=noreply@example.com`. Trigger a PendingLink. Confirm the email arrives at the expected inbox, the From address matches, and the link points to the configured `APP_URL`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `EMAIL_PROVIDER=resend` with a valid API key, **When** a PendingLink is created, **Then** an email is sent within one request cycle and a structured log line records the send.
+2. **Given** `EMAIL_PROVIDER=resend` with an invalid API key, **When** a PendingLink is created, **Then** the system fails closed: the PendingLink row is rolled back (not committed) and the user-facing response is `502 Bad Gateway` with body `{"error": "Unable to send verification email; please try again later"}`.
+3. **Given** `EMAIL_PROVIDER` is unset (default), **When** a PendingLink would normally be created, **Then** the system fails closed with `503 Service Unavailable` and the response body explains the operator must configure email.
+4. **Given** the sender domain lacks SPF/DKIM, **When** the email is sent, **Then** delivery is best-effort; the server does not retry on bounces (out of scope), and the operator runbook documents DNS prerequisites.
+
+---
+
+### User Story 3 - Verification interaction works on mobile email clients (Priority: P2)
+
+As Alice opening the verification email on a mobile inbox, I see a tappable link that works without requiring me to be signed into CloudTime in that browser session.
+
+**Why this priority**: Mobile email clients often pre-fetch links; the verify endpoint must be idempotent on first call and explicit about replay. The endpoint must be reachable without a session cookie because the recipient may not have a CloudTime tab open on that device.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verification email is opened on a mobile client that pre-fetches links, **When** the pre-fetch hits the verify endpoint, **Then** the token is consumed (first hit wins) and the user sees a "Verified — please return to CloudTime to approve" confirmation page. (Limitation acknowledged; documented in operator runbook.)
+2. **Given** the verify endpoint, **When** any request method other than GET is used, **Then** the server returns 405 Method Not Allowed.
+
+---
+
+### Edge Cases
+
+- **Single-user mode**: PendingLink is not used. The verify endpoint exists but never has rows to operate on; calls to `/auth/link/verify/:token` always return 410 Gone.
+- **Operator changes provider mid-deployment**: Outstanding tokens issued by the previous provider still resolve normally (the verification is server-state-driven, not provider-state-driven). No data migration needed.
+- **Email arrives after PendingLink expires**: Token resolves to a PendingLink row whose `expires_at` has passed. Server returns 410 Gone. Operator can re-trigger the merge by repeating OAuth login.
+- **Same email triggers multiple PendingLinks**: Existing application limit (3 active pending links per user) already bounds the worst case. Each new PendingLink gets its own token and email; older tokens remain valid until expiry.
+- **Spam folder**: Out of scope. Operator-side concern (DNS/sender reputation). Runbook documents SPF/DKIM/DMARC requirements.
+- **Recipient does not have an inbox at the configured email**: The merge cannot proceed — which is exactly the intended security posture.
+- **Email provider rate-limits us**: Best-effort. If the provider returns 429, the server fails closed and the operator may need to upgrade plans. Documented in the provider operator guide.
+- **Replay attack with leaked email**: Token is consumed on first use; subsequent attempts return 410. Token entropy (32 bytes base64url) prevents brute-forcing within the TTL.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST send a verification email when a PendingLink row is created in multi-user mode. The email contains a one-time link `${APP_URL}/api/v1/auth/link/verify/:token` where `:token` is 32 random bytes encoded base64url.
+- **FR-002**: The system MUST store only a SHA-256 hash of the token in `pending_links.email_verification_token_hash`. The plaintext appears only in the email body and is never logged or persisted.
+- **FR-003**: The system MUST expose `GET /api/v1/auth/link/verify/:token` as an unauthenticated public endpoint. On a successful first hit within TTL, it MUST set `pending_links.email_verified_at` to the current timestamp and return a confirmation response (HTML page or 200 JSON, per operator deployment).
+- **FR-004**: `POST /api/v1/auth/link/approve/:pending_link_id` MUST require `email_verified_at` to be non-null. If null, it MUST return `403 Forbidden` with body `{"error": "Email verification required"}` and not perform the merge.
+- **FR-005**: The verification token MUST expire after a configurable TTL (default 3600 seconds). Expired tokens MUST return `410 Gone` with body `{"error": "Token expired"}`.
+- **FR-006**: Tokens MUST be one-time. After successful verification, subsequent GETs of the same token MUST return `410 Gone` with body `{"error": "Token already used"}`. The replay check uses the existing `email_verified_at` field (non-null ⇒ already verified).
+- **FR-007**: Email send failures MUST roll back the PendingLink creation (transactional). The OAuth callback that triggered the merge MUST return `502 Bad Gateway` with a non-leaky error message.
+- **FR-008**: When `EMAIL_PROVIDER` is unset or empty, the system MUST fail closed: PendingLink creation returns `503 Service Unavailable` with body `{"error": "Email delivery not configured"}` and the row is not written.
+- **FR-009**: The system MUST support at least one provider in the initial PR: **Resend** via REST API (env: `EMAIL_PROVIDER=resend`, `RESEND_API_KEY`, `EMAIL_FROM`).
+- **FR-010**: The provider layer MUST be abstracted behind a single interface (`sendEmail(to, subject, html, text) → Promise<void>`) so additional adapters can be added without touching call sites.
+- **FR-011**: The system MUST emit one structured log line per send attempt containing: provider name, recipient domain (not local part), pending link ID (UUID), and success/failure. The log MUST NOT contain the recipient's full email, the token plaintext, or the email body.
+- **FR-012**: Single-user mode (`INSTANCE_MODE=single`) is unaffected; no emails are sent because no PendingLink is created. The verify endpoint MUST still exist but MUST always 410 in single-user mode.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Email send must not block the OAuth callback for more than 2 seconds total. If the provider exceeds this budget, the send fails and the PendingLink is rolled back.
+- **NFR-002**: The verification endpoint MUST be safe to call from email pre-fetchers (it is idempotent: first call wins, subsequent calls 410, no side effects from rejected calls).
+- **NFR-003**: Token comparison MUST use constant-time equality against the stored hash. Hash lookup uses SHA-256 of the URL token.
+- **NFR-004**: The verify endpoint MUST be exempt from CSRF (it is `GET` and never a state-changing form). State change (`email_verified_at` update) is acceptable on GET because the token itself is the proof.
+
+### Key Entities *(D1 schema change)*
+
+Add two columns to `pending_links`:
+- `email_verification_token_hash TEXT` — nullable, populated on creation with `sha256(token)`.
+- `email_verified_at TEXT` — nullable, set to `datetime('now')` on successful verify.
+
+Indexes:
+- `idx_pending_links_token_hash` on `email_verification_token_hash` for the verify endpoint's lookup.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With `EMAIL_PROVIDER=resend` configured, end-to-end merge takes ≤ 30 seconds from OAuth callback to approve success (most of that being human time to read the email).
+- **SC-002**: PendingLink rows with `email_verified_at IS NULL` cannot be approved (verified by attempting the approve endpoint and observing 403).
+- **SC-003**: Adding a second provider adapter touches only `src/utils/email/<provider>.ts`, plus an entry in the provider selector. No call site changes outside the email module.
+- **SC-004**: When email provider returns 5xx, no `pending_links` row exists in D1 after the failure (verified via post-failure SELECT).
+- **SC-005**: Operator runbook covers DNS setup (SPF/DKIM/DMARC) so a fresh deployment can pass an inbox deliverability test with mail-tester.com or equivalent within the first hour.
+
+## Out of Scope
+
+- **Email sending for any flow other than PendingLink verification**. Password reset, welcome emails, security alerts, etc. are not added in this PR.
+- **Bounce / complaint webhook handling**. Operators must monitor their provider dashboard. A future PR may add a webhook receiver.
+- **Retry/queue for transient send failures**. Workers Queues integration is out of scope; failures are immediate and the user must re-trigger.
+- **HTML email templates with branding**. The initial template is minimal: plain text with a single link plus a one-line HTML wrapper.
+- **Per-user opt-out / unsubscribe**. Verification emails are mandatory and transactional, not marketing.
+- **Multi-language email content**. English only; localisation is a separate feature.

--- a/specs/080-out-of-band-email-verification/spec.md
+++ b/specs/080-out-of-band-email-verification/spec.md
@@ -28,7 +28,7 @@ As Alice (existing user, registered with `alice@example.com` via GitHub), I rece
 1. **Given** a PendingLink is created and the email provider succeeds, **When** the email is sent and Alice clicks the verify link within the token TTL, **Then** the PendingLink's `email_verified_at` is set and Alice's subsequent `POST /auth/link/approve/:pending_link_id` returns 200.
 2. **Given** a PendingLink with `email_verified_at` not yet set, **When** Alice calls `POST /auth/link/approve/:pending_link_id`, **Then** the server returns 403 with body `{"error": "Email verification required"}` and the merge is **not** completed.
 3. **Given** a verification token is consumed once successfully, **When** the same token URL is opened again, **Then** the server returns 410 Gone with body `{"error": "Token already used"}`.
-4. **Given** a verification token has expired (configurable TTL, default 1 hour), **When** the link is opened, **Then** the server returns 410 Gone with body `{"error": "Token expired"}`.
+4. **Given** a verification token has expired with its PendingLink row (default 1 hour), **When** the link is opened, **Then** the server returns 410 Gone with body `{"error": "Token expired"}`.
 5. **Given** a PendingLink is itself expired, **When** the verify endpoint is opened, **Then** the server returns 410 Gone (verification cannot resurrect an expired PendingLink).
 
 ---
@@ -59,13 +59,13 @@ As Alice opening the verification email on a mobile inbox, I see a tappable link
 **Acceptance Scenarios**:
 
 1. **Given** a verification email is opened on a mobile client that pre-fetches links, **When** the pre-fetch hits the verify endpoint, **Then** the token is consumed (first hit wins) and the user sees a "Verified — please return to CloudTime to approve" confirmation page. (Limitation acknowledged; documented in operator runbook.)
-2. **Given** the verify endpoint, **When** any request method other than GET is used, **Then** the server returns 405 Method Not Allowed.
+2. **Given** the verify endpoint, **When** any request method other than GET is used, **Then** the server returns 405 Method Not Allowed before CSRF can turn the same request into 403.
 
 ---
 
 ### Edge Cases
 
-- **Single-user mode**: PendingLink is not used. The verify endpoint exists but never has rows to operate on; calls to `/auth/link/verify/:token` always return 410 Gone.
+- **Single-user mode**: PendingLink is not used. PR2 must move the `INSTANCE_MODE` check ahead of same-email PendingLink creation so default single-user mode never sends email, never writes `pending_links`, and keeps the existing direct/owner-only linking semantics. The verify endpoint exists but never has rows to operate on; calls to `/auth/link/verify/:token` always return 410 Gone.
 - **Operator changes provider mid-deployment**: Outstanding tokens issued by the previous provider still resolve normally (the verification is server-state-driven, not provider-state-driven). No data migration needed.
 - **Email arrives after PendingLink expires**: Token resolves to a PendingLink row whose `expires_at` has passed. Server returns 410 Gone. Operator can re-trigger the merge by repeating OAuth login.
 - **Same email triggers multiple PendingLinks**: Existing application limit (3 active pending links per user) already bounds the worst case. Each new PendingLink gets its own token and email; older tokens remain valid until expiry.
@@ -84,21 +84,21 @@ As Alice opening the verification email on a mobile inbox, I see a tappable link
 - **FR-002**: The system MUST store only a SHA-256 hash of the token in `pending_links.email_verification_token_hash`. The plaintext appears only in the email body and is never logged or persisted.
 - **FR-003**: The system MUST expose `GET /api/v1/auth/link/verify/:token` as an unauthenticated public endpoint. On a successful first hit within TTL, it MUST set `pending_links.email_verified_at` to the current timestamp and return a confirmation response (HTML page or 200 JSON, per operator deployment).
 - **FR-004**: `POST /api/v1/auth/link/approve/:pending_link_id` MUST require `email_verified_at` to be non-null. If null, it MUST return `403 Forbidden` with body `{"error": "Email verification required"}` and not perform the merge.
-- **FR-005**: The verification token MUST expire after a configurable TTL (default 3600 seconds). Expired tokens MUST return `410 Gone` with body `{"error": "Token expired"}`.
+- **FR-005**: The verification token MUST expire with `pending_links.expires_at` (default 3600 seconds). There is no independent verification-token TTL in PR2. Expired tokens MUST return `410 Gone` with body `{"error": "Token expired"}`.
 - **FR-006**: Tokens MUST be one-time. After successful verification, subsequent GETs of the same token MUST return `410 Gone` with body `{"error": "Token already used"}`. The replay check uses the existing `email_verified_at` field (non-null ⇒ already verified).
 - **FR-007**: Email send failures MUST roll back the PendingLink creation (transactional). The OAuth callback that triggered the merge MUST return `502 Bad Gateway` with a non-leaky error message.
 - **FR-008**: When `EMAIL_PROVIDER` is unset or empty, the system MUST fail closed: PendingLink creation returns `503 Service Unavailable` with body `{"error": "Email delivery not configured"}` and the row is not written.
 - **FR-009**: The system MUST support at least one provider in the initial PR: **Resend** via REST API (env: `EMAIL_PROVIDER=resend`, `RESEND_API_KEY`, `EMAIL_FROM`).
 - **FR-010**: The provider layer MUST be abstracted behind a single interface (`sendEmail(to, subject, html, text) → Promise<void>`) so additional adapters can be added without touching call sites.
 - **FR-011**: The system MUST emit one structured log line per send attempt containing: provider name, recipient domain (not local part), pending link ID (UUID), and success/failure. The log MUST NOT contain the recipient's full email, the token plaintext, or the email body.
-- **FR-012**: Single-user mode (`INSTANCE_MODE=single`) is unaffected; no emails are sent because no PendingLink is created. The verify endpoint MUST still exist but MUST always 410 in single-user mode.
+- **FR-012**: Single-user mode (`INSTANCE_MODE=single`) is unaffected; PR2 MUST ensure no PendingLink branch is entered, no emails are sent, and no `pending_links` rows are written in single-user mode. The verify endpoint MUST still exist but MUST always 410 in single-user mode.
 
 ### Non-Functional Requirements
 
 - **NFR-001**: Email send must not block the OAuth callback for more than 2 seconds total. If the provider exceeds this budget, the send fails and the PendingLink is rolled back.
 - **NFR-002**: The verification endpoint MUST be safe to call from email pre-fetchers (it is idempotent: first call wins, subsequent calls 410, no side effects from rejected calls).
-- **NFR-003**: Token comparison MUST use constant-time equality against the stored hash. Hash lookup uses SHA-256 of the URL token.
-- **NFR-004**: The verify endpoint MUST be exempt from CSRF (it is `GET` and never a state-changing form). State change (`email_verified_at` update) is acceptable on GET because the token itself is the proof.
+- **NFR-003**: Token plaintext MUST NOT be persisted or compared directly. The server hashes the URL token with SHA-256 and performs an indexed equality lookup on `pending_links.email_verification_token_hash`; constant-time string comparison is not applicable because the stored secret is never loaded and compared in application code.
+- **NFR-004**: The verify endpoint MUST be exempt from CSRF routing side effects. `GET` performs the token-gated state change, and non-GET methods on the same path MUST return 405 rather than being intercepted by global CSRF as 403.
 
 ### Key Entities *(D1 schema change)*
 

--- a/specs/080-out-of-band-email-verification/tasks.md
+++ b/specs/080-out-of-band-email-verification/tasks.md
@@ -34,26 +34,30 @@
 
 - [ ] **T-105**: Add helper `generateVerificationToken()` in `src/utils/crypto.ts` returning `{ plaintext, hash }` (32 random bytes, base64url, SHA-256).
 - [ ] **T-106**: Update `src/routes/auth/login.ts` PendingLink branch to:
-  1. Generate token before INSERT.
-  2. Build the email body (plain text + minimal HTML) including the verify link.
-  3. Call `sendEmail(env, msg)` BEFORE the D1 INSERT.
-  4. Only INSERT when the send resolves; store `email_verification_token_hash`.
-  5. On `EmailSendError`, return 502; on `EmailNotConfiguredError`, return 503. No partial state.
+  1. Move/introduce the `INSTANCE_MODE` check before same-email PendingLink creation so single-user mode never sends email and never writes `pending_links`.
+  2. Generate token before INSERT.
+  3. Build the email body (plain text + minimal HTML) including the verify link.
+  4. Call `sendEmail(env, msg)` BEFORE the D1 INSERT.
+  5. Only INSERT when the send resolves; store `email_verification_token_hash`.
+  6. On `EmailSendError`, return 502; on `EmailNotConfiguredError`, return 503. No partial state.
 
 ### Verify endpoint
 
-- [ ] **T-107**: Add `link.get("/link/verify/:token", ...)` in `src/routes/auth/link.ts` (public, no session middleware, no rate-limit middleware in PR2 — follow-up).
+- [ ] **T-107**: Add `link.get("/link/verify/:token", ...)` in `src/routes/auth/link.ts` (public, no session middleware, no rate-limit middleware in PR2 — follow-up). Add an explicit non-GET handler for the same path (for example `link.all("/link/verify/:token", ...)` after the GET route) returning 405.
 - [ ] **T-108**: Implement the lookup as a single UPDATE-with-RETURNING:
   ```sql
   UPDATE pending_links
   SET email_verified_at = datetime('now')
-  WHERE email_verification_token_hash = ?
+  WHERE email_verification_token_hash = ? -- SHA-256(url token), indexed equality lookup
     AND email_verified_at IS NULL
     AND expires_at > datetime('now')
   RETURNING id
   ```
   - `meta.changes === 1`: success ⇒ return HTML confirmation page.
   - `meta.changes === 0`: distinguish "not found / already verified / expired" via a follow-up SELECT, return 410 with the appropriate body.
+  - Do not load the stored hash for application-level token comparison; the URL token is hashed once and matched by indexed SQL equality.
+
+- [ ] **T-108a**: Ensure global CSRF middleware cannot convert non-GET verify requests into 403. Either exempt `/api/v1/auth/link/verify/*` before CSRF runs or mount the verify method-dispatch before CSRF; Scenario H must return 405 for a plain `curl -X POST` with no `Origin`.
 
 ### Approve endpoint gate
 
@@ -73,6 +77,8 @@
   - Replay: second GET returns 410.
   - Expired row: pre-aged `expires_at`, returns 410.
   - Approve before verify: 403.
+  - Non-GET verify request returns 405 even without `Origin` headers.
+  - Single-user same-email OAuth regression: no PendingLink row is created and no email send is attempted.
 
 ### Verification
 
@@ -93,7 +99,7 @@ T-102 → T-103 → T-104  (provider stack)
 T-104 → T-106 (call site needs the surface)
 T-105 → T-106 (token helper before use)
 T-106 → T-107 (DB column must exist before verify endpoint reads it)
-T-107 → T-109 (approve gate piggybacks on verify-set column)
+T-107 → T-108a → T-109 (method handling and approve gate piggyback on verify-set column)
 T-103/T-104 → T-112/T-113  (tests follow code)
 T-106/T-107/T-109 → T-114  (integration test needs all three branches)
 T-115/T-116 → T-117 → T-118

--- a/specs/080-out-of-band-email-verification/tasks.md
+++ b/specs/080-out-of-band-email-verification/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Out-of-Band Email Verification for PendingLink Approval
+
+**Branch**: `080-out-of-band-email-verification`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-17
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` covering FR-001..FR-012, NFRs, edge cases, success criteria.
+- [x] **T-002**: Author `plan.md` with Constitution Check and design sketch.
+- [x] **T-003**: Author `research.md` documenting 8 decisions (provider, fail mode, token shape, etc.).
+- [x] **T-004**: Author `quickstart.md` with scenarios A–H.
+- [x] **T-005**: Author `data-model.md` covering the two new `pending_links` columns.
+- [x] **T-006**: Author `contracts/openapi-diff.md` describing the new path and 410 response.
+- [x] **T-007**: Author `checklists/requirements.md` (PR1/PR2/post-deploy gates).
+- [ ] **T-008**: Add `schemas/components/responses/Gone.yaml` (new shared 410 response component).
+- [ ] **T-009**: Add `schemas/paths/auth/link-verify-token.yaml` (`GET /auth/link/verify/{token}` operation, `security: []`, 200/410/405 responses, `Gone.yaml` ref).
+- [ ] **T-010**: Wire the new path in `schemas/openapi.yaml` under `paths`.
+- [ ] **T-011**: Add `migrations/0002_pending_link_email_verification.sql` (ALTER TABLE + CREATE INDEX). Also update `src/db/schema.sql` so fresh deployments include the columns.
+- [ ] **T-012**: Update `schemas/components/schemas/PendingLink.yaml` (if it exists) or the inline schema, exposing `email_verified_at` as a nullable read-only field on the approve endpoint context where relevant.
+- [ ] **T-013**: Run `npm run generate` and verify the diff in `src/types/generated.ts` is additive only (new operation, new response type, new optional field).
+- [ ] **T-014**: Commit PR1 in two commits: `spec:` for SpecKit + schema + migration, `chore:` for generated types. Push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Email provider abstraction
+
+- [ ] **T-101**: Add `EMAIL_PROVIDER?: string`, `EMAIL_FROM?: string`, `RESEND_API_KEY?: string` to `Env` in `src/types.ts`.
+- [ ] **T-102**: Create `src/utils/email/types.ts` exporting `EmailMessage` and `EmailProvider` interfaces, plus error classes `EmailNotConfiguredError` and `EmailSendError`.
+- [ ] **T-103**: Create `src/utils/email/resend.ts` implementing `EmailProvider`. Single `fetch()` to `https://api.resend.com/emails` with bearer auth, 2-second `AbortSignal.timeout(2000)`. Throw `EmailSendError` on non-2xx.
+- [ ] **T-104**: Create `src/utils/email/index.ts` exporting `sendEmail(env, msg)` that selects provider by `env.EMAIL_PROVIDER`. Returns `EmailNotConfiguredError` when unset.
+
+### Token & DB layer
+
+- [ ] **T-105**: Add helper `generateVerificationToken()` in `src/utils/crypto.ts` returning `{ plaintext, hash }` (32 random bytes, base64url, SHA-256).
+- [ ] **T-106**: Update `src/routes/auth/login.ts` PendingLink branch to:
+  1. Generate token before INSERT.
+  2. Build the email body (plain text + minimal HTML) including the verify link.
+  3. Call `sendEmail(env, msg)` BEFORE the D1 INSERT.
+  4. Only INSERT when the send resolves; store `email_verification_token_hash`.
+  5. On `EmailSendError`, return 502; on `EmailNotConfiguredError`, return 503. No partial state.
+
+### Verify endpoint
+
+- [ ] **T-107**: Add `link.get("/link/verify/:token", ...)` in `src/routes/auth/link.ts` (public, no session middleware, no rate-limit middleware in PR2 — follow-up).
+- [ ] **T-108**: Implement the lookup as a single UPDATE-with-RETURNING:
+  ```sql
+  UPDATE pending_links
+  SET email_verified_at = datetime('now')
+  WHERE email_verification_token_hash = ?
+    AND email_verified_at IS NULL
+    AND expires_at > datetime('now')
+  RETURNING id
+  ```
+  - `meta.changes === 1`: success ⇒ return HTML confirmation page.
+  - `meta.changes === 0`: distinguish "not found / already verified / expired" via a follow-up SELECT, return 410 with the appropriate body.
+
+### Approve endpoint gate
+
+- [ ] **T-109**: In `src/routes/auth/link.ts` `POST /link/approve/:pending_link_id`, check `email_verified_at IS NOT NULL` before proceeding. If null, return 403 with `{"error": "Email verification required"}`.
+
+### Documentation
+
+- [ ] **T-110**: Update `docs/auth-design.md` PendingLink section to describe the verification step.
+- [ ] **T-111**: Add `docs/email-setup.md` operator runbook: DNS (SPF/DKIM/DMARC), Resend onboarding, troubleshooting, deliverability test with mail-tester.com.
+
+### Tests
+
+- [ ] **T-112**: Unit test for `src/utils/email/resend.ts` — mock `globalThis.fetch`, verify request shape, error handling, timeout behaviour.
+- [ ] **T-113**: Unit test for `src/utils/email/index.ts` provider selector — unset, unknown value, configured.
+- [ ] **T-114**: Integration test in `tests/integration/pending-link-verify.test.ts`:
+  - Happy path: seed PendingLink with known token hash, GET verify URL, assert `email_verified_at` set.
+  - Replay: second GET returns 410.
+  - Expired row: pre-aged `expires_at`, returns 410.
+  - Approve before verify: 403.
+
+### Verification
+
+- [ ] **T-115**: `npx tsc --noEmit` — zero errors.
+- [ ] **T-116**: `npm test` — all suites pass including new tests.
+- [ ] **T-117**: Run quickstart scenarios A–H against a deployed staging Worker with Resend; attach screenshots/log excerpts to the PR.
+
+### PR2 submission
+
+- [ ] **T-118**: Commit with `feat:` prefix. Push, open PR against `develop` referencing #80 and PR1.
+
+## Dependencies
+
+```
+T-001..T-007  → T-008..T-012 → T-013 → T-014  (PR1)
+T-014 → T-101..T-118  (PR2 starts after PR1 merge)
+T-102 → T-103 → T-104  (provider stack)
+T-104 → T-106 (call site needs the surface)
+T-105 → T-106 (token helper before use)
+T-106 → T-107 (DB column must exist before verify endpoint reads it)
+T-107 → T-109 (approve gate piggybacks on verify-set column)
+T-103/T-104 → T-112/T-113  (tests follow code)
+T-106/T-107/T-109 → T-114  (integration test needs all three branches)
+T-115/T-116 → T-117 → T-118
+```
+
+## Out of scope (do not implement in this feature)
+
+- Cloudflare Email Service adapter (binding-based; add after GA).
+- AWS SES adapter (SigV4 implementation; future PR).
+- Bounce / complaint webhook handling.
+- Workers Queues retry of failed sends.
+- Branded HTML email templates.
+- Per-user unsubscribe (these are transactional, not marketing).
+- Email locales other than English.
+- Rate limiting on the verify endpoint (the token's entropy is the protection; rate limit is follow-up if abuse appears).

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -82,11 +82,17 @@ CREATE TABLE IF NOT EXISTS pending_links (
   token_expires_at TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   expires_at TEXT NOT NULL,
+  -- Out-of-band email verification (Issue #80). Populated at PendingLink
+  -- creation when running in multi-user mode with an email provider configured.
+  email_verification_token_hash TEXT,
+  email_verified_at TEXT,
   FOREIGN KEY (existing_user_id) REFERENCES users(id) ON DELETE CASCADE,
   UNIQUE(existing_user_id, provider, provider_user_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_pending_links_expires ON pending_links(expires_at);
+CREATE INDEX IF NOT EXISTS idx_pending_links_token_hash
+  ON pending_links(email_verification_token_hash);
 
 -- ============================================================
 -- Heartbeats (core tracking data)

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -219,6 +219,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/link/verify/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Out-of-band email verification for PendingLink
+         * @description Verifies the recipient's inbox access for an outstanding PendingLink.
+         *     The token is single-use and embedded in a one-time email sent at
+         *     PendingLink creation.
+         *
+         *     On first successful hit within the token's TTL, the server marks the
+         *     underlying PendingLink row as email-verified. Subsequent hits, hits
+         *     against an expired row, and hits against an unknown token all return
+         *     410 Gone. The endpoint is public (no auth) because the recipient may
+         *     not have a CloudTime session in the browser used to open the email.
+         *
+         *     The state change occurs on GET because the token itself is the proof
+         *     of authorisation; this is acceptable for single-use tokens and is
+         *     intentionally compatible with mobile email clients that pre-fetch
+         *     links (pre-fetch consumes the token; user clicks then see 410 — this
+         *     behaviour is documented in the operator runbook).
+         *
+         *     See specs/080-out-of-band-email-verification/.
+         */
+        get: operations["verifyLinkEmailToken"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/providers": {
         parameters: {
             query?: never;
@@ -1590,6 +1626,22 @@ export interface components {
                 };
             };
         };
+        /**
+         * @description The resource exists but is no longer available. Used by single-use
+         *     verification flows where the token has been consumed, expired, or
+         *     never existed.
+         */
+        Gone: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @example Token expired */
+                    error?: string;
+                };
+            };
+        };
     };
     parameters: {
         /** @description Machine/device name (fallback if not provided in request body) */
@@ -1784,6 +1836,7 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             /** @description Pending link expired */
             410: {
@@ -1797,6 +1850,44 @@ export interface operations {
                 };
             };
             429: components["responses"]["TooManyRequests"];
+        };
+    };
+    verifyLinkEmailToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description 32-byte base64url-encoded one-time token. Plaintext appears only
+                 *     in the email body; only the SHA-256 hash is persisted server-side.
+                 */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Verification succeeded. Recipient should return to CloudTime to approve the merge. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example <!doctype html><h1>Email verified</h1>
+                     *     <p>Return to CloudTime and approve the account merge.</p>
+                     */
+                    "text/html": string;
+                };
+            };
+            /** @description Method Not Allowed — verify endpoint only accepts GET. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            410: components["responses"]["Gone"];
         };
     };
     getLinkedProviders: {


### PR DESCRIPTION
## Summary

PR1 of the SpecKit 2-PR workflow for [Issue #80](https://github.com/sudolifeagain/cloudtime/issues/80). Adds the SpecKit artifacts, OpenAPI surface, and DB migration for an out-of-band email verification step on the PendingLink merge flow.

**No implementation in this PR.** PR2 will land the Resend adapter, the send-before-INSERT pipeline, the verify endpoint, and the 403 gate on approve.

## Strategy chosen (full rationale in `research.md`)

| Provider | Role | Why |
|---|---|---|
| **Resend** | Day-one default | Best Workers DX (flat REST + bearer auth), free tier covers expected volume (PendingLink emails are rare even in multi-user mode), no time-limit on free tier |
| Cloudflare Email Service | Second adapter, designed-for | Currently public beta; revisit after GA |
| AWS SES | Future adapter | Cheapest at scale; SigV4 in Workers + sandbox-to-prod application flow makes it second-priority |
| MailChannels / SendGrid / Mailgun | Excluded | EOL'd CF Workers integration / no permanent free tier / trial-only |

## Schema changes (additive)

- **New**: `schemas/components/responses/Gone.yaml` — shared 410 component
- **New**: `schemas/paths/auth/link-verify-token.yaml` — `GET /auth/link/verify/{token}` (`security: []`, 200/405/410)
- **Modified**: `schemas/paths/auth/link-approve.yaml` — declares 403 via existing `Forbidden.yaml`
- **Modified**: `schemas/openapi.yaml` — wires the new path

## DB changes

- `migrations/0002_pending_link_email_verification.sql`:
  - `email_verification_token_hash TEXT` (nullable)
  - `email_verified_at TEXT` (nullable)
  - `idx_pending_links_token_hash`
- `src/db/schema.sql` synced so fresh deploys via `npm run db:init` include the new shape.
- **No backfill**. Pre-existing rows expire within 1 hour; impact is bounded.

## Behaviour (lands in PR2)

1. PendingLink creation: server generates token → calls `sendEmail(...)` → only INSERTs row on success. Failures roll back.
2. Verify endpoint: `GET /api/v1/auth/link/verify/:token` performs a single UPDATE-with-RETURNING. First hit wins, subsequent hits 410.
3. Approve gate: `POST /auth/link/approve/:id` returns 403 when `email_verified_at IS NULL`.
4. Single-user mode: unaffected (no PendingLink ⇒ no email ⇒ verify endpoint always 410).
5. Provider failure / unconfigured: fail closed (502 / 503), no partial state.

## Test plan

- [x] `npm run generate` produces additive-only diff in `src/types/generated.ts`
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 60/60 existing tests still pass (no behaviour change)
- [ ] CI workflow runs green

## What's NOT in this PR

- `src/utils/email/*` adapters
- Changes to `src/routes/auth/login.ts` or `src/routes/auth/link.ts`
- `src/types.ts` env extensions
- `docs/email-setup.md` operator runbook (lands with PR2)

All implementation work is enumerated in `specs/080-out-of-band-email-verification/tasks.md` § PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)