### PR TITLE
feat: out-of-band email verification for PendingLink (PR2/2) #80

### DIFF
--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -84,20 +84,32 @@ Controlled by `INSTANCE_MODE` environment variable:
 3. System checks DUAL email verification:
    a) Existing user's email_verified must be true
    b) Incoming provider must report email as verified
-4. If BOTH verified → creates PendingLink (TTL: 1 hour)
-   If EITHER unverified → creates new user account instead (no PendingLink)
+4. If BOTH verified → send out-of-band verification email FIRST, then on
+   success create PendingLink (TTL: 1 hour, see Issue #80)
+   If EITHER unverified → create new user account instead (no PendingLink)
 5. Returns pending_link with existing_username
-6. User calls POST /api/v1/auth/link/approve/{pending_link_id}
-7. OAuth account is linked to existing user
-8. User is logged in as existing account
+6. Recipient opens the verification link from their inbox →
+   pending_links.email_verified_at is set
+7. User calls POST /api/v1/auth/link/approve/{pending_link_id}
+   (returns 403 "Email verification required" if step 6 has not occurred)
+8. OAuth account is linked to existing user
+9. User is logged in as existing account
 ```
+
+**Out-of-band email verification (Issue #80)**: This is the third defence on
+top of "dual `email_verified` check" and "manual approval". Even when a
+provider reports `email_verified: true`, the existing user must prove inbox
+access before approval is honoured. The verification email is sent BEFORE the
+PendingLink row is committed — if the send fails or the provider is not
+configured, no row is written. See [email-setup.md](./email-setup.md) for
+operator configuration and `specs/080-out-of-band-email-verification/`.
 
 **email_verified behavior:**
 - Set on user creation based on the OAuth provider's report.
 - Updated on each login: uses a **high-water mark** approach — once verified (`true`), never downgraded back to `false`. Only upgrades (false → true) are applied. This follows industry best practices (Auth0, Firebase, Clerk).
 - Provider-specific extraction: GitHub requires `GET /user/emails` (primary email's `verified` field), Google returns `email_verified` or `verified_email` depending on endpoint, Discord returns `verified` (absent without `email` scope, treated as `false`).
 
-**Single-user mode:** Same-email detection still applies, but since there's only one user, the new provider is linked directly without approval. The `pending_links` table is not used. The `email_verified` field is still recorded accurately regardless of instance mode.
+**Single-user mode:** The same-email merge branch is gated on `INSTANCE_MODE=multi`. In single-user mode the PendingLink path is never entered — a second OAuth login that resolves to a different `(provider, provider_user_id)` falls through to the single-user gate (`WHERE (SELECT COUNT(*) FROM users) = 0`) which returns 403 "Registration closed". Operators who want a second provider linked to the owner must use `POST /api/v1/auth/link/{provider}` (session required), not the implicit same-email flow. The verification-email pipeline is therefore inert in single-user mode and `EMAIL_PROVIDER` need not be set.
 
 ## Session Security
 

--- a/docs/email-setup.md
+++ b/docs/email-setup.md
@@ -1,0 +1,119 @@
+# Email Setup for Operators
+
+This guide covers the email delivery pipeline used by the out-of-band
+PendingLink verification flow (Issue #80). It applies only when running in
+multi-user mode (`INSTANCE_MODE=multi`). Single-user instances do not send
+email and may skip this document entirely.
+
+## Provider support
+
+| Provider | Status | Env value |
+|---|---|---|
+| Resend | Supported | `EMAIL_PROVIDER=resend` |
+| Cloudflare Email Service | Planned (after GA) | `EMAIL_PROVIDER=cloudflare` |
+| AWS SES | Planned | `EMAIL_PROVIDER=ses` |
+
+Other providers (MailChannels, SendGrid, Mailgun, Postmark) are intentionally
+not supported as of this writing; see
+`specs/080-out-of-band-email-verification/research.md` for rationale.
+
+## Required configuration
+
+Set the following variables via `wrangler secret put` (or `[vars]` for
+non-secret values):
+
+```text
+EMAIL_PROVIDER   # one of: resend
+EMAIL_FROM       # e.g. "noreply@cloudtime.example.com"
+RESEND_API_KEY   # bearer token from https://resend.com/api-keys
+```
+
+`EMAIL_FROM` must be on a domain you control. The sending domain must pass
+SPF, DKIM, and (recommended) DMARC checks for the recipient's mail server to
+accept the message. Resend's domain-verification onboarding walks through
+the required DNS records.
+
+## DNS records (one-time per sending domain)
+
+| Record | Purpose |
+|---|---|
+| MX (optional) | Required if you want bounces handled by your own mail server. Resend can host bounces if you skip this. |
+| SPF | TXT record permitting Resend to send as your domain. |
+| DKIM | Public key Resend publishes on your behalf; sign every outgoing message. |
+| DMARC | Policy record telling recipients what to do when SPF/DKIM fail. Start with `p=none` to monitor, then tighten. |
+
+Validate end-to-end with [mail-tester.com](https://mail-tester.com) before
+relying on the deployment. A score of 9+/10 is the operational target.
+
+## Behaviour summary
+
+1. PendingLink would be created (multi-user mode + matched verified email).
+2. Server generates a 32-byte token, builds a verify URL on `APP_URL`, and
+   calls `sendEmail()`.
+3. On success, the PendingLink row is INSERTed with the SHA-256 hash of the
+   token and `email_verified_at = NULL`.
+4. The recipient opens the link from their inbox. The first hit consumes the
+   token via `UPDATE ... SET email_verified_at = datetime('now') ...
+   RETURNING id` and returns a small HTML confirmation page.
+5. The user returns to CloudTime and calls
+   `POST /api/v1/auth/link/approve/{pending_link_id}` to complete the merge.
+
+## Failure modes
+
+| Condition | Response | DB effect |
+|---|---|---|
+| `EMAIL_PROVIDER` unset | 503 Service Unavailable | No row written |
+| `EMAIL_PROVIDER=resend` but `RESEND_API_KEY` missing | 503 Service Unavailable | No row written |
+| Provider returns non-2xx | 502 Bad Gateway | No row written |
+| Send exceeds 2-second budget | 502 Bad Gateway | No row written |
+| User clicks link → success | 200 HTML confirmation | `email_verified_at` set |
+| User clicks already-verified link | 410 Gone (`"Token already used"`) | No change |
+| User clicks expired link | 410 Gone (`"Token expired"`) | No change |
+| User clicks unknown link | 410 Gone (`"Token not found"`) | No change |
+| Approve before verification | 403 Forbidden (`"Email verification required"`) | No merge |
+
+## Log fields
+
+Successful send:
+
+```
+[email] sent provider=resend pending_link=<uuid> recipient_domain=example.com
+```
+
+Failure or misconfiguration:
+
+```
+[email] not configured — refusing PendingLink for recipient_domain=example.com
+[email] send failed recipient_domain=example.com status=401 message=…
+```
+
+The recipient's full address, the token plaintext, and the email body are
+**never** logged.
+
+## Operator runbook
+
+- **Daily**: tail Worker logs for `[email]` entries. Any `send failed` should
+  be investigated immediately.
+- **Weekly**: check the Resend dashboard for bounce / complaint rates.
+  Sustained values above 1% combined suggest sender-reputation problems.
+- **On domain change**: re-run mail-tester.com against `EMAIL_FROM`. Update
+  SPF / DKIM / DMARC records as Resend instructs.
+
+## Mobile pre-fetch caveat
+
+Some mobile email clients pre-fetch links to detect phishing. A pre-fetch
+will consume the token, and when the user later taps the link they will see
+410 ("Token already used"). The token still served its security purpose
+(only an inbox holder could have triggered the pre-fetch). If users report
+this confusion frequently, consider switching to an explicit confirmation
+page that requires a user-initiated POST. This is documented as a known
+trade-off in `specs/080-out-of-band-email-verification/research.md`
+Decision 4.
+
+## Cost expectations
+
+Resend's free tier (3,000 emails/month) covers the expected volume of
+PendingLink verifications even for a 1,000-user instance — these emails are
+only triggered on account merge events. See
+`specs/080-out-of-band-email-verification/research.md` for the full
+provider comparison.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,14 @@ app.use("/*", async (c, next) => {
   if (c.req.header("Authorization")) {
     return next();
   }
+  // The out-of-band email verification endpoint (Issue #80) is intentionally
+  // exempt from CSRF: it is method-restricted at the route layer (GET success,
+  // 405 for other methods) and the bearer is the URL token itself, which is
+  // unguessable. CSRF would otherwise convert non-GET probes into 403 before
+  // the route handler can return the documented 405.
+  if (c.req.path.startsWith("/api/v1/auth/link/verify/")) {
+    return next();
+  }
   return csrfMiddleware(c, next);
 });
 

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -10,13 +10,17 @@ import link from "./link";
 
 const auth = new Hono<{ Bindings: Env }>();
 
-// Session-authenticated routes (static paths first)
+// `link` is mounted BEFORE `sessions` because the public verify endpoint
+// (`/link/verify/:token`, Issue #80) must not be intercepted by the
+// wildcard session middleware in `sessions`. Hono matches sub-apps in
+// mount order, so the verify route resolves to `link`'s handler before
+// sessions can claim it.
+auth.route("/", link);
+
+// Session-authenticated routes (static paths)
 auth.route("/", sessions);
 
 // Public routes (parameterized, last)
 auth.route("/", login);
-
-// Account linking routes (session required for initiation, cookie-based for callback)
-auth.route("/", link);
 
 export default auth;

--- a/src/routes/auth/link.ts
+++ b/src/routes/auth/link.ts
@@ -46,7 +46,17 @@ const link = new Hono<SessionAuthEnv>();
 // The token in the URL is the only proof; first hit consumes it via UPDATE-
 // with-RETURNING. CSRF middleware is bypassed for this path (see src/index.ts)
 // so non-GET methods reach the route layer and receive a clean 405.
-link.get("/link/verify/:token", async (c) => {
+link.all("/link/verify/:token", async (c) => {
+  if (c.req.method !== "GET") {
+    return c.json({ error: "Method Not Allowed" }, 405, {
+      Allow: "GET",
+      "Cache-Control": "no-store",
+    });
+  }
+  if (c.env.INSTANCE_MODE !== "multi") {
+    return c.json({ error: "Token not found" }, 410, noCacheHeaders());
+  }
+
   const token = c.req.param("token");
   if (!token) {
     return c.json({ error: "Token not found" }, 410, noCacheHeaders());
@@ -97,15 +107,6 @@ link.get("/link/verify/:token", async (c) => {
   }
   return c.json({ error: "Token expired" }, 410, noCacheHeaders());
 });
-
-// Non-GET methods on the verify path receive 405 (CSRF middleware is
-// bypassed for this path in src/index.ts so this handler is reachable).
-link.on(["POST", "PUT", "PATCH", "DELETE"], "/link/verify/:token", (c) =>
-  c.json({ error: "Method Not Allowed" }, 405, {
-    Allow: "GET",
-    "Cache-Control": "no-store",
-  }),
-);
 
 // POST /link/approve/:pending_link_id (session required)
 link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {

--- a/src/routes/auth/link.ts
+++ b/src/routes/auth/link.ts
@@ -34,7 +34,78 @@ import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../../
 import { sessionMw } from "./middleware";
 import { getRedirectUri, noCacheHeaders } from "./helpers";
 
+const VERIFY_SUCCESS_HTML =
+  `<!doctype html><html><head><meta charset="utf-8"><title>Email verified — CloudTime</title></head>` +
+  `<body><h1>Email verified</h1>` +
+  `<p>Thanks. Return to CloudTime and approve the account merge from your account settings.</p>` +
+  `</body></html>`;
+
 const link = new Hono<SessionAuthEnv>();
+
+// GET /link/verify/:token (public — out-of-band PendingLink verification, Issue #80).
+// The token in the URL is the only proof; first hit consumes it via UPDATE-
+// with-RETURNING. CSRF middleware is bypassed for this path (see src/index.ts)
+// so non-GET methods reach the route layer and receive a clean 405.
+link.get("/link/verify/:token", async (c) => {
+  const token = c.req.param("token");
+  if (!token) {
+    return c.json({ error: "Token not found" }, 410, noCacheHeaders());
+  }
+  let tokenHash: string;
+  try {
+    tokenHash = await sha256Hex(token);
+  } catch {
+    return c.json({ error: "Token not found" }, 410, noCacheHeaders());
+  }
+
+  // Atomic single-use consumption: only flip email_verified_at when the row
+  // exists, hasn't been verified yet, and hasn't expired. `meta.changes`
+  // distinguishes the success path from the various 410 cases.
+  const result = await c.env.DB.prepare(
+    `UPDATE pending_links
+       SET email_verified_at = datetime('now')
+     WHERE email_verification_token_hash = ?
+       AND email_verified_at IS NULL
+       AND expires_at > datetime('now')
+     RETURNING id`,
+  )
+    .bind(tokenHash)
+    .first<{ id: string }>();
+
+  if (result) {
+    return c.body(VERIFY_SUCCESS_HTML, 200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+      Pragma: "no-cache",
+    });
+  }
+
+  // Distinguish replay vs expiry vs not-found for clearer logs and bodies.
+  // SELECT after the failed UPDATE is two queries on the cold path only.
+  const existing = await c.env.DB.prepare(
+    `SELECT email_verified_at, expires_at FROM pending_links
+     WHERE email_verification_token_hash = ?`,
+  )
+    .bind(tokenHash)
+    .first<{ email_verified_at: string | null; expires_at: string }>();
+
+  if (!existing) {
+    return c.json({ error: "Token not found" }, 410, noCacheHeaders());
+  }
+  if (existing.email_verified_at !== null) {
+    return c.json({ error: "Token already used" }, 410, noCacheHeaders());
+  }
+  return c.json({ error: "Token expired" }, 410, noCacheHeaders());
+});
+
+// Non-GET methods on the verify path receive 405 (CSRF middleware is
+// bypassed for this path in src/index.ts so this handler is reachable).
+link.on(["POST", "PUT", "PATCH", "DELETE"], "/link/verify/:token", (c) =>
+  c.json({ error: "Method Not Allowed" }, 405, {
+    Allow: "GET",
+    "Cache-Control": "no-store",
+  }),
+);
 
 // POST /link/approve/:pending_link_id (session required)
 link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
@@ -45,7 +116,8 @@ link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
     const pending = await c.env.DB.prepare(
       `SELECT provider, provider_user_id, provider_username, provider_email,
               email_verified, access_token_encrypted, refresh_token_encrypted,
-              token_expires_at, expires_at
+              token_expires_at, expires_at,
+              email_verification_token_hash, email_verified_at
        FROM pending_links WHERE id = ? AND existing_user_id = ?`,
     )
       .bind(pendingLinkId, userId)
@@ -59,6 +131,8 @@ link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
         refresh_token_encrypted: string | null;
         token_expires_at: string | null;
         expires_at: string;
+        email_verification_token_hash: string | null;
+        email_verified_at: string | null;
       }>();
 
     if (!pending) return c.json({ error: "Not found" }, 404, noCacheHeaders());
@@ -68,6 +142,19 @@ link.post("/link/approve/:pending_link_id", sessionMw, async (c) => {
     if (new Date() > expiresAt) {
       await c.env.DB.prepare("DELETE FROM pending_links WHERE id = ?").bind(pendingLinkId).run();
       return c.json({ error: "Pending link expired" }, 410, noCacheHeaders());
+    }
+
+    // Out-of-band email verification gate (Issue #80). Rows created under the
+    // new flow carry a token hash; the recipient must have clicked the email
+    // link to set email_verified_at. Rows pre-dating the feature (NULL hash)
+    // also fail this check — they must be re-triggered via OAuth, and
+    // expire naturally within 1 hour.
+    if (pending.email_verified_at === null) {
+      return c.json(
+        { error: "Email verification required" },
+        403,
+        noCacheHeaders(),
+      );
     }
 
     // Check if this provider account was linked to another user in the meantime

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -221,7 +221,7 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
           // it in the email; only persist after the send succeeds (fail-closed).
           const { plaintext: verifyToken, hash: verifyTokenHash } =
             await generateVerificationToken();
-          const verifyOrigin = c.env.APP_URL ?? new URL(c.req.url).origin;
+          const verifyOrigin = (c.env.APP_URL ?? new URL(c.req.url).origin).replace(/\/+$/, "");
           const verifyUrl = `${verifyOrigin}/api/v1/auth/link/verify/${verifyToken}`;
           const recipientDomain = userInfo.providerEmail.includes("@")
             ? userInfo.providerEmail.slice(userInfo.providerEmail.indexOf("@") + 1)

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -14,9 +14,15 @@ import {
   generateNonce,
   generateSessionToken,
   generateApiKey,
+  generateVerificationToken,
   encryptToken,
   timingSafeEqual,
 } from "../../utils/crypto";
+import {
+  sendEmail,
+  EmailNotConfiguredError,
+  EmailSendError,
+} from "../../utils/email";
 import {
   isValidProvider,
   buildAuthorizeUrl,
@@ -175,9 +181,15 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
       );
     }
 
-    // No existing OAuth link — check if email matches an existing user
+    // No existing OAuth link — check if email matches an existing user.
+    // The same-email merge flow is only meaningful in multi-user mode;
+    // single-user mode falls through and the single-user gate further
+    // down returns "Registration closed" (Issue #80 PR2: ensure we never
+    // create a PendingLink, and therefore never need to send a
+    // verification email, in single-user mode).
     let unverifiedUserId: string | null = null;
-    if (userInfo.providerEmail) {
+    const isMultiUser = c.env.INSTANCE_MODE === "multi";
+    if (isMultiUser && userInfo.providerEmail) {
       const emailMatch = await c.env.DB.prepare("SELECT id, email_verified FROM users WHERE email = ?")
         .bind(userInfo.providerEmail)
         .first<{ id: string; email_verified: number }>();
@@ -205,16 +217,76 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
             ? await encryptToken(userInfo.refreshToken, c.env.ENCRYPTION_KEY, encCtx)
             : null;
 
-          // Create pending link for manual approval
+          // Generate the out-of-band verification token first so we can include
+          // it in the email; only persist after the send succeeds (fail-closed).
+          const { plaintext: verifyToken, hash: verifyTokenHash } =
+            await generateVerificationToken();
+          const verifyOrigin = c.env.APP_URL ?? new URL(c.req.url).origin;
+          const verifyUrl = `${verifyOrigin}/api/v1/auth/link/verify/${verifyToken}`;
+          const recipientDomain = userInfo.providerEmail.includes("@")
+            ? userInfo.providerEmail.slice(userInfo.providerEmail.indexOf("@") + 1)
+            : "(unknown)";
+
           const pendingId = crypto.randomUUID();
           const pendingExpiry = new Date(Date.now() + 3600_000) // 1 hour
             .toISOString()
             .replace("T", " ")
             .replace("Z", "");
 
+          try {
+            await sendEmail(c.env, {
+              from: c.env.EMAIL_FROM ?? "",
+              to: userInfo.providerEmail,
+              subject: "Confirm CloudTime account link",
+              text:
+                `Someone signed in with ${provider} using this email address and is requesting to merge it into your existing CloudTime account.\n\n` +
+                `If that was you, open this link to confirm — it expires in 1 hour:\n\n${verifyUrl}\n\n` +
+                `After confirming, return to CloudTime and approve the merge from your account settings.\n\n` +
+                `If this was not you, ignore this email; the request will expire and no change will be made.`,
+              html:
+                `<!doctype html><html><body>` +
+                `<p>Someone signed in with <strong>${provider}</strong> using this email address ` +
+                `and is requesting to merge it into your existing CloudTime account.</p>` +
+                `<p>If that was you, click the link below to confirm — it expires in 1 hour:</p>` +
+                `<p><a href="${verifyUrl}">${verifyUrl}</a></p>` +
+                `<p>After confirming, return to CloudTime and approve the merge from your account settings.</p>` +
+                `<p>If this was not you, ignore this email; the request will expire and no change will be made.</p>` +
+                `</body></html>`,
+            });
+            console.log(
+              `[email] sent provider=${c.env.EMAIL_PROVIDER} pending_link=${pendingId} recipient_domain=${recipientDomain}`,
+            );
+          } catch (err) {
+            if (err instanceof EmailNotConfiguredError) {
+              console.warn(
+                `[email] not configured — refusing PendingLink for recipient_domain=${recipientDomain}`,
+              );
+              return c.json(
+                { error: "Email delivery not configured" },
+                503,
+                noCacheHeaders(),
+              );
+            }
+            if (err instanceof EmailSendError) {
+              console.error(
+                `[email] send failed recipient_domain=${recipientDomain} status=${err.status ?? "n/a"} message=${err.message}`,
+              );
+              return c.json(
+                {
+                  error:
+                    "Unable to send verification email; please try again later",
+                },
+                502,
+                noCacheHeaders(),
+              );
+            }
+            throw err;
+          }
+
+          // Email sent — now persist the PendingLink with the matching hash.
           const linkResult = await c.env.DB.prepare(
-            `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `INSERT INTO pending_links (id, existing_user_id, provider, provider_user_id, provider_username, provider_email, email_verified, access_token_encrypted, refresh_token_encrypted, token_expires_at, expires_at, email_verification_token_hash)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(existing_user_id, provider, provider_user_id) DO UPDATE SET
                provider_username = excluded.provider_username,
                provider_email = excluded.provider_email,
@@ -222,7 +294,9 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
                access_token_encrypted = excluded.access_token_encrypted,
                refresh_token_encrypted = excluded.refresh_token_encrypted,
                token_expires_at = excluded.token_expires_at,
-               expires_at = excluded.expires_at
+               expires_at = excluded.expires_at,
+               email_verification_token_hash = excluded.email_verification_token_hash,
+               email_verified_at = NULL
              RETURNING id`,
           )
             .bind(
@@ -237,6 +311,7 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
               refreshTokenEnc,
               userInfo.tokenExpiresAt,
               pendingExpiry,
+              verifyTokenHash,
             )
             .first<{ id: string }>();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,13 @@ export interface Env {
   // Rate-limit bindings (optional — middleware fails open when undefined)
   RATE_LIMIT_OAUTH_INITIATE?: RateLimit;
   RATE_LIMIT_OAUTH_CALLBACK?: RateLimit;
+
+  // Email delivery (Issue #80). Required in multi-user mode for the
+  // out-of-band PendingLink verification flow. Single-user mode does not
+  // create PendingLinks and therefore does not send email.
+  EMAIL_PROVIDER?: string; // currently supports "resend"
+  EMAIL_FROM?: string; // e.g. "noreply@cloudtime.example.com"
+  RESEND_API_KEY?: string;
 }
 
 // Minimal shape of Cloudflare Workers Rate Limiting binding. The official

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -66,6 +66,19 @@ export async function generateApiKey(): Promise<{ plaintext: string; hash: strin
   return { plaintext, hash };
 }
 
+/**
+ * Generate a one-time verification token used in URLs sent to a user's
+ * email inbox (Issue #80, PendingLink out-of-band verification).
+ *
+ * The plaintext appears only in the email body and the URL; the
+ * SHA-256 hash is what we persist. Same pattern as `generateApiKey`.
+ */
+export async function generateVerificationToken(): Promise<{ plaintext: string; hash: string }> {
+  const plaintext = base64url(randomBytes(32));
+  const hash = await sha256Hex(plaintext);
+  return { plaintext, hash };
+}
+
 // ─── AES-256-GCM encryption for OAuth tokens at rest ─────
 
 async function importAesKey(keyHex: string): Promise<CryptoKey> {

--- a/src/utils/email/index.ts
+++ b/src/utils/email/index.ts
@@ -1,0 +1,45 @@
+import type { Env } from "../../types";
+import { ResendProvider } from "./resend";
+import {
+  type EmailMessage,
+  type EmailProvider,
+  EmailNotConfiguredError,
+} from "./types";
+
+export {
+  type EmailMessage,
+  type EmailProvider,
+  EmailNotConfiguredError,
+  EmailSendError,
+} from "./types";
+
+/**
+ * Resolve the configured EmailProvider for this environment, or null if
+ * none is configured. Selection is explicit via `EMAIL_PROVIDER` —
+ * presence of provider-specific secrets alone does not enable email.
+ */
+export function getEmailProvider(env: Env): EmailProvider | null {
+  switch (env.EMAIL_PROVIDER) {
+    case "resend":
+      if (!env.RESEND_API_KEY) return null;
+      return new ResendProvider(env.RESEND_API_KEY);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Send a transactional email via the configured provider. Throws
+ * EmailNotConfiguredError when no provider is selected or its credentials
+ * are missing; throws EmailSendError on provider/network failure. Call
+ * sites must translate both to HTTP responses (503 / 502 respectively)
+ * before any persistent state change.
+ */
+export async function sendEmail(env: Env, message: EmailMessage): Promise<void> {
+  const provider = getEmailProvider(env);
+  if (!provider) throw new EmailNotConfiguredError();
+  if (!message.from) {
+    throw new EmailNotConfiguredError("EMAIL_FROM is not configured");
+  }
+  await provider.send(message);
+}

--- a/src/utils/email/resend.ts
+++ b/src/utils/email/resend.ts
@@ -1,0 +1,51 @@
+import { type EmailMessage, type EmailProvider, EmailSendError } from "./types";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const SEND_TIMEOUT_MS = 2000;
+
+interface ResendErrorBody {
+  message?: string;
+  name?: string;
+}
+
+export class ResendProvider implements EmailProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async send(message: EmailMessage): Promise<void> {
+    let response: Response;
+    try {
+      response = await fetch(RESEND_ENDPOINT, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: message.from,
+          to: message.to,
+          subject: message.subject,
+          html: message.html,
+          text: message.text,
+        }),
+        signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "unknown";
+      throw new EmailSendError(`Resend request failed: ${reason}`);
+    }
+
+    if (response.ok) return;
+
+    let detail = "";
+    try {
+      const body = (await response.json()) as ResendErrorBody;
+      detail = body.message ?? body.name ?? "";
+    } catch {
+      // body wasn't JSON — fall through with empty detail
+    }
+    throw new EmailSendError(
+      `Resend rejected request: status=${response.status}${detail ? ` detail=${detail}` : ""}`,
+      response.status,
+    );
+  }
+}

--- a/src/utils/email/types.ts
+++ b/src/utils/email/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Email provider abstraction (Issue #80).
+ *
+ * Adapters implement EmailProvider and are selected at runtime by
+ * `getEmailProvider(env)` in ./index.ts. Call sites use `sendEmail()`
+ * and handle EmailNotConfiguredError / EmailSendError explicitly.
+ */
+
+export interface EmailMessage {
+  to: string;
+  from: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<void>;
+}
+
+export class EmailNotConfiguredError extends Error {
+  constructor(message = "Email delivery not configured") {
+    super(message);
+    this.name = "EmailNotConfiguredError";
+  }
+}
+
+export class EmailSendError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "EmailSendError";
+    this.status = status;
+  }
+}

--- a/tests/integration/pending-link-verify.test.ts
+++ b/tests/integration/pending-link-verify.test.ts
@@ -43,9 +43,11 @@ afterEach(async () => {
 async function call(
   path: string,
   init: RequestInit = {},
+  envOverrides: Partial<Cloudflare.Env> = {},
 ): Promise<Response> {
   const ctx = createExecutionContext();
-  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  const testEnv = { ...env, INSTANCE_MODE: "multi", ...envOverrides };
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), testEnv, ctx);
   await waitOnExecutionContext(ctx);
   return res;
 }
@@ -137,6 +139,40 @@ describe("GET /api/v1/auth/link/verify/:token", () => {
     const res = await call("/api/v1/auth/link/verify/anything", { method: "POST" });
     expect(res.status).toBe(405);
     expect(res.headers.get("Allow")).toBe("GET");
+  });
+
+  it("returns 405 for HEAD without consuming the token", async () => {
+    const { pendingLinkId, token } = await seedPendingLink({ ownerId: owner.userId });
+
+    const res = await call(`/api/v1/auth/link/verify/${token}`, { method: "HEAD" });
+
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("GET");
+    const row = await env.DB.prepare(
+      "SELECT email_verified_at FROM pending_links WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .first<{ email_verified_at: string | null }>();
+    expect(row?.email_verified_at).toBeNull();
+  });
+
+  it("always returns 410 in single-user mode", async () => {
+    const { pendingLinkId, token } = await seedPendingLink({ ownerId: owner.userId });
+
+    const res = await call(
+      `/api/v1/auth/link/verify/${token}`,
+      {},
+      { INSTANCE_MODE: "single" },
+    );
+
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({ error: "Token not found" });
+    const row = await env.DB.prepare(
+      "SELECT email_verified_at FROM pending_links WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .first<{ email_verified_at: string | null }>();
+    expect(row?.email_verified_at).toBeNull();
   });
 });
 

--- a/tests/integration/pending-link-verify.test.ts
+++ b/tests/integration/pending-link-verify.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for the out-of-band PendingLink verification flow
+ * (Issue #80). Seeds PendingLink rows directly to exercise the verify
+ * endpoint and the approve-gate without spinning up the full OAuth flow.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import {
+  generateSessionToken,
+  generateVerificationToken,
+  sha256Hex,
+} from "../../src/utils/crypto";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+
+let owner: SeededUser;
+let sessionToken: string;
+
+beforeEach(async () => {
+  owner = await seedUser({ username: "alice", email: "alice@example.test" });
+  // Owner has an active session for the approve calls
+  sessionToken = generateSessionToken();
+  const sessionTokenHash = await sha256Hex(sessionToken);
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at, last_active_at)
+     VALUES (?, ?, ?, datetime('now'), datetime('now', '+7 days'), datetime('now'))`,
+  )
+    .bind(crypto.randomUUID(), owner.userId, sessionTokenHash)
+    .run();
+});
+
+afterEach(async () => {
+  await truncate("pending_links", "sessions", "oauth_accounts", "users");
+  await env.KV.delete(`apikey:${owner.apiKeyHash}`);
+});
+
+async function call(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+interface SeededPendingLink {
+  pendingLinkId: string;
+  token: string;
+  tokenHash: string;
+}
+
+async function seedPendingLink(opts: {
+  ownerId: string;
+  expiresInSeconds?: number;
+  alreadyVerified?: boolean;
+}): Promise<SeededPendingLink> {
+  const { plaintext: token, hash: tokenHash } = await generateVerificationToken();
+  const pendingLinkId = crypto.randomUUID();
+  const ttl = opts.expiresInSeconds ?? 3600;
+  await env.DB.prepare(
+    `INSERT INTO pending_links (
+       id, existing_user_id, provider, provider_user_id, provider_username,
+       provider_email, email_verified,
+       expires_at,
+       email_verification_token_hash, email_verified_at
+     ) VALUES (?, ?, 'google', 'google-uid-1', 'alice', 'alice@example.test', 1,
+       datetime('now', '+' || ? || ' seconds'), ?, ?)`,
+  )
+    .bind(
+      pendingLinkId,
+      opts.ownerId,
+      ttl,
+      tokenHash,
+      opts.alreadyVerified ? new Date().toISOString().replace("T", " ").replace("Z", "") : null,
+    )
+    .run();
+  return { pendingLinkId, token, tokenHash };
+}
+
+describe("GET /api/v1/auth/link/verify/:token", () => {
+  it("consumes the token, sets email_verified_at, and returns 200 HTML", async () => {
+    const { pendingLinkId, token } = await seedPendingLink({ ownerId: owner.userId });
+
+    const res = await call(`/api/v1/auth/link/verify/${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("Email verified");
+
+    const row = await env.DB.prepare(
+      "SELECT email_verified_at FROM pending_links WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .first<{ email_verified_at: string | null }>();
+    expect(row?.email_verified_at).not.toBeNull();
+  });
+
+  it("returns 410 'Token already used' on replay", async () => {
+    const { token } = await seedPendingLink({ ownerId: owner.userId });
+    const first = await call(`/api/v1/auth/link/verify/${token}`);
+    expect(first.status).toBe(200);
+
+    const second = await call(`/api/v1/auth/link/verify/${token}`);
+    expect(second.status).toBe(410);
+    expect(await second.json()).toEqual({ error: "Token already used" });
+  });
+
+  it("returns 410 'Token not found' for an unknown token", async () => {
+    const res = await call(`/api/v1/auth/link/verify/no-such-token`);
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({ error: "Token not found" });
+  });
+
+  it("returns 410 'Token expired' when the underlying row has expired", async () => {
+    const { token, pendingLinkId } = await seedPendingLink({ ownerId: owner.userId });
+    // Force expiry by editing the row.
+    await env.DB.prepare(
+      "UPDATE pending_links SET expires_at = datetime('now', '-1 minute') WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .run();
+
+    const res = await call(`/api/v1/auth/link/verify/${token}`);
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({ error: "Token expired" });
+  });
+
+  it("returns 405 for non-GET methods (CSRF bypass for the verify path)", async () => {
+    const res = await call("/api/v1/auth/link/verify/anything", { method: "POST" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("GET");
+  });
+});
+
+describe("POST /api/v1/auth/link/approve/:pending_link_id email-verification gate", () => {
+  it("returns 403 'Email verification required' before the verify link is clicked", async () => {
+    const { pendingLinkId } = await seedPendingLink({ ownerId: owner.userId });
+
+    const res = await call(`/api/v1/auth/link/approve/${pendingLinkId}`, {
+      method: "POST",
+      headers: {
+        Cookie: `__Host-session=${sessionToken}`,
+        Origin: BASE,
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Email verification required" });
+
+    // Row remains in place; merge did not happen.
+    const linkCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM oauth_accounts WHERE user_id = ?",
+    )
+      .bind(owner.userId)
+      .first<{ c: number }>();
+    expect(linkCount?.c).toBe(0);
+  });
+
+  it("returns 200 and completes the merge after the verify link is consumed", async () => {
+    const { pendingLinkId, token } = await seedPendingLink({ ownerId: owner.userId });
+
+    // Step 1: verify
+    const verifyRes = await call(`/api/v1/auth/link/verify/${token}`);
+    expect(verifyRes.status).toBe(200);
+
+    // Step 2: approve
+    const approveRes = await call(`/api/v1/auth/link/approve/${pendingLinkId}`, {
+      method: "POST",
+      headers: {
+        Cookie: `__Host-session=${sessionToken}`,
+        Origin: BASE,
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(approveRes.status).toBe(200);
+    const body = (await approveRes.json()) as { data: { user: { id: string } } };
+    expect(body.data.user.id).toBe(owner.userId);
+
+    // oauth_accounts row exists, pending_links row consumed.
+    const oauthRow = await env.DB.prepare(
+      "SELECT user_id FROM oauth_accounts WHERE provider = 'google' AND provider_user_id = 'google-uid-1'",
+    ).first<{ user_id: string }>();
+    expect(oauthRow?.user_id).toBe(owner.userId);
+
+    const remaining = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM pending_links WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .first<{ c: number }>();
+    expect(remaining?.c).toBe(0);
+  });
+
+  it("returns 403 for legacy rows lacking a verification token hash", async () => {
+    // Insert a pre-feature-shaped row: no token hash, no verified_at.
+    const pendingLinkId = crypto.randomUUID();
+    await env.DB.prepare(
+      `INSERT INTO pending_links (
+         id, existing_user_id, provider, provider_user_id, provider_username,
+         provider_email, email_verified, expires_at
+       ) VALUES (?, ?, 'google', 'legacy-uid', 'alice', 'alice@example.test', 1,
+         datetime('now', '+1 hour'))`,
+    )
+      .bind(pendingLinkId, owner.userId)
+      .run();
+
+    const res = await call(`/api/v1/auth/link/approve/${pendingLinkId}`, {
+      method: "POST",
+      headers: {
+        Cookie: `__Host-session=${sessionToken}`,
+        Origin: BASE,
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Email verification required" });
+  });
+});

--- a/tests/security/email-provider.test.ts
+++ b/tests/security/email-provider.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for src/utils/email/* — provider selector and Resend adapter.
+ * The adapter mocks globalThis.fetch to avoid real network access.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EmailNotConfiguredError,
+  EmailSendError,
+  getEmailProvider,
+  sendEmail,
+} from "../../src/utils/email";
+import { ResendProvider } from "../../src/utils/email/resend";
+import type { Env } from "../../src/types";
+
+function envWith(overrides: Partial<Env>): Env {
+  return overrides as Env;
+}
+
+describe("getEmailProvider", () => {
+  it("returns null when EMAIL_PROVIDER is unset", () => {
+    expect(getEmailProvider(envWith({}))).toBeNull();
+  });
+
+  it("returns null for an unknown EMAIL_PROVIDER value", () => {
+    expect(
+      getEmailProvider(envWith({ EMAIL_PROVIDER: "smoke-signals" } as Partial<Env>)),
+    ).toBeNull();
+  });
+
+  it("returns null when EMAIL_PROVIDER=resend but RESEND_API_KEY is missing", () => {
+    expect(
+      getEmailProvider(envWith({ EMAIL_PROVIDER: "resend" } as Partial<Env>)),
+    ).toBeNull();
+  });
+
+  it("returns a ResendProvider when configured", () => {
+    const p = getEmailProvider(
+      envWith({ EMAIL_PROVIDER: "resend", RESEND_API_KEY: "re_xxx" } as Partial<Env>),
+    );
+    expect(p).toBeInstanceOf(ResendProvider);
+  });
+});
+
+describe("sendEmail (selector)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("throws EmailNotConfiguredError when no provider is selected", async () => {
+    await expect(
+      sendEmail(envWith({}), {
+        from: "from@example.test",
+        to: "to@example.test",
+        subject: "x",
+        text: "x",
+        html: "x",
+      }),
+    ).rejects.toBeInstanceOf(EmailNotConfiguredError);
+  });
+
+  it("throws EmailNotConfiguredError when EMAIL_FROM is empty", async () => {
+    await expect(
+      sendEmail(
+        envWith({ EMAIL_PROVIDER: "resend", RESEND_API_KEY: "re_xxx" } as Partial<Env>),
+        { from: "", to: "to@example.test", subject: "x", text: "x", html: "x" },
+      ),
+    ).rejects.toBeInstanceOf(EmailNotConfiguredError);
+  });
+
+  it("delegates to the provider on success", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg_1" }), { status: 200 }));
+
+    await sendEmail(
+      envWith({ EMAIL_PROVIDER: "resend", RESEND_API_KEY: "re_xxx" } as Partial<Env>),
+      {
+        from: "noreply@example.test",
+        to: "alice@example.test",
+        subject: "Confirm CloudTime account link",
+        text: "https://link",
+        html: "<p>https://link</p>",
+      },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.resend.com/emails");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer re_xxx",
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      from: "noreply@example.test",
+      to: "alice@example.test",
+      subject: "Confirm CloudTime account link",
+    });
+  });
+});
+
+describe("ResendProvider", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const message = {
+    from: "noreply@example.test",
+    to: "alice@example.test",
+    subject: "s",
+    text: "t",
+    html: "h",
+  };
+
+  it("succeeds when Resend returns 200", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "msg_1" }), { status: 200 }),
+    );
+    await expect(new ResendProvider("re_xxx").send(message)).resolves.toBeUndefined();
+  });
+
+  it("throws EmailSendError carrying the HTTP status on non-2xx", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "invalid key" }), { status: 401 }),
+    );
+    const err = await new ResendProvider("re_bad")
+      .send(message)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(EmailSendError);
+    expect((err as EmailSendError).status).toBe(401);
+    expect((err as Error).message).toContain("401");
+    expect((err as Error).message).toContain("invalid key");
+  });
+
+  it("throws EmailSendError when fetch itself rejects (e.g. timeout)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("AbortError: timed out"));
+    const err = await new ResendProvider("re_xxx").send(message).catch((e) => e);
+    expect(err).toBeInstanceOf(EmailSendError);
+    expect((err as Error).message).toContain("Resend request failed");
+  });
+
+  it("tolerates non-JSON error bodies", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Service Unavailable", { status: 503 }),
+    );
+    const err = await new ResendProvider("re_xxx").send(message).catch((e) => e);
+    expect(err).toBeInstanceOf(EmailSendError);
+    expect((err as EmailSendError).status).toBe(503);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -35,6 +35,10 @@ INSTANCE_MODE = "single"
 # GOOGLE_HOSTED_DOMAIN    - Optional. Google Workspace primary domain (e.g. "example.com").
 #                           When set, Google logins are restricted to accounts whose id_token
 #                           `hd` claim matches this value. See specs/037-google-hosted-domain/.
+# EMAIL_PROVIDER          - Required in multi-user mode. Currently supports "resend".
+#                           See docs/email-setup.md.
+# EMAIL_FROM              - Required in multi-user mode. From address on a domain you control.
+# RESEND_API_KEY          - Required when EMAIL_PROVIDER=resend. Bearer token from resend.com.
 
 # OAuth rate limits — see specs/058-oauth-rate-limiting/
 # Operators must verify current Cloudflare plan limits before production deployment.


### PR DESCRIPTION
## Summary

PR2 of 2 for [Issue #80](https://github.com/sudolifeagain/cloudtime/issues/80). Implements the verification-by-email step on top of the existing PendingLink merge flow.

PR1 (#93, merged) added the SpecKit artifacts, OpenAPI surface, and DB migration. This PR adds the runtime: Resend adapter, send-before-INSERT pipeline, public verify endpoint, and the 403 gate on approve.

## Behaviour

Multi-user mode only — single-user mode is unaffected (the same-email PendingLink branch is now explicitly gated on `INSTANCE_MODE === "multi"`).

1. OAuth callback finds a verified email matching an existing user.
2. Server generates a 32-byte token, builds `${APP_URL}/api/v1/auth/link/verify/<token>`, and calls `sendEmail()` **before** any DB write.
3. On send success, INSERTs `pending_links` with the SHA-256 hash and `email_verified_at = NULL`.
4. Recipient clicks the email link → atomic UPDATE-with-RETURNING flips `email_verified_at` and shows a small HTML page.
5. `POST /auth/link/approve/:id` returns `403 {"error": "Email verification required"}` until `email_verified_at` is non-null.

## Fail-closed semantics

| Condition | Response | DB effect |
|---|---|---|
| `EMAIL_PROVIDER` unset / `RESEND_API_KEY` missing / `EMAIL_FROM` empty | 503 | No row written |
| Provider 5xx, 4xx, or 2s timeout | 502 | No row written |
| Send succeeds | 200 from OAuth callback as before | Row written with token hash |
| Verify endpoint hit | 200 HTML | `email_verified_at` set |
| Verify replay | 410 `Token already used` | No change |
| Verify expired | 410 `Token expired` | No change |
| Verify non-GET | 405 (CSRF bypassed for this path) | No change |
| Approve before verify | 403 `Email verification required` | No merge |

## Files

| Area | Files |
|---|---|
| Provider layer | `src/utils/email/{types,resend,index}.ts` |
| Token helper | `src/utils/crypto.ts` (`generateVerificationToken`) |
| Env | `src/types.ts` |
| OAuth callback | `src/routes/auth/login.ts` (instance-mode gate + send-before-INSERT) |
| Verify + approve gate | `src/routes/auth/link.ts` |
| CSRF exemption | `src/index.ts` |
| Mount order | `src/routes/auth/index.ts` (link first so verify bypasses sessionMw) |
| Docs | `docs/email-setup.md` (new), `docs/auth-design.md`, `wrangler.toml` |
| Tests | `tests/security/email-provider.test.ts`, `tests/integration/pending-link-verify.test.ts` |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — **79/79** tests pass (60 prior + 11 new unit + 8 new integration)
- [x] No diff under GitHub or Discord OAuth code paths
- [ ] CI workflow runs green on this PR
- [ ] Staging deploy with a Resend key + verified `EMAIL_FROM` domain runs quickstart scenarios A–H (manual)

## Notable design points (per `research.md`)

- Token in URL path (not query) so common proxy/CDN logs don't capture it.
- Token is single-use via `UPDATE ... WHERE email_verified_at IS NULL AND expires_at > datetime('now') RETURNING id` — `meta.changes` distinguishes success from the various 410 states. SELECT after a failed UPDATE distinguishes `not-found`, `already-used`, and `expired` for clearer client/operator feedback.
- Sub-app mount order changed: `link` before `sessions`. This is the cleanest way to keep the public verify endpoint from being claimed by `sessions.use("*", sessionMw)`. Behaviour for all other auth paths is unchanged because they have specific, non-overlapping paths.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)