### PR TITLE
feat: implement Goals read endpoints (PR2/2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import heartbeats from "./routes/heartbeats";
 import summaries from "./routes/summaries";
 import stats from "./routes/stats";
 import users from "./routes/users";
+import goals from "./routes/goals";
 import { aggregateHeartbeats } from "./cron/aggregate";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -118,6 +119,9 @@ app.route("/api/v1/users/current", stats);
 
 // User routes (mounted at /users/current, sub-app defines /, /profile, /projects)
 app.route("/api/v1/users/current", users);
+
+// Goals routes (mounted at /users/current, sub-app defines /goals, /goals/:goal_id)
+app.route("/api/v1/users/current", goals);
 
 // Cron trigger handler for periodic aggregation + session cleanup
 export default {

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -1,0 +1,217 @@
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import {
+  buildChart,
+  buildDayRanges,
+  buildWeekRanges,
+  rebucketWeekly,
+  topStatus,
+  type ChartEntry,
+  type ChartRange,
+} from "../utils/goal-chart";
+
+type Goal = components["schemas"]["Goal"];
+type GoalWithChart = components["schemas"]["GoalWithChart"];
+
+interface GoalRow {
+  id: string;
+  user_id: string;
+  title: string;
+  type: string;
+  delta: string;
+  target_seconds: number;
+  is_enabled: number;
+  is_snoozed: number;
+  is_inverse: number;
+  languages: string | null;
+  editors: string | null;
+  projects: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+interface GoalRowWithTimezone extends GoalRow {
+  timezone: string;
+}
+
+const VALID_TYPES = new Set(["coding", "languages", "editors", "projects"]);
+const VALID_DELTAS = new Set(["day", "week"]);
+
+function parseFilterArray(raw: string | null, goalId: string, column: string): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    if (Array.isArray(value)) {
+      return value.filter((v): v is string => typeof v === "string");
+    }
+    console.warn(`[goals] non-array ${column} for goal=${goalId}; treating as []`);
+    return [];
+  } catch {
+    console.warn(`[goals] invalid JSON in ${column} for goal=${goalId}; treating as []`);
+    return [];
+  }
+}
+
+function rowToGoal(row: GoalRow): Goal {
+  const rawType = VALID_TYPES.has(row.type) ? row.type : "coding";
+  const rawDelta = VALID_DELTAS.has(row.delta) ? row.delta : "day";
+  return {
+    id: row.id,
+    title: row.title,
+    type: rawType as Goal["type"],
+    delta: rawDelta as Goal["delta"],
+    target_seconds: row.target_seconds,
+    is_enabled: row.is_enabled === 1,
+    is_snoozed: row.is_snoozed === 1,
+    is_inverse: row.is_inverse === 1,
+    languages: parseFilterArray(row.languages, row.id, "languages"),
+    editors: parseFilterArray(row.editors, row.id, "editors"),
+    projects: parseFilterArray(row.projects, row.id, "projects"),
+    created_at: row.created_at,
+    modified_at: row.modified_at,
+  };
+}
+
+const GOAL_COLUMNS = `id, user_id, title, type, delta, target_seconds,
+  is_enabled, is_snoozed, is_inverse, languages, editors, projects,
+  created_at, modified_at`;
+
+const goals = new Hono<AuthEnv>();
+
+goals.use("/goals", authMiddleware);
+goals.use("/goals/*", authMiddleware);
+
+goals.get("/goals", async (c) => {
+  const userId = c.get("userId");
+  try {
+    const { results } = await c.env.DB.prepare(
+      `SELECT ${GOAL_COLUMNS} FROM goals
+        WHERE user_id = ?
+        ORDER BY created_at ASC`,
+    )
+      .bind(userId)
+      .all<GoalRow>();
+    return c.json({ data: results.map(rowToGoal) });
+  } catch (err) {
+    console.error("GET /goals error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+goals.get("/goals/:goal_id", async (c) => {
+  const userId = c.get("userId");
+  const goalId = c.req.param("goal_id");
+
+  try {
+    const row = await c.env.DB.prepare(
+      `SELECT ${GOAL_COLUMNS.split(",").map((col) => `g.${col.trim()}`).join(", ")},
+              u.timezone AS timezone
+         FROM goals g
+         JOIN users u ON u.id = g.user_id
+        WHERE g.id = ? AND g.user_id = ?`,
+    )
+      .bind(goalId, userId)
+      .first<GoalRowWithTimezone>();
+
+    if (!row) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    const goal = rowToGoal(row);
+    const tz = row.timezone || "UTC";
+
+    // Pull the relevant filter array given goal type.
+    let filterValues: string[] = [];
+    let filterColumn: "language" | "editor" | "project" | null = null;
+    switch (goal.type) {
+      case "languages":
+        filterValues = goal.languages ?? [];
+        filterColumn = "language";
+        break;
+      case "editors":
+        filterValues = goal.editors ?? [];
+        filterColumn = "editor";
+        break;
+      case "projects":
+        filterValues = goal.projects ?? [];
+        filterColumn = "project";
+        break;
+      default:
+        filterColumn = null;
+    }
+
+    // Filtered goal with an empty allowlist matches nothing — skip the
+    // summaries scan entirely and report zeros.
+    const filterMatchesNothing = filterColumn !== null && filterValues.length === 0;
+
+    // 7 ranges in the user's timezone. For weeks we also need the
+    // underlying daily totals across the 49-day window so we can re-bucket.
+    const nowMs = Date.now();
+    const ranges: ChartRange[] = goal.delta === "week"
+      ? buildWeekRanges(nowMs, tz)
+      : buildDayRanges(nowMs, tz);
+
+    // Span queried in D1: from the oldest range's date to the last range's
+    // effective end-date (for weeks, the Sunday of the most recent week).
+    const startDate = ranges[0].date;
+    const endDate = goal.delta === "week"
+      ? // last range is the current week's Monday; query through current local date
+        addDaysIsoUtc(ranges[ranges.length - 1].date, 6)
+      : ranges[ranges.length - 1].date;
+
+    let actualsByDate = new Map<string, number>();
+    if (!filterMatchesNothing) {
+      const placeholders = filterValues.map(() => "?").join(",");
+      const filterClause = filterColumn !== null
+        ? ` AND ${filterColumn} IN (${placeholders})`
+        : "";
+      const sql =
+        `SELECT date, SUM(total_seconds) AS actual_seconds
+           FROM summaries
+          WHERE user_id = ?
+            AND date BETWEEN ? AND ?` + filterClause +
+        ` GROUP BY date`;
+      const binds: (string | number)[] = [userId, startDate, endDate, ...filterValues];
+      const { results } = await c.env.DB.prepare(sql)
+        .bind(...binds)
+        .all<{ date: string; actual_seconds: number }>();
+      for (const r of results) {
+        actualsByDate.set(r.date, Number(r.actual_seconds) || 0);
+      }
+    }
+
+    // For week goals, re-bucket the per-day map into per-Monday totals.
+    const bucketedActuals = goal.delta === "week"
+      ? rebucketWeekly(actualsByDate, ranges)
+      : actualsByDate;
+
+    const chart: ChartEntry[] = buildChart(
+      ranges,
+      bucketedActuals,
+      goal.target_seconds ?? 0,
+      goal.is_inverse ?? false,
+    );
+
+    const response: GoalWithChart = {
+      ...goal,
+      chart_data: chart,
+      status: topStatus(chart, goal.is_snoozed ?? false),
+    };
+
+    return c.json({ data: response });
+  } catch (err) {
+    console.error("GET /goals/:goal_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+function addDaysIsoUtc(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() + days);
+  return utc.toISOString().slice(0, 10);
+}
+
+export default goals;

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
+import { isValidTimezone } from "../utils/time-format";
+import { normalizeDateTime } from "../utils/user";
 import {
   buildChart,
   buildDayRanges,
@@ -69,8 +71,8 @@ function rowToGoal(row: GoalRow): Goal {
     languages: parseFilterArray(row.languages, row.id, "languages"),
     editors: parseFilterArray(row.editors, row.id, "editors"),
     projects: parseFilterArray(row.projects, row.id, "projects"),
-    created_at: row.created_at,
-    modified_at: row.modified_at,
+    created_at: normalizeDateTime(row.created_at),
+    modified_at: normalizeDateTime(row.modified_at),
   };
 }
 
@@ -120,7 +122,8 @@ goals.get("/goals/:goal_id", async (c) => {
     }
 
     const goal = rowToGoal(row);
-    const tz = row.timezone || "UTC";
+    const candidateTz = row.timezone || "UTC";
+    const tz = isValidTimezone(candidateTz) ? candidateTz : "UTC";
 
     // Pull the relevant filter array given goal type.
     let filterValues: string[] = [];

--- a/src/utils/goal-chart.ts
+++ b/src/utils/goal-chart.ts
@@ -1,0 +1,191 @@
+/**
+ * Pure helpers for Goals chart computation (Issue: specs/100-goals-read/).
+ *
+ * The route handler resolves a goal, fetches matching summary totals from
+ * D1, and assembles a 7-period chart. This module owns the deterministic
+ * parts (range boundary math, classification, top-status) so they are
+ * unit-testable without D1.
+ *
+ * Day periods span one local calendar day in the user's profile timezone.
+ * Week periods span ISO 8601 Monday-Sunday weeks in the user's profile
+ * timezone. The cron aggregator buckets `summaries.date` in that same
+ * timezone, so the chart can match by date strings directly.
+ */
+import { getDateForTimestamp, getEpochBoundsForDate } from "./time-format";
+
+export type RangeStatus = "success" | "fail" | "pending";
+
+export interface ChartRange {
+  date: string;
+  start: string;
+  end: string;
+  text: string;
+  timezone: string;
+}
+
+export interface ChartEntry {
+  actual_seconds: number;
+  goal_seconds: number;
+  range: ChartRange;
+  range_status: RangeStatus;
+}
+
+const CHART_LENGTH = 7;
+
+function isoDateUtc(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString();
+}
+
+/**
+ * Build 7 day-ranges in the user's profile timezone, oldest first.
+ * The final entry is "today" in that timezone (used as the pending period).
+ */
+export function buildDayRanges(
+  nowMs: number,
+  tz: string,
+  count = CHART_LENGTH,
+): ChartRange[] {
+  const ranges: ChartRange[] = [];
+  // Walk backwards from today by subtracting 86_400s from "today's epoch noon"
+  // and converting to the user's local date each step — this is robust across
+  // DST transitions because we resolve the local date via Intl, not naive math.
+  const todayLocal = getDateForTimestamp(nowMs / 1000, tz);
+  // Seed the loop with the local "today" string then walk back by computing
+  // bounds and stepping the loop pointer 24h earlier in epoch terms.
+  const dates: string[] = [todayLocal];
+  let cursorEpoch = Math.floor(nowMs / 1000);
+  while (dates.length < count) {
+    cursorEpoch -= 86_400;
+    dates.push(getDateForTimestamp(cursorEpoch, tz));
+  }
+  dates.reverse(); // oldest first
+  for (const date of dates) {
+    const bounds = getEpochBoundsForDate(date, tz);
+    ranges.push({
+      date,
+      start: isoDateUtc(bounds.start),
+      end: isoDateUtc(bounds.end),
+      text: date,
+      timezone: tz,
+    });
+  }
+  return ranges;
+}
+
+/**
+ * Compute the local-timezone ISO 8601 Monday for the given local date.
+ * Pure date arithmetic: weekday in 0..6 with Monday=0 .. Sunday=6.
+ */
+function isoWeekMonday(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  // Use UTC math to avoid the host's local timezone influencing weekday math.
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  // getUTCDay: Sunday=0..Saturday=6; convert to Mon=0..Sun=6.
+  const weekdayMonZero = (utc.getUTCDay() + 6) % 7;
+  utc.setUTCDate(utc.getUTCDate() - weekdayMonZero);
+  return utc.toISOString().slice(0, 10);
+}
+
+function addDaysLocal(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() + days);
+  return utc.toISOString().slice(0, 10);
+}
+
+/**
+ * Build 7 ISO-week ranges (Monday-Sunday in the user's profile timezone),
+ * oldest first. The final entry covers the current week — pending until
+ * Sunday 23:59:59.
+ */
+export function buildWeekRanges(
+  nowMs: number,
+  tz: string,
+  count = CHART_LENGTH,
+): ChartRange[] {
+  const todayLocal = getDateForTimestamp(nowMs / 1000, tz);
+  const thisMonday = isoWeekMonday(todayLocal);
+  const mondays: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    mondays.push(addDaysLocal(thisMonday, -7 * i));
+  }
+  return mondays.map((mondayDate) => {
+    const sundayDate = addDaysLocal(mondayDate, 6);
+    const startBounds = getEpochBoundsForDate(mondayDate, tz);
+    const endBounds = getEpochBoundsForDate(sundayDate, tz);
+    return {
+      date: mondayDate,
+      start: isoDateUtc(startBounds.start),
+      end: isoDateUtc(endBounds.end),
+      text: `${mondayDate} — ${sundayDate}`,
+      timezone: tz,
+    };
+  });
+}
+
+/**
+ * Classify one period given its actual total.
+ * The current (last) period is always `pending`. Otherwise compare actual
+ * to target using `>=` (or `<=` when the goal is inverse — a cap-style goal).
+ */
+export function classifyRange(
+  actual: number,
+  target: number,
+  isInverse: boolean,
+  isCurrent: boolean,
+): RangeStatus {
+  if (isCurrent) return "pending";
+  if (isInverse) return actual <= target ? "success" : "fail";
+  return actual >= target ? "success" : "fail";
+}
+
+/**
+ * Top-level Goal.status — mirror the most recently completed period's
+ * status, or force `pending` when the goal is snoozed.
+ */
+export function topStatus(entries: ChartEntry[], isSnoozed: boolean): RangeStatus {
+  if (isSnoozed) return "pending";
+  if (entries.length < 2) return "pending";
+  return entries[entries.length - 2].range_status;
+}
+
+/**
+ * Assemble the chart given pre-built ranges and a date → actual_seconds map.
+ * Missing dates contribute 0 actual. The last range is treated as pending.
+ */
+export function buildChart(
+  ranges: ChartRange[],
+  actualsByDate: Map<string, number>,
+  target: number,
+  isInverse: boolean,
+): ChartEntry[] {
+  const lastIdx = ranges.length - 1;
+  return ranges.map((range, i) => {
+    const actual = actualsByDate.get(range.date) ?? 0;
+    return {
+      actual_seconds: actual,
+      goal_seconds: target,
+      range,
+      range_status: classifyRange(actual, target, isInverse, i === lastIdx),
+    };
+  });
+}
+
+/**
+ * Aggregate per-day summary totals into the buckets of week ranges. The
+ * input map is keyed by YYYY-MM-DD (user-tz local date); the returned map
+ * is keyed by the Monday of each containing week.
+ */
+export function rebucketWeekly(
+  dailyActuals: Map<string, number>,
+  weekRanges: ChartRange[],
+): Map<string, number> {
+  const weekByDate = new Map<string, number>();
+  for (const week of weekRanges) weekByDate.set(week.date, 0);
+  for (const [date, seconds] of dailyActuals) {
+    const monday = isoWeekMonday(date);
+    if (!weekByDate.has(monday)) continue; // outside the 7-week window
+    weekByDate.set(monday, (weekByDate.get(monday) ?? 0) + seconds);
+  }
+  return weekByDate;
+}

--- a/src/utils/goal-chart.ts
+++ b/src/utils/goal-chart.ts
@@ -46,19 +46,11 @@ export function buildDayRanges(
   count = CHART_LENGTH,
 ): ChartRange[] {
   const ranges: ChartRange[] = [];
-  // Walk backwards from today by subtracting 86_400s from "today's epoch noon"
-  // and converting to the user's local date each step — this is robust across
-  // DST transitions because we resolve the local date via Intl, not naive math.
   const todayLocal = getDateForTimestamp(nowMs / 1000, tz);
-  // Seed the loop with the local "today" string then walk back by computing
-  // bounds and stepping the loop pointer 24h earlier in epoch terms.
-  const dates: string[] = [todayLocal];
-  let cursorEpoch = Math.floor(nowMs / 1000);
-  while (dates.length < count) {
-    cursorEpoch -= 86_400;
-    dates.push(getDateForTimestamp(cursorEpoch, tz));
+  const dates: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    dates.push(addDaysLocal(todayLocal, -i));
   }
-  dates.reverse(); // oldest first
   for (const date of dates) {
     const bounds = getEpochBoundsForDate(date, tz);
     ranges.push({

--- a/tests/aggregation/goal-chart.test.ts
+++ b/tests/aggregation/goal-chart.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChart,
+  buildDayRanges,
+  buildWeekRanges,
+  classifyRange,
+  rebucketWeekly,
+  topStatus,
+  type ChartEntry,
+  type ChartRange,
+} from "../../src/utils/goal-chart";
+
+const FRI_2026_05_15_NOON_JST = Date.UTC(2026, 4, 15, 3, 0, 0); // 12:00 JST
+const SUN_2026_03_08_NOON_NY = Date.UTC(2026, 2, 8, 16, 0, 0);  // 12:00 EDT (DST spring-forward day)
+
+describe("buildDayRanges", () => {
+  it("returns 7 consecutive local-tz dates oldest first, ending today", () => {
+    const ranges = buildDayRanges(FRI_2026_05_15_NOON_JST, "Asia/Tokyo");
+
+    expect(ranges).toHaveLength(7);
+    expect(ranges.map((r) => r.date)).toEqual([
+      "2026-05-09",
+      "2026-05-10",
+      "2026-05-11",
+      "2026-05-12",
+      "2026-05-13",
+      "2026-05-14",
+      "2026-05-15",
+    ]);
+    for (const r of ranges) expect(r.timezone).toBe("Asia/Tokyo");
+  });
+
+  it("walks the local timezone (not UTC) at the day boundary", () => {
+    // 2026-05-15 23:30 UTC == 2026-05-16 08:30 JST.
+    const nearMidnightUtc = Date.UTC(2026, 4, 15, 23, 30, 0);
+    const ranges = buildDayRanges(nearMidnightUtc, "Asia/Tokyo");
+    expect(ranges[ranges.length - 1].date).toBe("2026-05-16");
+  });
+
+  it("emits start/end that correctly span a 23-hour DST spring-forward day", () => {
+    // The most recent range covers 2026-03-08 in America/New_York (spring forward).
+    const ranges = buildDayRanges(SUN_2026_03_08_NOON_NY, "America/New_York");
+    const current = ranges[ranges.length - 1];
+    const startMs = Date.parse(current.start);
+    const endMs = Date.parse(current.end);
+    expect(current.date).toBe("2026-03-08");
+    expect((endMs - startMs) / 3_600_000).toBeCloseTo(23, 5);
+  });
+});
+
+describe("buildWeekRanges (ISO Mon-Sun)", () => {
+  it("returns 7 weeks oldest first, dated by Monday", () => {
+    // 2026-05-15 is a Friday; its ISO Monday is 2026-05-11.
+    const ranges = buildWeekRanges(FRI_2026_05_15_NOON_JST, "Asia/Tokyo");
+    expect(ranges).toHaveLength(7);
+    expect(ranges.map((r) => r.date)).toEqual([
+      "2026-03-30",
+      "2026-04-06",
+      "2026-04-13",
+      "2026-04-20",
+      "2026-04-27",
+      "2026-05-04",
+      "2026-05-11",
+    ]);
+  });
+
+  it("anchors when the current local date is itself a Monday", () => {
+    // 2026-05-11 noon JST.
+    const mondayNoonJst = Date.UTC(2026, 4, 11, 3, 0, 0);
+    const ranges = buildWeekRanges(mondayNoonJst, "Asia/Tokyo");
+    expect(ranges[ranges.length - 1].date).toBe("2026-05-11");
+  });
+
+  it("anchors when the current local date is a Sunday", () => {
+    // 2026-05-17 noon JST is the Sunday closing 2026-05-11..05-17.
+    const sundayNoonJst = Date.UTC(2026, 4, 17, 3, 0, 0);
+    const ranges = buildWeekRanges(sundayNoonJst, "Asia/Tokyo");
+    expect(ranges[ranges.length - 1].date).toBe("2026-05-11");
+  });
+});
+
+describe("classifyRange", () => {
+  it("returns 'pending' for the current period regardless of comparisons", () => {
+    expect(classifyRange(0, 3600, false, true)).toBe("pending");
+    expect(classifyRange(10_000, 3600, false, true)).toBe("pending");
+    expect(classifyRange(10_000, 3600, true, true)).toBe("pending");
+  });
+
+  it("treats equality at target as success (both normal and inverse goals)", () => {
+    expect(classifyRange(3600, 3600, false, false)).toBe("success");
+    expect(classifyRange(3600, 3600, true, false)).toBe("success");
+  });
+
+  it("normal goal: success when actual >= target, fail otherwise", () => {
+    expect(classifyRange(3601, 3600, false, false)).toBe("success");
+    expect(classifyRange(3599, 3600, false, false)).toBe("fail");
+  });
+
+  it("inverse goal: success when actual <= target, fail otherwise", () => {
+    expect(classifyRange(1799, 1800, true, false)).toBe("success");
+    expect(classifyRange(1801, 1800, true, false)).toBe("fail");
+  });
+});
+
+describe("topStatus", () => {
+  const mkEntry = (status: "success" | "fail" | "pending"): ChartEntry => ({
+    actual_seconds: 0,
+    goal_seconds: 0,
+    range: { date: "x", start: "x", end: "x", text: "x", timezone: "UTC" },
+    range_status: status,
+  });
+
+  it("returns 'pending' when the goal is snoozed regardless of period outcomes", () => {
+    const chart = [mkEntry("success"), mkEntry("success"), mkEntry("pending")];
+    expect(topStatus(chart, true)).toBe("pending");
+  });
+
+  it("returns the most recently completed period's status (second-to-last)", () => {
+    expect(
+      topStatus([mkEntry("fail"), mkEntry("success"), mkEntry("pending")], false),
+    ).toBe("success");
+    expect(
+      topStatus([mkEntry("success"), mkEntry("fail"), mkEntry("pending")], false),
+    ).toBe("fail");
+  });
+
+  it("returns 'pending' when the chart has fewer than 2 entries", () => {
+    expect(topStatus([], false)).toBe("pending");
+    expect(topStatus([mkEntry("pending")], false)).toBe("pending");
+  });
+});
+
+describe("buildChart", () => {
+  function mkRange(date: string): ChartRange {
+    return { date, start: "x", end: "x", text: date, timezone: "UTC" };
+  }
+
+  it("zeros out missing periods and marks only the last as pending", () => {
+    const ranges = ["d1", "d2", "d3", "d4", "d5", "d6", "d7"].map(mkRange);
+    const actuals = new Map([
+      ["d2", 1800],
+      ["d6", 5400],
+    ]);
+    const chart = buildChart(ranges, actuals, 3600, false);
+
+    expect(chart.map((c) => c.actual_seconds)).toEqual([0, 1800, 0, 0, 0, 5400, 0]);
+    expect(chart.map((c) => c.range_status)).toEqual([
+      "fail",
+      "fail", // 1800 < 3600
+      "fail",
+      "fail",
+      "fail",
+      "success", // 5400 >= 3600
+      "pending",
+    ]);
+    for (const entry of chart) expect(entry.goal_seconds).toBe(3600);
+  });
+
+  it("inverse goal: under-cap days succeed", () => {
+    const ranges = ["d1", "d2", "d3", "d4", "d5", "d6", "d7"].map(mkRange);
+    const actuals = new Map([
+      ["d1", 600],
+      ["d2", 1800],
+      ["d3", 1801],
+    ]);
+    const chart = buildChart(ranges, actuals, 1800, true);
+    expect(chart[0].range_status).toBe("success");
+    expect(chart[1].range_status).toBe("success");
+    expect(chart[2].range_status).toBe("fail");
+    expect(chart[chart.length - 1].range_status).toBe("pending");
+  });
+});
+
+describe("rebucketWeekly", () => {
+  it("sums daily totals into the Monday-keyed bucket of each containing week", () => {
+    // Week ranges defined by their Mondays.
+    const weekRanges: ChartRange[] = [
+      { date: "2026-05-04", start: "x", end: "x", text: "x", timezone: "UTC" },
+      { date: "2026-05-11", start: "x", end: "x", text: "x", timezone: "UTC" },
+    ];
+
+    const daily = new Map([
+      ["2026-05-04", 1000], // Monday
+      ["2026-05-07", 200],  // Thursday
+      ["2026-05-10", 300],  // Sunday
+      ["2026-05-11", 400],  // Monday (next week)
+      ["2026-05-12", 50],   // Tuesday (next week)
+    ]);
+
+    const weekly = rebucketWeekly(daily, weekRanges);
+    expect(weekly.get("2026-05-04")).toBe(1500);
+    expect(weekly.get("2026-05-11")).toBe(450);
+  });
+
+  it("drops daily totals outside the listed weeks", () => {
+    const weekRanges: ChartRange[] = [
+      { date: "2026-05-11", start: "x", end: "x", text: "x", timezone: "UTC" },
+    ];
+    const daily = new Map([
+      ["2026-05-04", 1000], // outside the window
+      ["2026-05-11", 400],
+    ]);
+    const weekly = rebucketWeekly(daily, weekRanges);
+    expect(weekly.get("2026-05-04")).toBeUndefined();
+    expect(weekly.get("2026-05-11")).toBe(400);
+  });
+});

--- a/tests/aggregation/goal-chart.test.ts
+++ b/tests/aggregation/goal-chart.test.ts
@@ -46,6 +46,22 @@ describe("buildDayRanges", () => {
     expect(current.date).toBe("2026-03-08");
     expect((endMs - startMs) / 3_600_000).toBeCloseTo(23, 5);
   });
+
+  it("does not skip the spring-forward day just after local midnight", () => {
+    // 2026-03-09 04:30 UTC == 2026-03-09 00:30 America/New_York.
+    const justAfterSpringForwardMidnight = Date.UTC(2026, 2, 9, 4, 30, 0);
+    const ranges = buildDayRanges(justAfterSpringForwardMidnight, "America/New_York");
+
+    expect(ranges.map((r) => r.date)).toEqual([
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+      "2026-03-06",
+      "2026-03-07",
+      "2026-03-08",
+      "2026-03-09",
+    ]);
+  });
 });
 
 describe("buildWeekRanges (ISO Mon-Sun)", () => {

--- a/tests/integration/goals-read.test.ts
+++ b/tests/integration/goals-read.test.ts
@@ -132,6 +132,7 @@ describe("GET /api/v1/users/current/goals (list)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: Array<Record<string, unknown>> };
     expect(body.data.map((g) => g.title)).toEqual(["first", "second", "third"]);
+    expect(body.data[0].created_at).toBe("2026-05-01T10:00:00Z");
     for (const g of body.data) {
       expect(g).not.toHaveProperty("chart_data");
       expect(g).not.toHaveProperty("status");
@@ -182,6 +183,23 @@ describe("GET /api/v1/users/current/goals/:goal_id (single)", () => {
       headers: auth(user.apiKey),
     });
     expect(res.status).toBe(404);
+  });
+
+  it("falls back to UTC when the stored user timezone is invalid", async () => {
+    await env.DB.prepare("UPDATE users SET timezone = 'Invalid/Zone' WHERE id = ?")
+      .bind(user.userId)
+      .run();
+    const goalId = await seedGoal({ ownerId: user.userId });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { chart_data: Array<{ range: { timezone: string } }> };
+    };
+    expect(body.data.chart_data.every((entry) => entry.range.timezone === "UTC")).toBe(true);
   });
 
   it("returns 404 when the goal belongs to another user (no 403 / no leak)", async () => {

--- a/tests/integration/goals-read.test.ts
+++ b/tests/integration/goals-read.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Integration tests for the Goals read endpoints (specs/100-goals-read/).
+ * Seeds goal + summary rows directly in D1 to exercise list, single-goal,
+ * filter semantics, snoozed override, inverse goals, cross-user isolation,
+ * and authentication.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("summaries", "goals", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function auth(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+interface SeedGoalInput {
+  ownerId: string;
+  title?: string;
+  type?: "coding" | "languages" | "editors" | "projects";
+  delta?: "day" | "week";
+  target?: number;
+  isSnoozed?: boolean;
+  isInverse?: boolean;
+  languages?: string[];
+  editors?: string[];
+  projects?: string[];
+  createdAt?: string;
+}
+
+async function seedGoal(opts: SeedGoalInput): Promise<string> {
+  const id = crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+                        is_enabled, is_snoozed, is_inverse, languages, editors, projects,
+                        created_at, modified_at)
+     VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?,
+             COALESCE(?, datetime('now')), datetime('now'))`,
+  )
+    .bind(
+      id,
+      opts.ownerId,
+      opts.title ?? "Test goal",
+      opts.type ?? "coding",
+      opts.delta ?? "day",
+      opts.target ?? 3600,
+      opts.isSnoozed ? 1 : 0,
+      opts.isInverse ? 1 : 0,
+      opts.languages ? JSON.stringify(opts.languages) : null,
+      opts.editors ? JSON.stringify(opts.editors) : null,
+      opts.projects ? JSON.stringify(opts.projects) : null,
+      opts.createdAt ?? null,
+    )
+    .run();
+  return id;
+}
+
+async function seedSummary(opts: {
+  userId: string;
+  date: string;
+  totalSeconds: number;
+  language?: string;
+  editor?: string;
+  project?: string;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO summaries (user_id, date, project, language, editor, total_seconds)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      opts.userId,
+      opts.date,
+      opts.project ?? null,
+      opts.language ?? null,
+      opts.editor ?? null,
+      opts.totalSeconds,
+    )
+    .run();
+}
+
+function todayUtcIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function utcDateOffset(daysBack: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysBack);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("GET /api/v1/users/current/goals (list)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call("/api/v1/users/current/goals");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns {data:[]} for a user with no goals", async () => {
+    const res = await call("/api/v1/users/current/goals", { headers: auth(user.apiKey) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it("returns goals ordered by created_at ASC, without chart_data or status", async () => {
+    await seedGoal({ ownerId: user.userId, title: "first", createdAt: "2026-05-01 10:00:00" });
+    await seedGoal({ ownerId: user.userId, title: "second", createdAt: "2026-05-02 10:00:00" });
+    await seedGoal({ ownerId: user.userId, title: "third", createdAt: "2026-05-03 10:00:00" });
+
+    const res = await call("/api/v1/users/current/goals", { headers: auth(user.apiKey) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<Record<string, unknown>> };
+    expect(body.data.map((g) => g.title)).toEqual(["first", "second", "third"]);
+    for (const g of body.data) {
+      expect(g).not.toHaveProperty("chart_data");
+      expect(g).not.toHaveProperty("status");
+    }
+  });
+
+  it("isolates results to the authenticated user", async () => {
+    const other = await seedUser({ username: "bob" });
+    await seedGoal({ ownerId: user.userId, title: "mine" });
+    await seedGoal({ ownerId: other.userId, title: "theirs" });
+
+    const res = await call("/api/v1/users/current/goals", { headers: auth(user.apiKey) });
+    const body = (await res.json()) as { data: Array<{ title: string }> };
+    expect(body.data.map((g) => g.title)).toEqual(["mine"]);
+
+    await env.KV.delete(`apikey:${other.apiKeyHash}`);
+  });
+
+  it("decodes JSON filter columns into arrays and tolerates invalid JSON", async () => {
+    // Valid JSON
+    const goodId = await seedGoal({
+      ownerId: user.userId,
+      type: "languages",
+      languages: ["TypeScript", "Go"],
+    });
+    // Manually corrupt one goal's languages column
+    await env.DB.prepare(
+      "UPDATE goals SET languages = 'not-valid-json' WHERE id = ?",
+    ).bind(goodId).run();
+    const goodId2 = await seedGoal({
+      ownerId: user.userId,
+      type: "editors",
+      editors: ["VSCode"],
+    });
+
+    const res = await call("/api/v1/users/current/goals", { headers: auth(user.apiKey) });
+    const body = (await res.json()) as { data: Array<{ id: string; languages: string[]; editors: string[] }> };
+    const corrupted = body.data.find((g) => g.id === goodId);
+    const intact = body.data.find((g) => g.id === goodId2);
+    expect(corrupted?.languages).toEqual([]);
+    expect(intact?.editors).toEqual(["VSCode"]);
+  });
+});
+
+describe("GET /api/v1/users/current/goals/:goal_id (single)", () => {
+  it("returns 404 for unknown goal IDs", async () => {
+    const res = await call("/api/v1/users/current/goals/missing", {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the goal belongs to another user (no 403 / no leak)", async () => {
+    const other = await seedUser({ username: "carol" });
+    const otherGoal = await seedGoal({ ownerId: other.userId });
+
+    const res = await call(`/api/v1/users/current/goals/${otherGoal}`, {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(404);
+
+    await env.KV.delete(`apikey:${other.apiKeyHash}`);
+  });
+
+  it("returns 7-entry chart_data with last entry pending and correct daily actuals", async () => {
+    const goalId = await seedGoal({
+      ownerId: user.userId,
+      type: "coding",
+      delta: "day",
+      target: 3600,
+    });
+
+    // Seed a few daily summaries within the 7-day window.
+    const today = todayUtcIso();
+    const yesterday = utcDateOffset(1);
+    const dayBefore = utcDateOffset(2);
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 7200, project: "p" });
+    await seedSummary({ userId: user.userId, date: dayBefore, totalSeconds: 100, project: "p" });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        chart_data: Array<{ actual_seconds: number; goal_seconds: number; range_status: string; range: { date: string } }>;
+        status: string;
+      };
+    };
+    expect(body.data.chart_data).toHaveLength(7);
+    expect(body.data.chart_data[body.data.chart_data.length - 1].range_status).toBe("pending");
+    expect(body.data.chart_data[body.data.chart_data.length - 1].range.date).toBe(today);
+
+    // Find the per-date entries we seeded.
+    const yesterdayEntry = body.data.chart_data.find((e) => e.range.date === yesterday);
+    const dayBeforeEntry = body.data.chart_data.find((e) => e.range.date === dayBefore);
+    expect(yesterdayEntry?.actual_seconds).toBe(7200);
+    expect(yesterdayEntry?.range_status).toBe("success"); // 7200 >= 3600
+    expect(dayBeforeEntry?.actual_seconds).toBe(100);
+    expect(dayBeforeEntry?.range_status).toBe("fail"); // 100 < 3600
+
+    expect(body.data.status).toBe(yesterdayEntry?.range_status);
+    expect(body.data.chart_data.every((e) => e.goal_seconds === 3600)).toBe(true);
+  });
+
+  it("applies the languages filter to actual_seconds", async () => {
+    const goalId = await seedGoal({
+      ownerId: user.userId,
+      type: "languages",
+      delta: "day",
+      target: 60,
+      languages: ["TypeScript"],
+    });
+
+    const yesterday = utcDateOffset(1);
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 600, language: "TypeScript" });
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 9999, language: "Python" });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+    const body = (await res.json()) as { data: { chart_data: Array<{ range: { date: string }; actual_seconds: number }> } };
+    const entry = body.data.chart_data.find((e) => e.range.date === yesterday);
+    expect(entry?.actual_seconds).toBe(600);
+  });
+
+  it("returns zero actuals (and no DB scan effects) when a filtered goal has empty filter array", async () => {
+    const goalId = await seedGoal({
+      ownerId: user.userId,
+      type: "languages",
+      delta: "day",
+      target: 60,
+      languages: [], // matches nothing by intent
+    });
+
+    const yesterday = utcDateOffset(1);
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 600, language: "TypeScript" });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+    const body = (await res.json()) as { data: { chart_data: Array<{ actual_seconds: number; range_status: string }> } };
+    expect(body.data.chart_data.every((e) => e.actual_seconds === 0)).toBe(true);
+    // All completed periods fail (0 < 60); the last is pending.
+    expect(body.data.chart_data.slice(0, -1).every((e) => e.range_status === "fail")).toBe(true);
+    expect(body.data.chart_data[body.data.chart_data.length - 1].range_status).toBe("pending");
+  });
+
+  it("inverse goal: under-target days succeed, over-target days fail", async () => {
+    const goalId = await seedGoal({
+      ownerId: user.userId,
+      type: "coding",
+      delta: "day",
+      target: 1800,
+      isInverse: true,
+    });
+
+    const yesterday = utcDateOffset(1);
+    const dayBefore = utcDateOffset(2);
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 600, project: "p" });
+    await seedSummary({ userId: user.userId, date: dayBefore, totalSeconds: 3600, project: "p" });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+    const body = (await res.json()) as { data: { chart_data: Array<{ range: { date: string }; range_status: string }> } };
+    expect(body.data.chart_data.find((e) => e.range.date === yesterday)?.range_status).toBe("success");
+    expect(body.data.chart_data.find((e) => e.range.date === dayBefore)?.range_status).toBe("fail");
+  });
+
+  it("snoozed goal: top-level status is 'pending' but per-period statuses are computed normally", async () => {
+    const goalId = await seedGoal({
+      ownerId: user.userId,
+      type: "coding",
+      delta: "day",
+      target: 3600,
+      isSnoozed: true,
+    });
+
+    const yesterday = utcDateOffset(1);
+    await seedSummary({ userId: user.userId, date: yesterday, totalSeconds: 7200, project: "p" });
+
+    const res = await call(`/api/v1/users/current/goals/${goalId}`, {
+      headers: auth(user.apiKey),
+    });
+    const body = (await res.json()) as {
+      data: { status: string; chart_data: Array<{ range: { date: string }; range_status: string }> };
+    };
+    expect(body.data.status).toBe("pending");
+    // The per-period status for the seeded day is still correctly computed.
+    expect(body.data.chart_data.find((e) => e.range.date === yesterday)?.range_status).toBe("success");
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of the SpecKit 2-PR workflow for Goals read endpoints. Wires `getGoals` and `getGoal` (declared in OpenAPI and tightened to the `Goal` / `GoalWithChart` split in #95) to real handlers backed by the existing `goals` and `summaries` D1 tables.

## Endpoints

| | List | Single |
|---|---|---|
| Method/path | `GET /api/v1/users/current/goals` | `GET /api/v1/users/current/goals/{goal_id}` |
| Auth | API key or session via `authMiddleware` | same |
| Response | `{ data: Goal[] }` ordered by `created_at` ASC | `{ data: GoalWithChart }` — 7-period chart + status |
| Cross-user | n/a (isolated to caller) | 404 (no existence leak) |

## Files

| Area | Files |
|---|---|
| Pure helpers | `src/utils/goal-chart.ts` (buildDay/WeekRanges, classifyRange, topStatus, rebucketWeekly, buildChart) |
| Handlers | `src/routes/goals.ts` |
| Wiring | `src/index.ts` |
| Tests | `tests/aggregation/goal-chart.test.ts` (17), `tests/integration/goals-read.test.ts` (12) |

## Design highlights (from PR1 `research.md`)

- **Read from `summaries`**, never from `heartbeats` — pre-aggregated; stays inside the 10ms CPU budget on free tier.
- **Joined goal query**: a single `SELECT g.*, u.timezone FROM goals g JOIN users u ON …` pulls the user's profile timezone with the goal row — no separate timezone lookup.
- **ISO 8601 Monday-Sunday weeks** in the user's profile timezone. Aggregated daily totals are re-bucketed into weekly Mondays in TypeScript so the SQL stays one query.
- **Empty filter array short-circuit**: a `type=languages` goal with `languages: []` skips the summaries scan entirely and returns 7 zeros.
- **Defensive JSON decode**: malformed `languages/editors/projects` columns become `[]` with a `console.warn` carrying only the goal id (never the raw value).
- **DST-correct day boundaries** via the existing `time-format` helper (already used by `/summaries`, `/stats`, `/durations`).
- **404 for cross-user / unknown IDs** to avoid information leaks.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — **110/110** pass (81 prior + 17 new unit + 12 new integration)
- [x] No diff in `src/routes/heartbeats.ts`, `src/routes/summaries.ts`, `src/routes/stats.ts`, or any auth-flow file
- [ ] CI workflow runs green
- [ ] Manual quickstart scenario C against staging (chart correctness over a known summaries fixture)
- [ ] Manual quickstart scenario J against staging (non-UTC timezone bucketing)

## Out of scope

- CRUD on goals (POST/PATCH/DELETE). A separate spec will add it later.
- Notification/email when status flips.
- Goal templates or recommendations.
- History beyond 7 periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)