### PR TITLE
spec: add goals list filter parameters

### DIFF
--- a/schemas/paths/goals/goals.yaml
+++ b/schemas/paths/goals/goals.yaml
@@ -10,6 +10,27 @@ get:
     endpoint — clients that need per-period progress must request each goal
     individually via
     `GET /users/current/goals/{goal_id}`.
+
+    Optional `enabled` and `snoozed` query parameters filter on
+    `is_enabled` / `is_snoozed` respectively. Omitting a filter returns
+    goals regardless of that flag. When both are provided they are AND'd.
+  parameters:
+    - name: enabled
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: |
+        When `true`, return only enabled goals. When `false`, only disabled
+        goals. Omit to include both.
+    - name: snoozed
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: |
+        When `true`, return only snoozed goals. When `false`, only
+        non-snoozed goals. Omit to include both.
   responses:
     '200':
       description: List of goals

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -613,6 +613,10 @@ export interface paths {
          *     endpoint — clients that need per-period progress must request each goal
          *     individually via
          *     `GET /users/current/goals/{goal_id}`.
+         *
+         *     Optional `enabled` and `snoozed` query parameters filter on
+         *     `is_enabled` / `is_snoozed` respectively. Omitting a filter returns
+         *     goals regardless of that flag. When both are provided they are AND'd.
          */
         get: operations["getGoals"];
         put?: never;
@@ -2563,7 +2567,18 @@ export interface operations {
     };
     getGoals: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description When `true`, return only enabled goals. When `false`, only disabled
+                 *     goals. Omit to include both.
+                 */
+                enabled?: boolean;
+                /**
+                 * @description When `true`, return only snoozed goals. When `false`, only
+                 *     non-snoozed goals. Omit to include both.
+                 */
+                snoozed?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;


### PR DESCRIPTION
## Summary

Spec-only precursor for PR #113.

- Adds optional nabled and snoozed query parameters to GET /users/current/goals.
- Regenerates OpenAPI TypeScript types from the schema.

## Test plan

- [x] 
pm run generate`n- [x] 
px tsc --noEmit`n
Part of #111.