### PR TITLE
feat: user_agents list endpoint and Goals filter params (#105 #111)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import summaries from "./routes/summaries";
 import stats from "./routes/stats";
 import users from "./routes/users";
 import goals from "./routes/goals";
+import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -122,6 +123,9 @@ app.route("/api/v1/users/current", users);
 
 // Goals routes (mounted at /users/current, sub-app defines /goals, /goals/:goal_id)
 app.route("/api/v1/users/current", goals);
+
+// User agents routes (mounted at /users/current, sub-app defines /user_agents)
+app.route("/api/v1/users/current", userAgents);
 
 // Cron trigger handler for periodic aggregation + session cleanup
 export default {

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -85,15 +85,50 @@ const goals = new Hono<AuthEnv>();
 goals.use("/goals", authMiddleware);
 goals.use("/goals/*", authMiddleware);
 
+/**
+ * Parse a boolean-ish query parameter. Accepts common truthy/falsy aliases.
+ * Returns `undefined` when the param is absent and `null` when the value is
+ * unrecognised so the caller can reject with 400.
+ */
+function parseBoolQuery(raw: string | undefined): boolean | null | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.toLowerCase();
+  if (v === "true" || v === "1") return true;
+  if (v === "false" || v === "0") return false;
+  return null;
+}
+
 goals.get("/goals", async (c) => {
   const userId = c.get("userId");
+
+  // Issue #111: optional filters on the persisted boolean columns.
+  const enabledFilter = parseBoolQuery(c.req.query("enabled"));
+  const snoozedFilter = parseBoolQuery(c.req.query("snoozed"));
+  if (enabledFilter === null) {
+    return c.json({ error: "Invalid enabled query parameter; expected true|false" }, 400);
+  }
+  if (snoozedFilter === null) {
+    return c.json({ error: "Invalid snoozed query parameter; expected true|false" }, 400);
+  }
+
+  const conditions: string[] = ["user_id = ?"];
+  const binds: (string | number)[] = [userId];
+  if (enabledFilter !== undefined) {
+    conditions.push("is_enabled = ?");
+    binds.push(enabledFilter ? 1 : 0);
+  }
+  if (snoozedFilter !== undefined) {
+    conditions.push("is_snoozed = ?");
+    binds.push(snoozedFilter ? 1 : 0);
+  }
+
   try {
     const { results } = await c.env.DB.prepare(
       `SELECT ${GOAL_COLUMNS} FROM goals
-        WHERE user_id = ?
+        WHERE ${conditions.join(" AND ")}
         ORDER BY created_at ASC`,
     )
-      .bind(userId)
+      .bind(...binds)
       .all<GoalRow>();
     return c.json({ data: results.map(rowToGoal) });
   } catch (err) {

--- a/src/routes/user-agents.ts
+++ b/src/routes/user-agents.ts
@@ -1,0 +1,66 @@
+/**
+ * Read-only endpoint exposing the user_agents resolved by heartbeat
+ * ingestion (Issue #105).
+ *
+ * The `user_agents` table is populated server-side as each heartbeat is
+ * received (see src/utils/user-agent.ts). This route surfaces those rows so
+ * that clients / dashboards can show a per-plugin breakdown of activity.
+ */
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { normalizeDateTime } from "../utils/user";
+
+type UserAgent = components["schemas"]["UserAgent"];
+
+interface UserAgentRow {
+  id: string;
+  value: string;
+  editor: string | null;
+  version: string | null;
+  os: string | null;
+  is_browser_extension: number;
+  is_desktop_app: number;
+  last_seen_at: string;
+  created_at: string;
+}
+
+function rowToUserAgent(row: UserAgentRow): UserAgent {
+  return {
+    id: row.id,
+    value: row.value,
+    editor: row.editor ?? undefined,
+    version: row.version ?? undefined,
+    os: row.os ?? undefined,
+    is_browser_extension: row.is_browser_extension === 1,
+    is_desktop_app: row.is_desktop_app === 1,
+    last_seen_at: normalizeDateTime(row.last_seen_at),
+    created_at: normalizeDateTime(row.created_at),
+  };
+}
+
+const userAgents = new Hono<AuthEnv>();
+
+userAgents.use("/user_agents", authMiddleware);
+
+userAgents.get("/user_agents", async (c) => {
+  const userId = c.get("userId");
+  try {
+    const { results } = await c.env.DB.prepare(
+      `SELECT id, value, editor, version, os, is_browser_extension,
+              is_desktop_app, last_seen_at, created_at
+         FROM user_agents
+        WHERE user_id = ?
+        ORDER BY last_seen_at DESC`,
+    )
+      .bind(userId)
+      .all<UserAgentRow>();
+    return c.json({ data: results.map(rowToUserAgent) });
+  } catch (err) {
+    console.error("GET /user_agents error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default userAgents;

--- a/tests/integration/goals-list-filters.test.ts
+++ b/tests/integration/goals-list-filters.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for GET /api/v1/users/current/goals filter parameters
+ * (Issue #111).
+ *
+ * Seeds four goals covering every combination of (is_enabled, is_snoozed)
+ * and verifies that each combination of `?enabled=` / `?snoozed=` filters
+ * returns the expected subset.
+ */
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice" });
+});
+
+afterEach(async () => {
+  await truncate("goals", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`https://test.cloudtime.dev${path}`, init),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function auth(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+async function seedGoal(opts: {
+  userId: string;
+  title: string;
+  isEnabled?: boolean;
+  isSnoozed?: boolean;
+  createdAt?: string;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+                        is_enabled, is_snoozed, is_inverse,
+                        created_at, modified_at)
+     VALUES (?, ?, ?, 'coding', 'day', 3600,
+             ?, ?, 0,
+             COALESCE(?, datetime('now')), datetime('now'))`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      opts.userId,
+      opts.title,
+      opts.isEnabled === false ? 0 : 1,
+      opts.isSnoozed ? 1 : 0,
+      opts.createdAt ?? null,
+    )
+    .run();
+}
+
+beforeEach(async () => {
+  await seedGoal({ userId: user.userId, title: "active",       isEnabled: true,  isSnoozed: false, createdAt: "2026-05-01 10:00:00" });
+  await seedGoal({ userId: user.userId, title: "snoozed",      isEnabled: true,  isSnoozed: true,  createdAt: "2026-05-02 10:00:00" });
+  await seedGoal({ userId: user.userId, title: "disabled",     isEnabled: false, isSnoozed: false, createdAt: "2026-05-03 10:00:00" });
+  await seedGoal({ userId: user.userId, title: "disabled+snz", isEnabled: false, isSnoozed: true,  createdAt: "2026-05-04 10:00:00" });
+});
+
+async function listGoals(query: string): Promise<string[]> {
+  const res = await call(`/api/v1/users/current/goals${query}`, {
+    headers: auth(user.apiKey),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { data: Array<{ title: string }> };
+  return body.data.map((g) => g.title);
+}
+
+describe("GET /goals filter query parameters (#111)", () => {
+  it("no filter returns all 4 goals", async () => {
+    expect(await listGoals("")).toEqual(["active", "snoozed", "disabled", "disabled+snz"]);
+  });
+
+  it("enabled=true returns only enabled goals (both snoozed and not)", async () => {
+    expect(await listGoals("?enabled=true")).toEqual(["active", "snoozed"]);
+  });
+
+  it("enabled=false returns only disabled goals", async () => {
+    expect(await listGoals("?enabled=false")).toEqual(["disabled", "disabled+snz"]);
+  });
+
+  it("snoozed=true returns only snoozed goals (regardless of enabled flag)", async () => {
+    expect(await listGoals("?snoozed=true")).toEqual(["snoozed", "disabled+snz"]);
+  });
+
+  it("snoozed=false returns only non-snoozed goals", async () => {
+    expect(await listGoals("?snoozed=false")).toEqual(["active", "disabled"]);
+  });
+
+  it("enabled=true&snoozed=false returns the single 'active' goal", async () => {
+    expect(await listGoals("?enabled=true&snoozed=false")).toEqual(["active"]);
+  });
+
+  it("accepts 1 / 0 as truthy / falsy values", async () => {
+    expect(await listGoals("?enabled=1&snoozed=0")).toEqual(["active"]);
+    expect(await listGoals("?enabled=0")).toEqual(["disabled", "disabled+snz"]);
+  });
+
+  it("rejects an invalid boolean value with 400", async () => {
+    const res = await call("/api/v1/users/current/goals?enabled=maybe", {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/user-agents-list.test.ts
+++ b/tests/integration/user-agents-list.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Integration tests for GET /api/v1/users/current/user_agents (Issue #105).
+ * The table is populated by heartbeat ingestion (Issue #99); these tests seed
+ * rows directly so the endpoint can be exercised without the full POST path.
+ */
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice" });
+});
+
+afterEach(async () => {
+  await truncate("user_agents", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`https://test.cloudtime.dev${path}`, init),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function auth(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+async function seedUserAgent(opts: {
+  userId: string;
+  value: string;
+  editor?: string;
+  version?: string;
+  os?: string;
+  lastSeenAt?: string;
+  createdAt?: string;
+}): Promise<string> {
+  const id = crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO user_agents (id, user_id, value, editor, version, os, last_seen_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), COALESCE(?, datetime('now')))`,
+  )
+    .bind(
+      id,
+      opts.userId,
+      opts.value,
+      opts.editor ?? null,
+      opts.version ?? null,
+      opts.os ?? null,
+      opts.lastSeenAt ?? null,
+      opts.createdAt ?? null,
+    )
+    .run();
+  return id;
+}
+
+describe("GET /api/v1/users/current/user_agents", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call("/api/v1/users/current/user_agents");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns {data: []} when no rows exist", async () => {
+    const res = await call("/api/v1/users/current/user_agents", {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it("returns user_agents ordered by last_seen_at DESC, isolated to the caller", async () => {
+    // Seed three for our user with different last_seen_at, plus one for a
+    // different user that must not appear in the response.
+    await seedUserAgent({
+      userId: user.userId,
+      value: "plugin-client/v1 (linux-1-amd64) runtime editor-a/1.0.0",
+      editor: "editor-a",
+      version: "1.0.0",
+      os: "linux",
+      lastSeenAt: "2026-05-01 10:00:00",
+      createdAt: "2026-04-01 10:00:00",
+    });
+    await seedUserAgent({
+      userId: user.userId,
+      value: "plugin-client/v1 (darwin-1-arm64) runtime editor-b/14.0.3",
+      editor: "editor-b",
+      version: "14.0.3",
+      os: "darwin",
+      lastSeenAt: "2026-05-17 12:00:00",
+      createdAt: "2026-04-17 12:00:00",
+    });
+    await seedUserAgent({
+      userId: user.userId,
+      value: "plugin-client/v1 (windows-10-amd64) runtime editor-c/9.0.0",
+      editor: "editor-c",
+      version: "9.0.0",
+      os: "windows",
+      lastSeenAt: "2026-05-10 08:00:00",
+      createdAt: "2026-04-10 08:00:00",
+    });
+
+    const other = await seedUser({ username: "bob" });
+    await seedUserAgent({
+      userId: other.userId,
+      value: "plugin-client/v1 (linux-1-amd64) runtime editor-d/1.0.0",
+    });
+
+    const res = await call("/api/v1/users/current/user_agents", {
+      headers: auth(user.apiKey),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{
+        editor?: string;
+        os?: string;
+        value: string;
+        last_seen_at: string;
+        created_at: string;
+      }>;
+    };
+    expect(body.data.map((ua) => ua.editor)).toEqual([
+      "editor-b",
+      "editor-c",
+      "editor-a",
+    ]);
+    expect(body.data[0].last_seen_at).toBe("2026-05-17T12:00:00Z");
+    expect(body.data[0].created_at).toBe("2026-04-17T12:00:00Z");
+    // No leak from the other user.
+    expect(body.data.some((ua) => ua.value.includes("editor-d"))).toBe(false);
+
+    await env.KV.delete(`apikey:${other.apiKeyHash}`);
+  });
+
+  it("converts INTEGER 0/1 boolean columns to proper booleans in the response", async () => {
+    const id = crypto.randomUUID();
+    await env.DB.prepare(
+      `INSERT INTO user_agents (id, user_id, value, is_browser_extension, is_desktop_app)
+       VALUES (?, ?, ?, 1, 0)`,
+    )
+      .bind(id, user.userId, "plugin-client/v1 (linux-1-amd64) runtime web/1.0")
+      .run();
+
+    const res = await call("/api/v1/users/current/user_agents", {
+      headers: auth(user.apiKey),
+    });
+    const body = (await res.json()) as {
+      data: Array<{ is_browser_extension: unknown; is_desktop_app: unknown }>;
+    };
+    expect(body.data[0].is_browser_extension).toBe(true);
+    expect(body.data[0].is_desktop_app).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR after the spec-only precursor in #114.

### #105 - GET /users/current/user_agents

The `getUserAgents` operation was already declared in OpenAPI but had no route. This PR adds the read endpoint that surfaces rows populated during heartbeat ingestion.

- Auth: API key or session via `authMiddleware`.
- Response: `{ data: UserAgent[] }` ordered by `last_seen_at DESC`.
- Strict per-user isolation.
- INTEGER 0/1 columns (`is_browser_extension`, `is_desktop_app`) come back as booleans.
- SQLite datetime columns are normalized to OpenAPI `date-time` strings.

### #111 - GET /goals filter parameters

Implements optional `?enabled=true|false` and `?snoozed=true|false` on the existing list endpoint. Both filters are AND'd when supplied, and `1` / `0` aliases are accepted. Behavior without params is unchanged.

OpenAPI and generated type changes were split into #114 and merged before this implementation PR.

## Files

| File | Change |
|---|---|
| `src/routes/user-agents.ts` | List handler for #105 |
| `src/index.ts` | Mount the sub-app at `/api/v1/users/current` |
| `src/routes/goals.ts` | `parseBoolQuery` helper + filter SQL fragments |
| `tests/integration/user-agents-list.test.ts` | User-agent list coverage |
| `tests/integration/goals-list-filters.test.ts` | Goal filter coverage |

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test`
- [ ] CI runs green

Closes #105.
Closes #111.