### PR TITLE
spec: Goals read endpoints (PR1/2)

### DIFF
--- a/schemas/components/schemas/Goal.yaml
+++ b/schemas/components/schemas/Goal.yaml
@@ -43,6 +43,9 @@ properties:
       type: string
   chart_data:
     type: array
+    description: |
+      Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
+      in chronological order; the last entry is always `range_status: pending`.
     items:
       type: object
       properties:
@@ -62,6 +65,10 @@ properties:
             - pending
   status:
     type: string
+    description: |
+      Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
+      `range_status` of the most recently completed period unless the goal
+      is snoozed, in which case it is forced to `pending`.
     enum:
       - success
       - fail

--- a/schemas/components/schemas/Goal.yaml
+++ b/schemas/components/schemas/Goal.yaml
@@ -41,38 +41,6 @@ properties:
     type: array
     items:
       type: string
-  chart_data:
-    type: array
-    description: |
-      Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
-      in chronological order; the last entry is always `range_status: pending`.
-    items:
-      type: object
-      properties:
-        actual_seconds:
-          type: number
-          format: double
-        goal_seconds:
-          type: number
-          format: double
-        range:
-          $ref: ./TimeRange.yaml
-        range_status:
-          type: string
-          enum:
-            - success
-            - fail
-            - pending
-  status:
-    type: string
-    description: |
-      Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
-      `range_status` of the most recently completed period unless the goal
-      is snoozed, in which case it is forced to `pending`.
-    enum:
-      - success
-      - fail
-      - pending
   created_at:
     type: string
     format: date-time

--- a/schemas/components/schemas/GoalWithChart.yaml
+++ b/schemas/components/schemas/GoalWithChart.yaml
@@ -1,0 +1,45 @@
+allOf:
+  - $ref: ./Goal.yaml
+  - type: object
+    required:
+      - chart_data
+      - status
+    properties:
+      chart_data:
+        type: array
+        description: |
+          Always 7 entries in chronological order; the last entry is always
+          `range_status: pending`.
+        minItems: 7
+        maxItems: 7
+        items:
+          type: object
+          required:
+            - actual_seconds
+            - goal_seconds
+            - range
+            - range_status
+          properties:
+            actual_seconds:
+              type: number
+              format: double
+            goal_seconds:
+              type: number
+              format: double
+            range:
+              $ref: ./TimeRange.yaml
+            range_status:
+              type: string
+              enum:
+                - success
+                - fail
+                - pending
+      status:
+        type: string
+        description: |
+          Mirrors the `range_status` of the most recently completed period
+          unless the goal is snoozed, in which case it is forced to `pending`.
+        enum:
+          - success
+          - fail
+          - pending

--- a/schemas/paths/goals/goal.yaml
+++ b/schemas/paths/goals/goal.yaml
@@ -3,6 +3,18 @@ get:
   tags:
     - goals
   summary: Get a single goal with chart data
+  description: |
+    Returns a single goal owned by the authenticated user, augmented with
+    `chart_data` (the most recent 7 periods of actual vs target activity)
+    and top-level `status` (the most recently completed period's outcome,
+    forced to `pending` if the goal is snoozed).
+
+    Period boundaries use the user's profile timezone (`users.timezone`).
+    Day periods span local calendar days. Week periods span ISO 8601
+    Monday-Sunday weeks in the user's timezone.
+
+    Requests for a goal owned by a different user return 404 (not 403) to
+    avoid leaking goal-id existence.
   parameters:
     - name: goal_id
       in: path

--- a/schemas/paths/goals/goal.yaml
+++ b/schemas/paths/goals/goal.yaml
@@ -32,7 +32,7 @@ get:
               - data
             properties:
               data:
-                $ref: ../../components/schemas/Goal.yaml
+                $ref: ../../components/schemas/GoalWithChart.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
     '404':

--- a/schemas/paths/goals/goals.yaml
+++ b/schemas/paths/goals/goals.yaml
@@ -3,6 +3,12 @@ get:
   tags:
     - goals
   summary: List user's goals
+  description: |
+    Returns the authenticated user's goals ordered by `created_at` ascending.
+    Each entry includes only the persisted Goal fields. `chart_data` and
+    `status` are NOT computed for the list endpoint — clients that need
+    per-period progress must request each goal individually via
+    `GET /users/current/goals/{goal_id}`.
   responses:
     '200':
       description: List of goals

--- a/schemas/paths/goals/goals.yaml
+++ b/schemas/paths/goals/goals.yaml
@@ -5,9 +5,10 @@ get:
   summary: List user's goals
   description: |
     Returns the authenticated user's goals ordered by `created_at` ascending.
-    Each entry includes only the persisted Goal fields. `chart_data` and
-    `status` are NOT computed for the list endpoint — clients that need
-    per-period progress must request each goal individually via
+    Each entry conforms to the `Goal` schema, which includes only persisted
+    goal fields. `chart_data` and `status` are NOT computed for the list
+    endpoint — clients that need per-period progress must request each goal
+    individually via
     `GET /users/current/goals/{goal_id}`.
   responses:
     '200':

--- a/specs/100-goals-read/checklists/requirements.md
+++ b/specs/100-goals-read/checklists/requirements.md
@@ -1,0 +1,68 @@
+# Acceptance Checklist: Goals Read Endpoints
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [ ] `spec.md` covers FR-001..FR-012 with no `[NEEDS CLARIFICATION]` markers.
+- [ ] `plan.md` Constitution Check has all five principles marked PASS.
+- [ ] `research.md` documents the 9 design decisions.
+- [ ] `data-model.md` confirms no schema change is required.
+- [ ] `quickstart.md` enumerates scenarios A–J.
+- [ ] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [ ] `contracts/openapi-diff.md` documents only description-level YAML changes.
+- [ ] `schemas/paths/goals/goals.yaml`, `schemas/paths/goals/goal.yaml`, and
+      `schemas/components/schemas/Goal.yaml` carry the clarifying description text.
+- [ ] `npm run generate` produces a JSDoc-only diff in `src/types/generated.ts`.
+- [ ] PR1 contains no changes under `src/routes/goals.ts`, `src/utils/goal-chart.ts`,
+      or `src/index.ts`.
+- [ ] PR1 references this feature folder and explicitly notes that CRUD is out of scope.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/goal-chart.ts` exports the helper API listed in `tasks.md` T-101.
+- [ ] `src/routes/goals.ts` exports a Hono sub-app with both endpoints
+      behind `authMiddleware`.
+- [ ] Cross-user request returns 404 (verified by integration test).
+- [ ] List endpoint omits `chart_data` and `status` from each Goal in the response.
+- [ ] `npx tsc --noEmit` passes with zero errors.
+- [ ] No diff in `src/routes/heartbeats.ts`, `src/routes/summaries.ts`,
+      `src/routes/stats.ts`, or any auth-flow file.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] Scenario A: empty list returns `{"data":[]}`.
+- [ ] Scenario B: populated list returns ordered entries without chart_data.
+- [ ] Scenario C: single goal returns chart_data of length 7 with correct
+      actuals against a seeded summary set.
+- [ ] Scenario D: `type=languages` filter excludes non-matching summary rows.
+- [ ] Scenario E: `delta=week` periods span ISO Mon-Sun in the user's timezone.
+- [ ] Scenario F: `is_inverse=true` flips success/fail semantics.
+- [ ] Scenario G: `is_snoozed=true` forces top-level `status=pending` while
+      preserving per-range statuses.
+- [ ] Scenario H: cross-user 404.
+- [ ] Scenario I: unauthenticated 401.
+- [ ] Scenario J: timezone-shifted day attribution is correct.
+
+### Tests
+
+- [ ] `tests/aggregation/goal-chart.test.ts` covers DST transitions, ISO week
+      boundaries, equality at target, inverse semantics, snoozed override.
+- [ ] `tests/integration/goals-read.test.ts` covers scenarios A, B, C, D, F,
+      G, H, I (J is manual due to TZ + cron coupling).
+- [ ] `npm test` reports 88+ tests passing (existing 79 + ≥9 new).
+
+### Documentation
+
+- [ ] `docs/auth-design.md` no change required (Goals are user-scoped, not auth-flow).
+- [ ] No new operator runbook required (no env vars added).
+
+## Post-deployment gate
+
+- [ ] Spot-check a real user's `GET /goals/{id}` response and compare
+      `chart_data[i].actual_seconds` to a direct
+      `SELECT SUM(total_seconds) FROM summaries WHERE date = ?` query for
+      the same period.
+- [ ] No 500 responses logged for Goals endpoints in the first 7 days.
+- [ ] If any goal row has malformed `languages` / `editors` / `projects` JSON,
+      confirm the warning log fires and the endpoint still returns 200.

--- a/specs/100-goals-read/checklists/requirements.md
+++ b/specs/100-goals-read/checklists/requirements.md
@@ -2,19 +2,21 @@
 
 ## PR1 (Spec) gate — must be ✅ before merging
 
-- [ ] `spec.md` covers FR-001..FR-012 with no `[NEEDS CLARIFICATION]` markers.
-- [ ] `plan.md` Constitution Check has all five principles marked PASS.
-- [ ] `research.md` documents the 9 design decisions.
-- [ ] `data-model.md` confirms no schema change is required.
-- [ ] `quickstart.md` enumerates scenarios A–J.
-- [ ] `tasks.md` separates PR1 from PR2 with dependency arrows.
-- [ ] `contracts/openapi-diff.md` documents only description-level YAML changes.
-- [ ] `schemas/paths/goals/goals.yaml`, `schemas/paths/goals/goal.yaml`, and
-      `schemas/components/schemas/Goal.yaml` carry the clarifying description text.
-- [ ] `npm run generate` produces a JSDoc-only diff in `src/types/generated.ts`.
-- [ ] PR1 contains no changes under `src/routes/goals.ts`, `src/utils/goal-chart.ts`,
+- [x] `spec.md` covers FR-001..FR-012 with no `[NEEDS CLARIFICATION]` markers.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 9 design decisions.
+- [x] `data-model.md` confirms no schema change is required.
+- [x] `quickstart.md` enumerates scenarios A–J.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the list/single response schema split.
+- [x] `schemas/paths/goals/goals.yaml`, `schemas/paths/goals/goal.yaml`,
+      `schemas/components/schemas/Goal.yaml`, and
+      `schemas/components/schemas/GoalWithChart.yaml` encode the response shapes.
+- [x] `npm run generate` produces generated types where `getGoals` returns
+      `Goal[]` and `getGoal` returns `GoalWithChart`.
+- [x] PR1 contains no changes under `src/routes/goals.ts`, `src/utils/goal-chart.ts`,
       or `src/index.ts`.
-- [ ] PR1 references this feature folder and explicitly notes that CRUD is out of scope.
+- [x] PR1 references this feature folder and explicitly notes that CRUD is out of scope.
 
 ## PR2 (Implementation) gate — must be ✅ before merging
 
@@ -24,7 +26,7 @@
 - [ ] `src/routes/goals.ts` exports a Hono sub-app with both endpoints
       behind `authMiddleware`.
 - [ ] Cross-user request returns 404 (verified by integration test).
-- [ ] List endpoint omits `chart_data` and `status` from each Goal in the response.
+- [ ] List endpoint omits `chart_data` and `status` from each `Goal` in the response.
 - [ ] `npx tsc --noEmit` passes with zero errors.
 - [ ] No diff in `src/routes/heartbeats.ts`, `src/routes/summaries.ts`,
       `src/routes/stats.ts`, or any auth-flow file.

--- a/specs/100-goals-read/contracts/openapi-diff.md
+++ b/specs/100-goals-read/contracts/openapi-diff.md
@@ -1,0 +1,98 @@
+# OpenAPI Diff
+
+The Goals read surface already exists in `schemas/openapi.yaml` and the
+referenced path files. PR1 makes only **description-level** tightening to
+make the two endpoints' response shape contract precise.
+
+## Files touched
+
+1. `schemas/paths/goals/goals.yaml` — list endpoint description.
+2. `schemas/paths/goals/goal.yaml` — single-goal endpoint description.
+3. `schemas/components/schemas/Goal.yaml` — clarifies which fields are
+   populated where.
+
+## Diff 1 — `goals.yaml`
+
+Add a `description` block stating the list endpoint omits `chart_data` and
+`status` (matches FR-002).
+
+```diff
+ get:
+   operationId: getGoals
+   tags:
+     - goals
+   summary: List user's goals
++  description: |
++    Returns the authenticated user's goals ordered by `created_at` ascending.
++    Each entry includes only the persisted Goal fields. `chart_data` and
++    `status` are NOT computed for the list endpoint — clients that need
++    per-period progress must request each goal individually via
++    `GET /users/current/goals/{goal_id}`.
+   responses:
+     '200':
+       description: List of goals
+```
+
+## Diff 2 — `goal.yaml`
+
+Add a `description` block explaining the chart's 7-period window and the
+timezone source.
+
+```diff
+ get:
+   operationId: getGoal
+   tags:
+     - goals
+   summary: Get a single goal with chart data
++  description: |
++    Returns a single goal owned by the authenticated user, augmented with
++    `chart_data` (the most recent 7 periods of actual vs target activity)
++    and top-level `status` (the most recently completed period's outcome,
++    forced to `pending` if the goal is snoozed).
++
++    Period boundaries use the user's profile timezone (`users.timezone`).
++    Day periods span local calendar days. Week periods span ISO 8601
++    Monday-Sunday weeks in the user's timezone.
++
++    Requests for a goal owned by a different user return 404 (not 403) to
++    avoid leaking goal-id existence.
+```
+
+## Diff 3 — `Goal.yaml`
+
+Annotate `chart_data` and `status` as "populated only by `GET /goals/{id}`".
+
+```diff
+   chart_data:
+     type: array
++    description: |
++      Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
++      in chronological order; the last entry is always `range_status: pending`.
+     items:
+       …
+   status:
+     type: string
++    description: |
++      Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
++      `range_status` of the most recently completed period unless the goal
++      is snoozed, in which case it is forced to `pending`.
+     enum:
+       - success
+       - fail
+       - pending
+```
+
+## Generated-types impact
+
+`npm run generate` emits JSDoc-only changes in `src/types/generated.ts`:
+- Two operation descriptions and three field descriptions.
+- No new types, no removed types, no type shape changes.
+
+The diff must remain JSDoc-only; if `tsc` flags any type-shape change, the
+description text was probably mis-edited and PR1 is blocked until the change
+is narrowed.
+
+## SDD compliance note
+
+Per CLAUDE.md: PR1 lands SpecKit + schema (description only). PR2 lands
+the route handlers and the chart helper. No runtime code in PR1.

--- a/specs/100-goals-read/contracts/openapi-diff.md
+++ b/specs/100-goals-read/contracts/openapi-diff.md
@@ -1,98 +1,61 @@
 # OpenAPI Diff
 
 The Goals read surface already exists in `schemas/openapi.yaml` and the
-referenced path files. PR1 makes only **description-level** tightening to
-make the two endpoints' response shape contract precise.
+referenced path files. PR1 tightens the response contract so the list and
+single-goal endpoints expose distinct generated types.
 
 ## Files touched
 
-1. `schemas/paths/goals/goals.yaml` — list endpoint description.
-2. `schemas/paths/goals/goal.yaml` — single-goal endpoint description.
-3. `schemas/components/schemas/Goal.yaml` — clarifies which fields are
-   populated where.
+1. `schemas/paths/goals/goals.yaml` — list endpoint description and response
+   remains `Goal`.
+2. `schemas/paths/goals/goal.yaml` — single-goal response now references
+   `GoalWithChart`.
+3. `schemas/components/schemas/Goal.yaml` — persisted goal fields only.
+4. `schemas/components/schemas/GoalWithChart.yaml` — new schema requiring
+   `chart_data` and `status`.
 
-## Diff 1 — `goals.yaml`
+## Contract shape
 
-Add a `description` block stating the list endpoint omits `chart_data` and
-`status` (matches FR-002).
+### `GET /users/current/goals`
 
-```diff
- get:
-   operationId: getGoals
-   tags:
-     - goals
-   summary: List user's goals
-+  description: |
-+    Returns the authenticated user's goals ordered by `created_at` ascending.
-+    Each entry includes only the persisted Goal fields. `chart_data` and
-+    `status` are NOT computed for the list endpoint — clients that need
-+    per-period progress must request each goal individually via
-+    `GET /users/current/goals/{goal_id}`.
-   responses:
-     '200':
-       description: List of goals
-```
+Returns `{"data": Goal[]}`. `Goal` contains only persisted columns:
 
-## Diff 2 — `goal.yaml`
+- `id`, `title`, `type`, `delta`, `target_seconds`
+- `is_enabled`, `is_snoozed`, `is_inverse`
+- `languages`, `editors`, `projects`
+- `created_at`, `modified_at`
 
-Add a `description` block explaining the chart's 7-period window and the
-timezone source.
+The list response does not define `chart_data` or `status`.
 
-```diff
- get:
-   operationId: getGoal
-   tags:
-     - goals
-   summary: Get a single goal with chart data
-+  description: |
-+    Returns a single goal owned by the authenticated user, augmented with
-+    `chart_data` (the most recent 7 periods of actual vs target activity)
-+    and top-level `status` (the most recently completed period's outcome,
-+    forced to `pending` if the goal is snoozed).
-+
-+    Period boundaries use the user's profile timezone (`users.timezone`).
-+    Day periods span local calendar days. Week periods span ISO 8601
-+    Monday-Sunday weeks in the user's timezone.
-+
-+    Requests for a goal owned by a different user return 404 (not 403) to
-+    avoid leaking goal-id existence.
-```
+### `GET /users/current/goals/{goal_id}`
 
-## Diff 3 — `Goal.yaml`
+Returns `{"data": GoalWithChart}`. `GoalWithChart` is `Goal` plus required:
 
-Annotate `chart_data` and `status` as "populated only by `GET /goals/{id}`".
+- `chart_data`: exactly 7 entries in chronological order.
+- `status`: `success`, `fail`, or `pending`.
 
-```diff
-   chart_data:
-     type: array
-+    description: |
-+      Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
-+      in chronological order; the last entry is always `range_status: pending`.
-     items:
-       …
-   status:
-     type: string
-+    description: |
-+      Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
-+      `range_status` of the most recently completed period unless the goal
-+      is snoozed, in which case it is forced to `pending`.
-     enum:
-       - success
-       - fail
-       - pending
-```
+Each chart entry requires:
+
+- `actual_seconds`
+- `goal_seconds`
+- `range`
+- `range_status`
 
 ## Generated-types impact
 
-`npm run generate` emits JSDoc-only changes in `src/types/generated.ts`:
-- Two operation descriptions and three field descriptions.
-- No new types, no removed types, no type shape changes.
+`npm run generate` updates `src/types/generated.ts` with a real response-type
+split:
 
-The diff must remain JSDoc-only; if `tsc` flags any type-shape change, the
-description text was probably mis-edited and PR1 is blocked until the change
-is narrowed.
+- `components["schemas"]["Goal"]` no longer includes `chart_data` or `status`.
+- `components["schemas"]["GoalWithChart"]` requires `chart_data` and `status`.
+- `operations["getGoals"]` returns `Goal[]`.
+- `operations["getGoal"]` returns `GoalWithChart`.
+
+This is intentional. The diff is no longer JSDoc-only because the OpenAPI
+contract now encodes the list-vs-single response shape instead of relying on
+description text alone.
 
 ## SDD compliance note
 
-Per CLAUDE.md: PR1 lands SpecKit + schema (description only). PR2 lands
-the route handlers and the chart helper. No runtime code in PR1.
+Per repository rules: PR1 lands SpecKit + schema + generated types. PR2 lands
+the route handlers and chart helper. No runtime code in PR1.

--- a/specs/100-goals-read/data-model.md
+++ b/specs/100-goals-read/data-model.md
@@ -88,10 +88,12 @@ For a `delta=week` goal, the same query but the WHERE clause spans the last 7 IS
 ### Period count vs query count
 
 The single-goal endpoint issues two D1 queries:
-1. `SELECT … FROM goals WHERE id = ? AND user_id = ?`
+1. `SELECT … FROM goals JOIN users ON users.id = goals.user_id WHERE goals.id = ? AND goals.user_id = ?`
 2. The summary aggregation query above.
 
-No N+1. No per-period query.
+The joined goal query returns `users.timezone` with the goal row, so the
+handler does not need a separate profile-timezone lookup. No N+1. No
+per-period query.
 
 ## Domain types (TypeScript, not in D1)
 
@@ -101,15 +103,18 @@ type TimeRange = { date: DateString; start: string; end: string };
 
 interface ChartEntry {
   actual_seconds: number;
-  goal_seconds: number;          // always === goal.target_seconds (denormalised per WakaTime convention)
+  goal_seconds: number;          // always === goal.target_seconds (denormalised for client compatibility)
   range: TimeRange;
   range_status: "success" | "fail" | "pending";
 }
 
-interface GoalForRead {
+interface GoalListItem {
   // ...all of the existing Goal columns decoded to their TS types
-  chart_data?: ChartEntry[];     // present only on single-goal endpoint
-  status?: "success" | "fail" | "pending"; // present only on single-goal endpoint
+}
+
+interface GoalWithChart extends GoalListItem {
+  chart_data: ChartEntry[];      // exactly 7 entries
+  status: "success" | "fail" | "pending";
 }
 ```
 

--- a/specs/100-goals-read/data-model.md
+++ b/specs/100-goals-read/data-model.md
@@ -1,0 +1,118 @@
+# Data Model: Goals Read Endpoints
+
+No schema changes. This document describes how existing tables drive the read endpoints.
+
+## `goals` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS goals (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'coding',       -- coding | languages | editors | projects
+  delta TEXT NOT NULL DEFAULT 'day',         -- day | week
+  target_seconds REAL NOT NULL,
+  is_enabled INTEGER NOT NULL DEFAULT 1,
+  is_snoozed INTEGER NOT NULL DEFAULT 0,
+  is_inverse INTEGER NOT NULL DEFAULT 0,
+  languages TEXT,                            -- JSON array (nullable)
+  editors TEXT,                              -- JSON array (nullable)
+  projects TEXT,                             -- JSON array (nullable)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_goals_user ON goals(user_id);
+```
+
+### Field treatment in handlers
+
+| Column | Handler treatment |
+|---|---|
+| `id`, `title`, `created_at`, `modified_at` | Pass through |
+| `type` | Validate against enum on read; fall back to `coding` if unknown |
+| `delta` | Validate against enum on read; fall back to `day` |
+| `target_seconds` | Number, no transformation |
+| `is_enabled`, `is_snoozed`, `is_inverse` | INTEGER 0/1 → boolean |
+| `languages`, `editors`, `projects` | JSON.parse → string[]; non-array or parse error ⇒ `[]` with warning log |
+
+## `summaries` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,                  -- YYYY-MM-DD in user's profile timezone
+  project TEXT,
+  language TEXT,
+  editor TEXT,
+  operating_system TEXT,
+  category TEXT,
+  branch TEXT,
+  machine TEXT,
+  entity TEXT,
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+
+This is the only data source for `actual_seconds`. The cron aggregator already buckets rows in the user's profile timezone, so the goal chart can scan by `date BETWEEN ? AND ?` without re-doing TZ math.
+
+### Chart computation query shape
+
+For a `delta=day` goal:
+
+```sql
+SELECT date, SUM(total_seconds) AS actual_seconds
+  FROM summaries
+ WHERE user_id = ?
+   AND date BETWEEN ? AND ?     -- (today - 6) .. today, in user's local calendar
+   /* type-specific filter applied here, e.g.:                                          */
+   /*   AND language IN (?,?,?)   for type=languages                                    */
+ GROUP BY date
+ ORDER BY date ASC;
+```
+
+For a `delta=week` goal, the same query but the WHERE clause spans the last 7 ISO weeks (so 49 days), and we re-bucket the daily rows into weeks in TypeScript using the same Monday-Sunday boundaries the cron aggregator's timezone helper provides.
+
+### Filter SQL fragments
+
+| `type` | Filter |
+|---|---|
+| `coding` | (none — sum across all summaries) |
+| `languages` | `AND language IN (?, ?, ...)` — placeholders correspond to the goal's `languages` array. Empty array ⇒ filter is `AND 0` (matches nothing). |
+| `editors` | `AND editor IN (?, ?, ...)` |
+| `projects` | `AND project IN (?, ?, ...)` |
+
+### Period count vs query count
+
+The single-goal endpoint issues two D1 queries:
+1. `SELECT … FROM goals WHERE id = ? AND user_id = ?`
+2. The summary aggregation query above.
+
+No N+1. No per-period query.
+
+## Domain types (TypeScript, not in D1)
+
+```ts
+type DateString = string;       // YYYY-MM-DD
+type TimeRange = { date: DateString; start: string; end: string };
+
+interface ChartEntry {
+  actual_seconds: number;
+  goal_seconds: number;          // always === goal.target_seconds (denormalised per WakaTime convention)
+  range: TimeRange;
+  range_status: "success" | "fail" | "pending";
+}
+
+interface GoalForRead {
+  // ...all of the existing Goal columns decoded to their TS types
+  chart_data?: ChartEntry[];     // present only on single-goal endpoint
+  status?: "success" | "fail" | "pending"; // present only on single-goal endpoint
+}
+```
+
+## Cleanup / cascade
+
+`goals` has `ON DELETE CASCADE` from `users`. When a user is deleted, their goals are removed automatically. No additional cleanup logic in this feature.

--- a/specs/100-goals-read/plan.md
+++ b/specs/100-goals-read/plan.md
@@ -17,7 +17,7 @@ No DB migration, no new env var, no new dependency. OpenAPI already declares the
 **Testing**: Vitest + workers pool; new unit tests for the chart-computation helper, integration tests for both endpoints against a seeded D1
 **Target Platform**: Cloudflare Workers (edge compute)
 **Project Type**: Web service (REST API)
-**Performance Goals**: <10ms CPU per single-goal request (one SELECT against the goal row, one SELECT against summaries clamped to a 7-period window)
+**Performance Goals**: <10ms CPU per single-goal request (one joined SELECT against the goal row plus user timezone, one SELECT against summaries clamped to a 7-period window)
 **Constraints**: D1 binding parameter limit (we stay well under), Workers free-tier CPU budget
 
 ## Constitution Check
@@ -26,7 +26,7 @@ No DB migration, no new env var, no new dependency. OpenAPI already declares the
 |-----------|--------|-------|
 | I. SDD | PASS | OpenAPI already declares the operations. PR1 is spec-only; PR2 lands the handlers. `npm run generate` produces no type-shape change. |
 | II. Cloudflare-Native | PASS | Pure D1 reads + existing `time-format` helpers. No new bindings or services. |
-| III. Type Safety | PASS | Handlers use `components["schemas"]["Goal"]` from `src/types/generated.ts`. No hand-edited types. |
+| III. Type Safety | PASS | Handlers use `components["schemas"]["Goal"]` and `components["schemas"]["GoalWithChart"]` from `src/types/generated.ts`. No hand-edited types. |
 | IV. Legal/Trademark | PASS | "WakaTime-compatible" only in docs context. No source/asset borrowing. |
 | V. Simplicity First | PASS | ≤200 LoC new code in `src/routes/goals.ts`; the chart helper is a single function over already-aggregated data. |
 
@@ -91,12 +91,13 @@ goals.get("/goals/:id", authMiddleware, async (c) => {
   const userId = c.get("userId");
   const id = c.req.param("id");
   const row = await c.env.DB.prepare(
-    `SELECT ... FROM goals WHERE id = ? AND user_id = ?`,
+    `SELECT g..., u.timezone
+       FROM goals g JOIN users u ON u.id = g.user_id
+      WHERE g.id = ? AND g.user_id = ?`,
   ).bind(id, userId).first<GoalRow>();
   if (!row) return c.json({ error: "Not found" }, 404);
 
-  const userTz = await getUserTimezone(c);  // already used by other endpoints
-  const { ranges, summarySumQuery } = planChart(row, userTz);
+  const { ranges, summarySumQuery } = planChart(row, row.timezone);
   const totals = await c.env.DB.prepare(summarySumQuery).all<TotalsRow>();
   const goal = await assembleGoal(row, ranges, totals);
   return c.json({ data: goal });
@@ -123,7 +124,10 @@ export function topStatus(entries: ChartEntry[], isSnoozed: boolean): "success" 
 
 ### OpenAPI surface
 
-Already declared. PR1 verifies the existing yaml files still describe the response correctly; no shape change anticipated. PR1 may add a minor `description` clarification noting which fields are populated on list vs single — see [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+Already declared. PR1 tightens the response contract by keeping `Goal` as
+the persisted-field list shape and adding `GoalWithChart` for the single-goal
+response, where `chart_data` and `status` are required — see
+[contracts/openapi-diff.md](./contracts/openapi-diff.md).
 
 ## Phase 2 — Implementation Tasks
 

--- a/specs/100-goals-read/plan.md
+++ b/specs/100-goals-read/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Goals Read Endpoints
+
+**Branch**: `100-goals-read` | **Date**: 2026-05-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/100-goals-read/spec.md`
+
+## Summary
+
+Wires the two read endpoints declared in OpenAPI (`getGoals`, `getGoal`) to real handlers backed by the existing `goals` and `summaries` D1 tables. Adds a `src/utils/goal-chart.ts` helper that computes the 7-period `chart_data` for a single goal by selecting from the already-aggregated `summaries` table — no heartbeat scan.
+
+No DB migration, no new env var, no new dependency. OpenAPI already declares the surface; PR1 confirms the surface and the new path/response shape is buildable, then PR2 ships the implementation.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (existing `goals` and `summaries` tables only)
+**Testing**: Vitest + workers pool; new unit tests for the chart-computation helper, integration tests for both endpoints against a seeded D1
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (REST API)
+**Performance Goals**: <10ms CPU per single-goal request (one SELECT against the goal row, one SELECT against summaries clamped to a 7-period window)
+**Constraints**: D1 binding parameter limit (we stay well under), Workers free-tier CPU budget
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI already declares the operations. PR1 is spec-only; PR2 lands the handlers. `npm run generate` produces no type-shape change. |
+| II. Cloudflare-Native | PASS | Pure D1 reads + existing `time-format` helpers. No new bindings or services. |
+| III. Type Safety | PASS | Handlers use `components["schemas"]["Goal"]` from `src/types/generated.ts`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | "WakaTime-compatible" only in docs context. No source/asset borrowing. |
+| V. Simplicity First | PASS | ≤200 LoC new code in `src/routes/goals.ts`; the chart helper is a single function over already-aggregated data. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/100-goals-read/
+├── plan.md
+├── spec.md
+├── research.md            # week boundary, snoozed semantics, status-from-pending
+├── data-model.md          # uses existing goals + summaries; no schema change
+├── quickstart.md          # operator/QA scenarios
+├── tasks.md               # PR1/PR2 split
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── goals.ts                  # NEW: getGoals + getGoal handlers, mounted at /users/current
+├── utils/
+│   └── goal-chart.ts             # NEW: computeGoalChart(goal, summaries, userTz)
+└── index.ts                      # NEW route mount: app.route("/api/v1/users/current", goals)
+```
+
+**Structure Decision**: `goals.ts` mirrors the existing route-file convention (`heartbeats.ts`, `summaries.ts`, `stats.ts`). Chart computation is split into a pure helper so it is unit-testable without D1.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Week boundary = ISO 8601 Monday-Sunday in the user's profile timezone.** Matches the cron aggregator's bucketing.
+2. **7-period window** (current + 6 prior), chronologically ordered oldest-first.
+3. **`is_snoozed` overrides top-level `status` to `pending`**, but does NOT pause chart computation — the actuals are still useful to the user.
+4. **Per-period status uses `>=` (or `<=` when inverse) against the target**; equality is success.
+5. **List omits `chart_data`** to keep the response small for any future client that paginates / batches.
+6. **Cross-user 404** instead of 403 (do not leak goal ID existence).
+
+## Phase 1 — Design Outputs
+
+### Handler sketch
+
+```ts
+// src/routes/goals.ts
+goals.get("/goals", authMiddleware, async (c) => {
+  const userId = c.get("userId");
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, title, type, delta, target_seconds, is_enabled, is_snoozed,
+            is_inverse, languages, editors, projects, created_at, modified_at
+       FROM goals WHERE user_id = ? ORDER BY created_at ASC`,
+  ).bind(userId).all<GoalRow>();
+  return c.json({ data: results.map(rowToGoalListItem) });
+});
+
+goals.get("/goals/:id", authMiddleware, async (c) => {
+  const userId = c.get("userId");
+  const id = c.req.param("id");
+  const row = await c.env.DB.prepare(
+    `SELECT ... FROM goals WHERE id = ? AND user_id = ?`,
+  ).bind(id, userId).first<GoalRow>();
+  if (!row) return c.json({ error: "Not found" }, 404);
+
+  const userTz = await getUserTimezone(c);  // already used by other endpoints
+  const { ranges, summarySumQuery } = planChart(row, userTz);
+  const totals = await c.env.DB.prepare(summarySumQuery).all<TotalsRow>();
+  const goal = await assembleGoal(row, ranges, totals);
+  return c.json({ data: goal });
+});
+```
+
+### Chart-helper sketch
+
+```ts
+// src/utils/goal-chart.ts
+export interface PeriodTotal { range: { date: string; start: string; end: string };
+  actual_seconds: number;
+}
+export interface ChartEntry extends PeriodTotal {
+  goal_seconds: number;
+  range_status: "success" | "fail" | "pending";
+}
+
+export function buildRanges(delta: "day" | "week", userTz: string, count = 7): TimeRange[] { … }
+export function classify(actual: number, target: number, isInverse: boolean,
+                         isPending: boolean): "success" | "fail" | "pending" { … }
+export function topStatus(entries: ChartEntry[], isSnoozed: boolean): "success" | "fail" | "pending" { … }
+```
+
+### OpenAPI surface
+
+Already declared. PR1 verifies the existing yaml files still describe the response correctly; no shape change anticipated. PR1 may add a minor `description` clarification noting which fields are populated on list vs single — see [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+No constitution violations. The complexity is bounded to chart computation (week boundaries + DST handling are already solved by `time-format.ts`).

--- a/specs/100-goals-read/quickstart.md
+++ b/specs/100-goals-read/quickstart.md
@@ -1,0 +1,130 @@
+# Quickstart: Goals Read Endpoints
+
+This guide walks through manually verifying `GET /goals` and `GET /goals/{id}` once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+- A deployed CloudTime worker. Single-user or multi-user mode both work — goal endpoints are user-scoped and not gated by `INSTANCE_MODE`.
+- A user account with a valid API key (e.g. `ck_…`).
+- One or more rows in the `goals` table for that user. Until the CRUD endpoints exist, seed manually via:
+
+  ```bash
+  wrangler d1 execute cloudtime-db --remote --command "
+    INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+                       is_enabled, is_snoozed, is_inverse, languages, editors, projects)
+    VALUES (
+      lower(hex(randomblob(16))),
+      '<your user_id>',
+      'Code 1 hour per day',
+      'coding', 'day', 3600,
+      1, 0, 0, NULL, NULL, NULL
+    );
+  "
+  ```
+
+- Recent heartbeats and at least one cron aggregation cycle so `summaries` has data.
+
+## Scenario A — Empty list
+
+Run as a freshly created user with no goal rows.
+
+```bash
+curl -sH "Authorization: Bearer $API_KEY" \
+  https://cloudtime.example.dev/api/v1/users/current/goals
+```
+
+**Expected**: `{"data":[]}` with HTTP 200.
+
+## Scenario B — List populated, no chart_data
+
+Seed three goal rows (one disabled, one snoozed, one normal). Repeat the call.
+
+**Expected**:
+- 200 status, `data` array of length 3 ordered by `created_at` ascending.
+- Each entry has `id`, `title`, `type`, `delta`, `target_seconds`, the three booleans, and `created_at` / `modified_at`.
+- **No** entry has `chart_data` or top-level `status`.
+- The disabled goal is still in the response.
+
+## Scenario C — Single goal with chart_data (`type=coding`, `delta=day`)
+
+Pick one of the seeded goal IDs and fetch it:
+
+```bash
+curl -sH "Authorization: Bearer $API_KEY" \
+  https://cloudtime.example.dev/api/v1/users/current/goals/$GOAL_ID
+```
+
+**Expected**:
+- `data.chart_data` is an array of length 7.
+- Entries are ordered chronologically; the last entry's `range_status` is `pending`.
+- Earlier entries' `range_status` is `success` if `actual_seconds >= target_seconds`, else `fail`.
+- `data.status` matches the entry immediately before the pending one.
+- Each `chart_data[i].range.date` is the YYYY-MM-DD label in the user's profile timezone.
+
+## Scenario D — `type=languages` filter
+
+Seed:
+
+```bash
+INSERT INTO goals (... type='languages', languages='["TypeScript","Go"]', ...);
+```
+
+**Expected**:
+- `chart_data[i].actual_seconds` only counts summary rows where `language IN ('TypeScript','Go')` for that period.
+- Adding heartbeats in Python during the test window MUST NOT bump any period's actual.
+
+## Scenario E — `delta=week`
+
+Seed with `delta='week', type='coding', target_seconds=18000` (5h/week).
+
+**Expected**:
+- `chart_data` length 7, one per ISO week starting Monday (in user's profile timezone).
+- Each `range.start` is a Monday 00:00 local, each `range.end` is the following Monday 00:00 local.
+- The pending period is the current week (whichever weekday it is when you call).
+
+## Scenario F — `is_inverse=true` cap-style goal
+
+Seed `is_inverse=1, target_seconds=1800` (cap of 30 min/day). On a day with `actual_seconds=600`:
+
+**Expected**: that day's `range_status` is `success` (under cap).
+
+On a day with `actual_seconds=3600`: `fail`.
+
+## Scenario G — Snoozed goal
+
+Seed with `is_snoozed=1`. Confirm:
+
+**Expected**:
+- `data.status` is `pending`.
+- Individual `chart_data[i].range_status` values are computed normally (some may be `success`, others `fail`).
+
+## Scenario H — Cross-user 404
+
+As user A, attempt to fetch a goal ID that belongs to user B:
+
+```bash
+curl -sH "Authorization: Bearer $A_API_KEY" \
+  https://cloudtime.example.dev/api/v1/users/current/goals/$B_GOAL_ID
+```
+
+**Expected**: 404 with `{"error":"Not found"}`. No information leaks that the ID exists.
+
+## Scenario I — Unauthenticated request
+
+```bash
+curl -i https://cloudtime.example.dev/api/v1/users/current/goals
+```
+
+**Expected**: 401 Unauthorized.
+
+## Scenario J — Timezone correctness
+
+Set the user's profile timezone to `Asia/Tokyo`. Generate heartbeats just past local midnight (e.g. 2026-05-18 01:00 JST = 2026-05-17 16:00 UTC). Wait for cron aggregation.
+
+**Expected**:
+- The new heartbeats are attributed to the `2026-05-18` summary row.
+- `chart_data` for a `delta=day` goal labels the most recent period as `2026-05-18` and treats `2026-05-17` as the previous (completed) period.
+
+## Reverting / cleanup
+
+There is nothing to revert. The read endpoints are pure SELECTs against existing tables. Removing the routes from `src/routes/goals.ts` and unmounting in `src/index.ts` would disable the feature without data loss.

--- a/specs/100-goals-read/research.md
+++ b/specs/100-goals-read/research.md
@@ -1,0 +1,123 @@
+# Research: Goals Read Endpoints
+
+## Decision 1: Read summaries, not heartbeats
+
+**Decision**: `chart_data` is built by summing rows from the `summaries` table, never from `heartbeats`.
+
+**Rationale**:
+- `summaries` is already aggregated per user / date / project / language / editor / etc by the hourly cron. Reading it is O(matches), heartbeats would be O(raw events).
+- Stays within the 10ms CPU budget on the free tier even for active users.
+- Matches what the existing `/summaries`, `/stats`, and `/status_bar/today` endpoints do; consistent behaviour across the API.
+- Side benefit: deletes/edits to heartbeats outside the aggregation window don't change goal chart history (which is desirable — goals are about historical effort, not present-time replay).
+
+**Alternative considered**:
+- **Live heartbeat scan**: would give second-by-second accuracy for the current period but requires scanning a much larger table. The cron lag (≤1 hour) is acceptable for goals since the unit of comparison is a day or week.
+
+---
+
+## Decision 2: Week boundary = ISO 8601 Monday-Sunday
+
+**Decision**: For `delta=week` goals, a "week" runs from Monday 00:00 to Sunday 23:59 in the user's profile timezone.
+
+**Rationale**:
+- ISO 8601 is the international standard. Most developer tools use it.
+- Avoids US-centric Sunday-Saturday weeks which surprise non-US users.
+- The cron aggregator already buckets summaries by user-timezone day; ISO week is a deterministic function of those days.
+
+**Alternative considered**:
+- **US Sunday-Saturday**: rejected on i18n grounds.
+- **User-configurable week start**: out of scope; can be added later via a column on `users` or `goals` without breaking the contract.
+
+---
+
+## Decision 3: `is_snoozed` overrides top-level `status` only
+
+**Decision**: When `is_snoozed=true`, the top-level `status` field is forced to `pending`. The `chart_data` array still contains per-period `range_status` values computed normally.
+
+**Rationale**:
+- The user is pausing *interpretation*, not data collection. They still want to see what their activity looks like.
+- Reflects WakaTime's behaviour and what most users intuitively expect.
+- Keeps the per-period status pure (a function of actuals and target) so callers who want raw data can ignore the top-level field.
+
+**Alternative considered**:
+- **Force all `range_status` to `pending` when snoozed**: makes the chart less informative. Rejected.
+
+---
+
+## Decision 4: Per-period status uses `>=` (or `<=` if inverse)
+
+**Decision**: `range_status` is `success` if `actual_seconds >= target_seconds` (`actual_seconds <= target_seconds` when `is_inverse=true`), `fail` otherwise, except the current incomplete period which is always `pending`.
+
+**Rationale**:
+- Hitting exactly the target counts as success. Anything else would surprise users who set round numbers.
+- Inverse semantics (cap-style goals like "stay under 1h on Twitter") need the opposite comparison; the boolean is sufficient to model both.
+
+**Alternative considered**:
+- **Strict `>` for success**: punishes users who hit their target exactly. Rejected.
+
+---
+
+## Decision 5: Top-level `status` mirrors the most recently completed period
+
+**Decision**: The top-level `status` field equals the `range_status` of the chart entry immediately preceding the pending one — i.e., "yesterday's verdict" for day goals, "last week's verdict" for week goals.
+
+**Rationale**:
+- Users want a glanceable answer: "Am I doing OK?" — most recent completed period is the right answer for that.
+- More sophisticated aggregations (e.g., "3 out of last 5") are subjective and can be UI-side derivations from `chart_data`.
+
+**Alternative considered**:
+- **Weighted average / streak count**: domain-modeling debt. Defer to clients.
+
+---
+
+## Decision 6: 7-period window (current + 6 prior)
+
+**Decision**: `chart_data` always returns 7 entries: today plus the six days before (or this-week plus the six weeks before).
+
+**Rationale**:
+- WakaTime returns roughly the same; matching the convention reduces client surprises.
+- Seven is enough for users to see a recent trend without paging.
+- Pre-aggregated; bounded read cost.
+
+**Alternative considered**:
+- **Configurable count via query parameter**: adds API surface for marginal benefit. Defer.
+- **30-period (month)**: too long for a daily-cadence visualisation; out of scope.
+
+---
+
+## Decision 7: Cross-user requests get 404, not 403
+
+**Decision**: A request for a goal owned by a different user returns 404 Not Found, the same response as a missing ID.
+
+**Rationale**:
+- Goal IDs are UUIDs and not meant to be public. Distinguishing "exists but yours not" from "doesn't exist" leaks ID-space information.
+- The existing approve endpoint uses the same pattern; we keep behaviour consistent.
+
+**Alternative considered**:
+- **403 Forbidden**: clearer for client debugging but a small information leak. Rejected on principle of least information.
+
+---
+
+## Decision 8: List endpoint omits `chart_data`
+
+**Decision**: `GET /goals` returns each Goal *without* `chart_data` or top-level `status`. Single-goal endpoint is the only one that emits chart data.
+
+**Rationale**:
+- The list endpoint should be cheap. Computing 7 periods × N goals × possibly 4 dimension filters = unnecessary fan-out for a "show me my goals" call.
+- Clients that want chart data for many goals can issue parallel single-goal requests; that pattern stays explicit and rate-limitable per-goal.
+
+**Alternative considered**:
+- **Include `chart_data` on list**: simpler client code, but at most users have a few goals so the savings would be marginal compared to the extra D1 reads. Defer until a client actually demands batch chart data.
+
+---
+
+## Decision 9: JSON-decode `languages` / `editors` / `projects` defensively
+
+**Decision**: When decoding the TEXT columns, treat any non-JSON value or non-array result as an empty array, and log a warning. The endpoint MUST NOT 500 because of legacy data.
+
+**Rationale**:
+- These columns are user-controlled (will be in the CRUD spec) and may end up with malformed data during migration or external imports.
+- Failing fast inside a read endpoint is worse than degraded behaviour; the goal still appears, just without filters applied.
+
+**Alternative considered**:
+- **500 on bad JSON**: makes the entire endpoint brittle to one bad row. Rejected.

--- a/specs/100-goals-read/research.md
+++ b/specs/100-goals-read/research.md
@@ -36,7 +36,7 @@
 
 **Rationale**:
 - The user is pausing *interpretation*, not data collection. They still want to see what their activity looks like.
-- Reflects WakaTime's behaviour and what most users intuitively expect.
+- Reflects common goal-tracking behaviour and what most users intuitively expect.
 - Keeps the per-period status pure (a function of actuals and target) so callers who want raw data can ignore the top-level field.
 
 **Alternative considered**:
@@ -75,7 +75,7 @@
 **Decision**: `chart_data` always returns 7 entries: today plus the six days before (or this-week plus the six weeks before).
 
 **Rationale**:
-- WakaTime returns roughly the same; matching the convention reduces client surprises.
+- Compatible clients generally expect a compact recent-history window; matching that convention reduces client surprises.
 - Seven is enough for users to see a recent trend without paging.
 - Pre-aggregated; bounded read cost.
 

--- a/specs/100-goals-read/spec.md
+++ b/specs/100-goals-read/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Goals Read Endpoints
+
+**Feature Branch**: `100-goals-read`
+**Created**: 2026-05-17
+**Status**: Draft
+**Input**: OpenAPI declares `getGoals` and `getGoal` operations and a `goals` D1 table exists, but neither endpoint is implemented. This feature wires the read path.
+
+## Background
+
+The `goals` D1 table is part of the WakaTime-compatible domain model. A goal expresses an intent to spend at least (or at most) `target_seconds` of coding time per `delta` period, optionally filtered by language / editor / project. `getGoals` returns a flat list; `getGoal` returns a single goal augmented with `chart_data` — a series of past periods showing actual vs target vs status.
+
+This spec covers the **read path only**. Create / update / delete endpoints are explicitly deferred to a follow-up feature so this PR keeps a tight reviewable surface area and ships chart computation correctness first.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List my goals (Priority: P1)
+
+As an authenticated user, I want to see the goals I've configured so that I can confirm my current commitments and choose one to inspect.
+
+**Why this priority**: Lists are the entry point to every WakaTime UI surface that consumes goals. Without it the single-goal endpoint is unreachable through any normal client flow.
+
+**Independent Test**: Authenticate as a user with three `goals` rows seeded (different types) and call `GET /api/v1/users/current/goals`. Verify the response contains all three goals with their static fields, ordered deterministically, and that `chart_data` is **omitted** (list view is intentionally lightweight).
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with two enabled goals and one disabled goal, **When** they call `GET /goals`, **Then** the response contains all three goals (enabled flag exposed but no filtering at the API layer).
+2. **Given** the user has no goals, **When** they call `GET /goals`, **Then** the response is `{"data": []}` with HTTP 200.
+3. **Given** an unauthenticated request, **When** they call `GET /goals`, **Then** the server returns 401.
+4. **Given** another user has goals, **When** the calling user requests `GET /goals`, **Then** none of the other user's goals appear (strict per-user isolation).
+5. **Given** a goal whose `languages` / `editors` / `projects` columns contain JSON arrays, **When** the goal is returned, **Then** the server has decoded the JSON columns into arrays before serialising the response.
+
+---
+
+### User Story 2 - Inspect a single goal with progress chart (Priority: P1)
+
+As an authenticated user, I want to drill into a specific goal and see how I've been tracking against it over the past several periods, so I can decide whether to keep, adjust, or abandon it.
+
+**Why this priority**: The chart is the single most useful piece of information a goals UI shows. Without it the feature is functionally inert.
+
+**Independent Test**: Seed summary rows in D1 covering the past 7 days for a user, then create a `coding` goal with `delta=day` and `target_seconds=3600`. Call `GET /goals/{goal_id}` and verify:
+- `chart_data` is an array of 7 entries (today + 6 prior days).
+- For each entry, `actual_seconds` matches the sum of matching summary rows for that local-timezone day.
+- `range_status` is `success` when `actual_seconds >= target_seconds`, `fail` otherwise, except the most recent period which is `pending`.
+- Top-level `status` equals the most recently completed period's status (the entry immediately preceding the pending one).
+
+**Acceptance Scenarios**:
+
+1. **Given** a `type=coding, delta=day, target_seconds=3600` goal and 7 days of summary data, **When** the user calls `GET /goals/{id}`, **Then** `chart_data` has 7 entries, indexed today-back-to-six-days-ago in chronological order.
+2. **Given** a `type=languages, delta=day, languages=["TypeScript"]` goal, **When** the user calls `GET /goals/{id}`, **Then** `actual_seconds` for each period sums only summary rows whose `language='TypeScript'`.
+3. **Given** a `type=editors, delta=week, editors=["VSCode"]` goal, **When** the user calls `GET /goals/{id}`, **Then** `chart_data` has 7 entries one per ISO week, each summing the user's `VSCode`-tagged summaries within that week's date range.
+4. **Given** an `is_inverse=true` goal with `target_seconds=1800` and a day with `actual_seconds=600`, **When** the goal is returned, **Then** that day's `range_status` is `success` (under cap), not `fail`.
+5. **Given** `is_snoozed=true`, **When** the goal is returned, **Then** the chart still reflects actuals but the top-level `status` is `pending` regardless of period outcomes — snoozing pauses status interpretation, not data collection.
+6. **Given** a goal whose owner is a different user, **When** the calling user requests it, **Then** the server returns 404 (not 403, to avoid leaking goal-id existence).
+7. **Given** an unknown goal ID, **When** the user requests it, **Then** the server returns 404.
+
+---
+
+### User Story 3 - Pending day-boundary correctness across timezones (Priority: P2)
+
+As a user located outside UTC, I want the "today" period in my goal chart to reflect my actual local day, so the `pending` status moves with my real day boundary instead of jumping at UTC midnight.
+
+**Why this priority**: Heartbeat summarisation already buckets by user timezone (Issue #28/#65). The goal chart must use the same convention or users will see misaligned periods.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with `timezone='Asia/Tokyo'`, **When** the local time is 2026-05-18 02:00 JST (still 2026-05-17 in UTC), **Then** the pending range in `chart_data` is dated 2026-05-18.
+2. **Given** the spring-forward DST day in `America/New_York`, **When** the goal chart includes that date, **Then** the range still spans the local calendar day even though the underlying epoch range is 23 hours.
+
+---
+
+### Edge Cases
+
+- **Empty filter arrays**: A `type=languages` goal with `languages=[]` matches nothing. Documented but not an error condition — clients should validate before persisting (CRUD spec, not this one).
+- **Goal `delta` value not in the spec enum (`day` / `week`)**: Should not happen because schema constrains it, but defensively the server treats unknown values as `day`.
+- **Goal `type` outside enum**: Same as above — defensively treat as `coding`.
+- **Summaries gap**: If no summary rows exist for a given period, `actual_seconds` is 0 and status follows the comparison rule.
+- **Snoozed + inverse**: Status is `pending` (snoozed wins).
+- **Disabled goal**: Returned by the list and single endpoints unchanged. Clients decide to hide / dim disabled goals in UI. No filtering at the API layer to keep the contract straightforward.
+- **`chart_data` length when goal is newer than 7 periods ago**: All 7 periods are still returned. Periods predating goal creation simply show whatever actuals exist (heartbeats predate the goal); status is computed normally. Documented to avoid confusion — the chart is "last 7 periods of activity," not "last 7 periods since goal creation."
+- **Day boundary uses user's profile timezone**: Source of truth for the user's TZ is `users.timezone` (already validated and used by the cron aggregator). Fall back to UTC if the value is unparseable.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `GET /api/v1/users/current/goals` MUST return all goal rows owned by the authenticated user, in `created_at` ascending order, as `{"data": [Goal, ...]}`.
+- **FR-002**: The list endpoint MUST NOT include `chart_data` on returned goals (lightweight response).
+- **FR-003**: `GET /api/v1/users/current/goals/{goal_id}` MUST return a single goal owned by the user, augmented with `chart_data` and top-level `status`, as `{"data": Goal}`.
+- **FR-004**: A request for a goal not owned by the user MUST return 404 (not 403 — do not leak existence).
+- **FR-005**: `chart_data` MUST contain exactly 7 entries: the current period plus the 6 immediately preceding periods, in chronological order (oldest first).
+- **FR-006**: For `delta=day`, each entry spans one local-calendar day in the user's profile timezone. For `delta=week`, each entry spans Monday 00:00 through Sunday 23:59 in the user's profile timezone.
+- **FR-007**: `actual_seconds` per period MUST be the sum of matching `summaries.total_seconds` rows for that period. Filter semantics:
+  - `type=coding`: sum across all summaries.
+  - `type=languages`: only rows whose `language` is in the goal's `languages` filter.
+  - `type=editors`: only rows whose `editor` is in the goal's `editors` filter.
+  - `type=projects`: only rows whose `project` is in the goal's `projects` filter.
+- **FR-008**: `range_status` per period MUST be `pending` for the current (incomplete) period. For completed periods, `success` if `actual_seconds >= target_seconds` (when `is_inverse=false`) or `actual_seconds <= target_seconds` (when `is_inverse=true`); `fail` otherwise.
+- **FR-009**: Top-level `status` MUST equal the `range_status` of the period immediately preceding the pending one (i.e., the most recently completed period). If the goal is `is_snoozed=true`, top-level `status` MUST be `pending` regardless of period outcomes.
+- **FR-010**: All endpoints MUST require API key or session authentication. Single-user mode and multi-user mode behave identically.
+- **FR-011**: The list endpoint MUST emit `Cache-Control: no-store` to prevent caching of user-private data. (The `authMiddleware` already adds this header centrally; no per-route work needed.)
+- **FR-012**: `languages`, `editors`, and `projects` columns are stored as JSON-encoded TEXT in D1. The handlers MUST decode them into arrays before serialising, and MUST treat invalid JSON as an empty array (with an error log).
+
+### Non-Functional Requirements
+
+- **NFR-001**: A single `GET /goals/{id}` request MUST complete within the Workers 10ms CPU budget on the free tier. The chart computation reads at most ~7 days of pre-aggregated `summaries` rows; no heartbeat scan.
+- **NFR-002**: The list endpoint MUST issue at most one D1 query (single SELECT against `goals`).
+- **NFR-003**: The single-goal endpoint MUST issue at most two D1 queries: one for the goal row, one batched read of the 7-period summary aggregates.
+
+### Key Entities *(no schema change)*
+
+No schema changes. Existing columns on `goals` cover everything; existing `summaries` rows are the data source for `actual_seconds`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An authenticated user with three goals receives a list with three entries in stable order.
+- **SC-002**: A single-goal request returns `chart_data` of length 7 with chronologically ordered periods.
+- **SC-003**: Chart actuals reproduce the user's known summary totals for each period (verifiable by comparing to a direct `summaries` SELECT).
+- **SC-004**: Status computation passes all rules in FR-008 (covered by acceptance scenarios 1-5 of User Story 2).
+- **SC-005**: Cross-user requests return 404, never 200 or 403.
+- **SC-006**: New code under `src/routes/goals.ts` is ≤ 200 LoC and uses only the project's existing D1 helpers and `time-format` utilities.
+
+## Out of Scope
+
+- **POST / PATCH / DELETE** on goals. A separate spec will add CRUD, after the read shape is established and reviewed.
+- **Notification or reminder** of pending / failed goals. Email or push surfaces are out of scope; the chart is the only feedback surface.
+- **Goal templates / suggestions**. CloudTime does not propose goals based on activity.
+- **History longer than 7 periods**. Trends beyond a week of data are deferred to future analytics endpoints.
+- **Aggregating multiple goals**. Each goal is independent; there is no compound "today's overall status" derived from multiple goals.
+- **Soft-deleted goals / archive view**. `is_enabled=false` keeps the goal visible; archiving is part of the CRUD spec (delete vs disable).

--- a/specs/100-goals-read/spec.md
+++ b/specs/100-goals-read/spec.md
@@ -17,7 +17,7 @@ This spec covers the **read path only**. Create / update / delete endpoints are 
 
 As an authenticated user, I want to see the goals I've configured so that I can confirm my current commitments and choose one to inspect.
 
-**Why this priority**: Lists are the entry point to every WakaTime UI surface that consumes goals. Without it the single-goal endpoint is unreachable through any normal client flow.
+**Why this priority**: Lists are the entry point to every compatible goals UI surface. Without it the single-goal endpoint is unreachable through any normal client flow.
 
 **Independent Test**: Authenticate as a user with three `goals` rows seeded (different types) and call `GET /api/v1/users/current/goals`. Verify the response contains all three goals with their static fields, ordered deterministically, and that `chart_data` is **omitted** (list view is intentionally lightweight).
 
@@ -87,7 +87,7 @@ As a user located outside UTC, I want the "today" period in my goal chart to ref
 
 - **FR-001**: `GET /api/v1/users/current/goals` MUST return all goal rows owned by the authenticated user, in `created_at` ascending order, as `{"data": [Goal, ...]}`.
 - **FR-002**: The list endpoint MUST NOT include `chart_data` on returned goals (lightweight response).
-- **FR-003**: `GET /api/v1/users/current/goals/{goal_id}` MUST return a single goal owned by the user, augmented with `chart_data` and top-level `status`, as `{"data": Goal}`.
+- **FR-003**: `GET /api/v1/users/current/goals/{goal_id}` MUST return a single goal owned by the user, augmented with required `chart_data` and top-level `status`, as `{"data": GoalWithChart}`.
 - **FR-004**: A request for a goal not owned by the user MUST return 404 (not 403 — do not leak existence).
 - **FR-005**: `chart_data` MUST contain exactly 7 entries: the current period plus the 6 immediately preceding periods, in chronological order (oldest first).
 - **FR-006**: For `delta=day`, each entry spans one local-calendar day in the user's profile timezone. For `delta=week`, each entry spans Monday 00:00 through Sunday 23:59 in the user's profile timezone.
@@ -104,9 +104,9 @@ As a user located outside UTC, I want the "today" period in my goal chart to ref
 
 ### Non-Functional Requirements
 
-- **NFR-001**: A single `GET /goals/{id}` request MUST complete within the Workers 10ms CPU budget on the free tier. The chart computation reads at most ~7 days of pre-aggregated `summaries` rows; no heartbeat scan.
+- **NFR-001**: A single `GET /goals/{id}` request MUST complete within the Workers 10ms CPU budget on the free tier. The chart computation reads at most the 7-period date window from pre-aggregated `summaries` rows (7 days for daily goals, 49 daily buckets for weekly goals); no heartbeat scan.
 - **NFR-002**: The list endpoint MUST issue at most one D1 query (single SELECT against `goals`).
-- **NFR-003**: The single-goal endpoint MUST issue at most two D1 queries: one for the goal row, one batched read of the 7-period summary aggregates.
+- **NFR-003**: The single-goal endpoint MUST issue at most two D1 queries: one joined read for the goal row plus the user's timezone, and one batched read of the 7-period summary aggregates.
 
 ### Key Entities *(no schema change)*
 

--- a/specs/100-goals-read/tasks.md
+++ b/specs/100-goals-read/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: Goals Read Endpoints
+
+**Branch**: `100-goals-read`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-17
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (3 user stories, FR-001..FR-012, NFRs, edge cases).
+- [x] **T-002**: Author `plan.md` (Constitution Check, sketches).
+- [x] **T-003**: Author `research.md` (9 documented decisions).
+- [x] **T-004**: Author `data-model.md` (uses existing tables only).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–J).
+- [x] **T-006**: Author `contracts/openapi-diff.md` (minor description clarifications).
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [ ] **T-008**: Optionally tighten `schemas/components/schemas/Goal.yaml` to note that `chart_data` and `status` are only populated by the single-goal endpoint, not the list endpoint.
+- [ ] **T-009**: Run `npm run generate`. Verify `src/types/generated.ts` diff is description-only.
+- [ ] **T-010**: Commit PR1, push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Helper
+
+- [ ] **T-101**: Create `src/utils/goal-chart.ts` exporting:
+  - `buildDayRanges(today: Date, userTz: string, count = 7)`
+  - `buildWeekRanges(today: Date, userTz: string, count = 7)` (ISO 8601 Monday-Sunday)
+  - `classifyRange(actual: number, target: number, isInverse: boolean, isCurrent: boolean)`
+  - `topStatus(entries: ChartEntry[], isSnoozed: boolean)`
+- [ ] **T-102**: Add unit tests in `tests/aggregation/goal-chart.test.ts` covering DST transitions, ISO week edge cases, equality at target, inverse semantics, and snoozed override.
+
+### Route handler
+
+- [ ] **T-103**: Create `src/routes/goals.ts` exporting a Hono sub-app with:
+  - `GET /goals` listing the user's goals (no chart_data).
+  - `GET /goals/:id` returning `{ data: Goal }` with chart_data + status.
+  - Both behind `authMiddleware`.
+- [ ] **T-104**: Decode `languages` / `editors` / `projects` JSON columns defensively; treat invalid JSON as `[]` with a `console.warn` containing the goal id but not the raw value.
+- [ ] **T-105**: Implement the summary-totals SQL with parameterised `IN (?, ?, ...)` for filtered goal types. Guard against zero-length filter arrays (the query degenerates to "no rows" by intent).
+
+### Wiring
+
+- [ ] **T-106**: Mount the sub-app in `src/index.ts`:
+  ```ts
+  import goals from "./routes/goals";
+  // ...
+  app.route("/api/v1/users/current", goals);
+  ```
+
+### Tests
+
+- [ ] **T-107**: Integration test in `tests/integration/goals-read.test.ts`:
+  - Empty list returns `{"data":[]}` (scenario A).
+  - Populated list returns ordered entries without chart_data (scenario B).
+  - Single goal returns chart_data of length 7 with correct actuals after seeding summaries (scenario C).
+  - `type=languages` filter excludes non-matching summary rows (scenario D).
+  - `is_inverse=true` flips success/fail semantics (scenario F).
+  - `is_snoozed=true` forces top-level `status=pending` while leaving per-period statuses computed normally (scenario G).
+  - Cross-user 404 (scenario H).
+  - Unauthenticated 401 (scenario I).
+
+### Verification
+
+- [ ] **T-108**: `npx tsc --noEmit` — zero errors.
+- [ ] **T-109**: `npm test` — all 79+ tests pass plus new unit + integration.
+- [ ] **T-110**: Manual run of `quickstart.md` scenarios against a staging worker for at least scenarios C and J (timezone + chart correctness).
+
+### PR2 submission
+
+- [ ] **T-111**: Commit with `feat:` prefix. Push, open PR against `develop` referencing PR1.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                              (PR1)
+T-010 → T-101 .. T-111                              (PR2 starts after PR1 merge)
+T-101 → T-102                                       (helper before its tests)
+T-101 → T-103 → T-104 → T-105                       (handler stack)
+T-103 → T-106                                       (must exist before mounting)
+T-102 / T-105 / T-106 → T-107                       (integration test needs full surface)
+T-107 → T-108 → T-109 → T-110 → T-111
+```
+
+## Out of scope
+
+- POST / PATCH / DELETE on goals (future spec).
+- Notifications, email, or push when status flips.
+- Goal templates or recommendations.
+- History beyond 7 periods.
+- Cross-user "team goals" / shared goals.

--- a/specs/100-goals-read/tasks.md
+++ b/specs/100-goals-read/tasks.md
@@ -13,9 +13,9 @@
 - [x] **T-005**: Author `quickstart.md` (scenarios A–J).
 - [x] **T-006**: Author `contracts/openapi-diff.md` (minor description clarifications).
 - [x] **T-007**: Author `checklists/requirements.md`.
-- [ ] **T-008**: Optionally tighten `schemas/components/schemas/Goal.yaml` to note that `chart_data` and `status` are only populated by the single-goal endpoint, not the list endpoint.
-- [ ] **T-009**: Run `npm run generate`. Verify `src/types/generated.ts` diff is description-only.
-- [ ] **T-010**: Commit PR1, push, open PR against `develop`.
+- [x] **T-008**: Split the OpenAPI response contract so `Goal` contains only persisted fields and `GoalWithChart` requires `chart_data` and `status` for the single-goal endpoint.
+- [x] **T-009**: Run `npm run generate`. Verify `src/types/generated.ts` reflects the `Goal` / `GoalWithChart` response split.
+- [x] **T-010**: Commit PR1, push, open PR against `develop`.
 
 ## PR2 — Implementation (after PR1 merges)
 
@@ -32,7 +32,7 @@
 
 - [ ] **T-103**: Create `src/routes/goals.ts` exporting a Hono sub-app with:
   - `GET /goals` listing the user's goals (no chart_data).
-  - `GET /goals/:id` returning `{ data: Goal }` with chart_data + status.
+  - `GET /goals/:id` returning `{ data: GoalWithChart }` with chart_data + status.
   - Both behind `authMiddleware`.
 - [ ] **T-104**: Decode `languages` / `editors` / `projects` JSON columns defensively; treat invalid JSON as `[]` with a `console.warn` containing the goal id but not the raw value.
 - [ ] **T-105**: Implement the summary-totals SQL with parameterised `IN (?, ?, ...)` for filtered goal types. Guard against zero-length filter arrays (the query degenerates to "no rows" by intent).

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -608,9 +608,10 @@ export interface paths {
         /**
          * List user's goals
          * @description Returns the authenticated user's goals ordered by `created_at` ascending.
-         *     Each entry includes only the persisted Goal fields. `chart_data` and
-         *     `status` are NOT computed for the list endpoint — clients that need
-         *     per-period progress must request each goal individually via
+         *     Each entry conforms to the `Goal` schema, which includes only persisted
+         *     goal fields. `chart_data` and `status` are NOT computed for the list
+         *     endpoint — clients that need per-period progress must request each goal
+         *     individually via
          *     `GET /users/current/goals/{goal_id}`.
          */
         get: operations["getGoals"];
@@ -1332,30 +1333,31 @@ export interface components {
             languages?: string[];
             editors?: string[];
             projects?: string[];
-            /**
-             * @description Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
-             *     in chronological order; the last entry is always `range_status: pending`.
-             */
-            chart_data?: {
-                /** Format: double */
-                actual_seconds?: number;
-                /** Format: double */
-                goal_seconds?: number;
-                range?: components["schemas"]["TimeRange"];
-                /** @enum {string} */
-                range_status?: "success" | "fail" | "pending";
-            }[];
-            /**
-             * @description Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
-             *     `range_status` of the most recently completed period unless the goal
-             *     is snoozed, in which case it is forced to `pending`.
-             * @enum {string}
-             */
-            status?: "success" | "fail" | "pending";
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
             modified_at?: string;
+        };
+        GoalWithChart: components["schemas"]["Goal"] & {
+            /**
+             * @description Always 7 entries in chronological order; the last entry is always
+             *     `range_status: pending`.
+             */
+            chart_data: {
+                /** Format: double */
+                actual_seconds: number;
+                /** Format: double */
+                goal_seconds: number;
+                range: components["schemas"]["TimeRange"];
+                /** @enum {string} */
+                range_status: "success" | "fail" | "pending";
+            }[];
+            /**
+             * @description Mirrors the `range_status` of the most recently completed period
+             *     unless the goal is snoozed, in which case it is forced to `pending`.
+             * @enum {string}
+             */
+            status: "success" | "fail" | "pending";
         };
         LeaderboardEntry: {
             rank?: number;
@@ -2600,7 +2602,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        data: components["schemas"]["Goal"];
+                        data: components["schemas"]["GoalWithChart"];
                     };
                 };
             };

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -605,7 +605,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List user's goals */
+        /**
+         * List user's goals
+         * @description Returns the authenticated user's goals ordered by `created_at` ascending.
+         *     Each entry includes only the persisted Goal fields. `chart_data` and
+         *     `status` are NOT computed for the list endpoint — clients that need
+         *     per-period progress must request each goal individually via
+         *     `GET /users/current/goals/{goal_id}`.
+         */
         get: operations["getGoals"];
         put?: never;
         post?: never;
@@ -622,7 +629,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get a single goal with chart data */
+        /**
+         * Get a single goal with chart data
+         * @description Returns a single goal owned by the authenticated user, augmented with
+         *     `chart_data` (the most recent 7 periods of actual vs target activity)
+         *     and top-level `status` (the most recently completed period's outcome,
+         *     forced to `pending` if the goal is snoozed).
+         *
+         *     Period boundaries use the user's profile timezone (`users.timezone`).
+         *     Day periods span local calendar days. Week periods span ISO 8601
+         *     Monday-Sunday weeks in the user's timezone.
+         *
+         *     Requests for a goal owned by a different user return 404 (not 403) to
+         *     avoid leaking goal-id existence.
+         */
         get: operations["getGoal"];
         put?: never;
         post?: never;
@@ -1312,6 +1332,10 @@ export interface components {
             languages?: string[];
             editors?: string[];
             projects?: string[];
+            /**
+             * @description Populated only by `GET /users/current/goals/{goal_id}`. Always 7 entries
+             *     in chronological order; the last entry is always `range_status: pending`.
+             */
             chart_data?: {
                 /** Format: double */
                 actual_seconds?: number;
@@ -1321,7 +1345,12 @@ export interface components {
                 /** @enum {string} */
                 range_status?: "success" | "fail" | "pending";
             }[];
-            /** @enum {string} */
+            /**
+             * @description Populated only by `GET /users/current/goals/{goal_id}`. Mirrors the
+             *     `range_status` of the most recently completed period unless the goal
+             *     is snoozed, in which case it is forced to `pending`.
+             * @enum {string}
+             */
             status?: "success" | "fail" | "pending";
             /** Format: date-time */
             created_at: string;


### PR DESCRIPTION
## Summary

PR1 of the SpecKit 2-PR workflow for **Goals read endpoints**. The `goals` D1 table and the `getGoals` / `getGoal` operations are already declared, but neither has a handler. PR1 locks down the read contract; PR2 will ship the implementation.

## Scope

**Read-only.** CRUD endpoints (POST / PATCH / DELETE) are explicitly deferred to a follow-up spec to keep this PR's review surface tight.

| | List | Single goal |
|---|---|---|
| Endpoint | `GET /users/current/goals` | `GET /users/current/goals/{goal_id}` |
| Returns | `{"data": [Goal, ...]}` ordered by `created_at` ASC | `{"data": GoalWithChart}` with required `chart_data` + top-level `status` |
| `chart_data` | omitted from the `Goal` schema | 7 entries, oldest first, last is `pending` |
| Status semantics | n/a | mirrors most-recent completed period; forced `pending` if snoozed |

## Design decisions (full text in `research.md`)

1. Read from `summaries`, never from `heartbeats` — fast, consistent with existing endpoints.
2. Week boundary = ISO 8601 Monday-Sunday in the user's profile timezone.
3. `is_snoozed` overrides top-level `status` only; per-period status still computed.
4. Per-period status uses `>=` (or `<=` if inverse) — equality at target counts as success.
5. Top-level `status` mirrors the most-recent completed period.
6. 7-period window (current + 6 prior).
7. Cross-user requests return 404, not 403 — no goal-id existence leak.
8. List omits `chart_data` to keep the response cheap.
9. JSON-decode `languages/editors/projects` defensively (invalid → `[]` + warning log).

## Schema changes

- `schemas/paths/goals/goals.yaml` — documents the lightweight list endpoint and keeps the response as `Goal[]`.
- `schemas/paths/goals/goal.yaml` — returns `GoalWithChart` for the single-goal endpoint.
- `schemas/components/schemas/Goal.yaml` — persisted goal fields only; no `chart_data` or `status`.
- `schemas/components/schemas/GoalWithChart.yaml` — adds required `chart_data` and `status`.

No DB changes. No new env vars. No code under `src/routes/` or `src/utils/`.

## Test plan

- [x] `npm run generate` updates `src/types/generated.ts` with the `Goal` / `GoalWithChart` response split
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test -- --run` — 81/81 existing tests still pass (no behaviour change in this PR)
- [ ] CI workflow runs green on this PR

## Follow-up

After this PR merges:

- **PR2** lands `src/utils/goal-chart.ts` (week-range builder + classify + topStatus) and `src/routes/goals.ts` (the two handlers), wired up in `src/index.ts`. Includes unit tests for chart correctness and an integration test set against a seeded D1.
- A separate **CRUD spec** later will add POST / PATCH / DELETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
