### PR TITLE
docs: deployment + backup/restore operator guides (#109 #110)

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -2,7 +2,7 @@
 
 This guide covers operator-managed backups of the CloudTime D1 database. Cloudflare provides account-level snapshots, but operator-driven exports remain necessary for migration, schema-change confidence, and self-managed retention.
 
-> **Scope**: only the D1 database needs backup. KV is a cache (auth lookups, OAuth state, Google JWKS) and re-warms automatically after restore.
+> **Scope**: only the D1 database needs durable backup. KV is a cache (auth lookups, OAuth state, Google JWKS), but stale auth cache entries must be cleared or replaced after a D1 restore.
 
 ---
 
@@ -11,7 +11,7 @@ This guide covers operator-managed backups of the CloudTime D1 database. Cloudfl
 | Resource | Backup needed? | Why |
 |---|---|---|
 | `cloudtime-db` (D1) | **Yes** | Source of truth for users, heartbeats, summaries, goals, sessions, oauth_accounts, pending_links, user_agents, machine_names, … |
-| `CLOUDTIME_KV` (KV) | No | Cache only. Keys: `apikey:<hash>`, `session:<hash>`, `oauth:state:<state>`, `google:jwks`. All TTL-bound and reconstructable. |
+| `CLOUDTIME_KV` (KV) | No, but clear on restore | Cache only. Keys: `apikey:<hash>`, `session:<hash>`, `oauth:state:<state>`, `google:jwks`. All TTL-bound and reconstructable, but stale auth caches can briefly outlive a D1 rollback unless purged. |
 | Worker secrets | Track elsewhere | `wrangler secret put` values (OAuth client secrets, `ENCRYPTION_KEY`, `RESEND_API_KEY`). Store these in a password manager — there is no `wrangler secret get`. |
 | Source code | Yes, via Git | This repo is the source; tag releases for the version actually deployed. |
 
@@ -138,6 +138,23 @@ wrangler d1 execute cloudtime-db --remote --command "
 wrangler d1 execute cloudtime-db --remote --file=backup-20260518-090000.sql
 ```
 
+Then clear `CLOUDTIME_KV` before sending traffic back to the Worker. At minimum remove auth-related cache keys:
+
+```bash
+wrangler kv key list --binding=CLOUDTIME_KV --remote --prefix=apikey: > kv-apikey.json
+wrangler kv key list --binding=CLOUDTIME_KV --remote --prefix=session: > kv-session.json
+wrangler kv bulk delete kv-apikey.json --binding=CLOUDTIME_KV --remote
+wrangler kv bulk delete kv-session.json --binding=CLOUDTIME_KV --remote
+```
+
+The safer option is to create a fresh KV namespace, update `wrangler.toml`, and redeploy:
+
+```bash
+wrangler kv namespace create CLOUDTIME_KV
+# update wrangler.toml with the new id
+wrangler deploy
+```
+
 In practice it's simpler to drop and recreate the database entirely:
 
 ```bash
@@ -145,6 +162,8 @@ wrangler d1 delete cloudtime-db
 wrangler d1 create cloudtime-db          # writes a new database_id
 # update wrangler.toml with the new id
 wrangler d1 execute cloudtime-db --remote --file=backup-20260518-090000.sql
+wrangler kv namespace create CLOUDTIME_KV # writes a new id
+# update wrangler.toml with the new KV id too, or otherwise clear old auth cache keys
 wrangler deploy
 ```
 
@@ -156,6 +175,8 @@ Useful for migration to a new Cloudflare account or environment:
 wrangler d1 create cloudtime-db-restored
 # add a new [[d1_databases]] block in wrangler.toml pointing at this DB
 wrangler d1 execute cloudtime-db-restored --remote --file=backup-20260518-090000.sql
+wrangler kv namespace create CLOUDTIME_KV_RESTORED
+# bind CLOUDTIME_KV to the new namespace id for the restored environment
 
 # Swap the binding name once verified, then redeploy
 wrangler deploy
@@ -166,6 +187,7 @@ wrangler deploy
 After restore, walk through this list before relying on the instance:
 
 - [ ] `GET /api/v1/health` returns 200.
+- [ ] `CLOUDTIME_KV` was recreated or auth cache keys (`apikey:*`, `session:*`) were purged before traffic resumed.
 - [ ] `GET /api/v1/users/current` with your stored API key returns your profile (proves the row + `api_key_hash` survived).
 - [ ] Send one test heartbeat; verify it appears in `SELECT * FROM heartbeats ORDER BY time DESC LIMIT 1`.
 - [ ] Wait for one cron cycle (≤1 hour) and confirm `summaries` aggregation runs without errors (`wrangler tail`).

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,205 @@
+# Backup and Restore
+
+This guide covers operator-managed backups of the CloudTime D1 database. Cloudflare provides account-level snapshots, but operator-driven exports remain necessary for migration, schema-change confidence, and self-managed retention.
+
+> **Scope**: only the D1 database needs backup. KV is a cache (auth lookups, OAuth state, Google JWKS) and re-warms automatically after restore.
+
+---
+
+## What to back up
+
+| Resource | Backup needed? | Why |
+|---|---|---|
+| `cloudtime-db` (D1) | **Yes** | Source of truth for users, heartbeats, summaries, goals, sessions, oauth_accounts, pending_links, user_agents, machine_names, … |
+| `CLOUDTIME_KV` (KV) | No | Cache only. Keys: `apikey:<hash>`, `session:<hash>`, `oauth:state:<state>`, `google:jwks`. All TTL-bound and reconstructable. |
+| Worker secrets | Track elsewhere | `wrangler secret put` values (OAuth client secrets, `ENCRYPTION_KEY`, `RESEND_API_KEY`). Store these in a password manager — there is no `wrangler secret get`. |
+| Source code | Yes, via Git | This repo is the source; tag releases for the version actually deployed. |
+
+### Critical: protect `ENCRYPTION_KEY`
+
+OAuth tokens (`access_token_encrypted`, `refresh_token_encrypted`) are stored encrypted with `ENCRYPTION_KEY` using AES-256-GCM. A D1 export by itself is **useless** for restoring those tokens unless you also have the matching encryption key.
+
+- **Losing the key** means all stored OAuth tokens become unrecoverable. Users can re-authenticate via OAuth; no data is lost beyond cached tokens.
+- **Rotating the key** without re-encrypting will break decryption of existing rows.
+
+Store the key in two places (e.g., password manager + offline backup). Never commit it to git.
+
+---
+
+## Backup: manual export
+
+The simplest backup is a SQL dump:
+
+```bash
+wrangler d1 export cloudtime-db --remote --output backup-$(date +%Y%m%d-%H%M%S).sql
+```
+
+This produces a single `.sql` file containing schema + all rows. For a typical single-user deployment with a year of heartbeats, expect 50–500 MB depending on coding intensity.
+
+### Sanity-check the dump
+
+```bash
+# Open in sqlite3 locally and confirm row counts
+sqlite3 :memory: <<EOF
+.read backup-20260518-090000.sql
+SELECT COUNT(*) FROM heartbeats;
+SELECT COUNT(*) FROM summaries;
+SELECT COUNT(*) FROM users;
+EOF
+```
+
+If you see your expected counts, the dump is good. Store it somewhere durable (cloud storage, encrypted external drive, etc.).
+
+---
+
+## Backup: scheduled / unattended
+
+For a single-user deployment, weekly is usually enough; daily is safer if your heartbeat throughput is high.
+
+### Option A — GitHub Actions
+
+`.github/workflows/d1-backup.yml` example:
+
+```yaml
+name: D1 backup
+
+on:
+  schedule:
+    - cron: "0 3 * * *"   # daily at 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install wrangler
+        run: npm install -g wrangler@latest
+
+      - name: Export D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler d1 export cloudtime-db --remote \
+            --output backup-$(date +%Y%m%d).sql
+
+      - name: Upload to artifact store
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudtime-d1-${{ github.run_id }}
+          path: backup-*.sql
+          retention-days: 90
+```
+
+The Cloudflare API token needs `D1:Edit` permission on the account. GitHub Actions artifacts have a 90-day default retention; bump it or push to an external store (R2, S3, your own backup target) for longer keeps.
+
+### Option B — cron on a self-managed host
+
+If you have a VPS or home server running 24/7:
+
+```bash
+# /etc/cron.daily/cloudtime-backup
+#!/bin/bash
+set -euo pipefail
+cd /path/to/cloudtime
+wrangler d1 export cloudtime-db --remote \
+  --output /var/backups/cloudtime/backup-$(date +%Y%m%d).sql
+find /var/backups/cloudtime -name "backup-*.sql" -mtime +30 -delete
+```
+
+Make it executable: `chmod +x /etc/cron.daily/cloudtime-backup`. Adjust retention (`-mtime +30` keeps 30 days).
+
+---
+
+## Restore
+
+Restore is **destructive** — it replaces all data in the target D1. Be intentional.
+
+### Restoring to the same database
+
+If you want to roll back the existing database:
+
+```bash
+# 1. WARNING: this wipes the current database
+wrangler d1 execute cloudtime-db --remote --command "
+  DROP TABLE IF EXISTS heartbeats;
+  DROP TABLE IF EXISTS summaries;
+  DROP TABLE IF EXISTS users;
+  -- … list every table here, or recreate from schema.sql
+"
+
+# 2. Replay the backup
+wrangler d1 execute cloudtime-db --remote --file=backup-20260518-090000.sql
+```
+
+In practice it's simpler to drop and recreate the database entirely:
+
+```bash
+wrangler d1 delete cloudtime-db
+wrangler d1 create cloudtime-db          # writes a new database_id
+# update wrangler.toml with the new id
+wrangler d1 execute cloudtime-db --remote --file=backup-20260518-090000.sql
+wrangler deploy
+```
+
+### Restoring to a fresh database
+
+Useful for migration to a new Cloudflare account or environment:
+
+```bash
+wrangler d1 create cloudtime-db-restored
+# add a new [[d1_databases]] block in wrangler.toml pointing at this DB
+wrangler d1 execute cloudtime-db-restored --remote --file=backup-20260518-090000.sql
+
+# Swap the binding name once verified, then redeploy
+wrangler deploy
+```
+
+### Post-restore checklist
+
+After restore, walk through this list before relying on the instance:
+
+- [ ] `GET /api/v1/health` returns 200.
+- [ ] `GET /api/v1/users/current` with your stored API key returns your profile (proves the row + `api_key_hash` survived).
+- [ ] Send one test heartbeat; verify it appears in `SELECT * FROM heartbeats ORDER BY time DESC LIMIT 1`.
+- [ ] Wait for one cron cycle (≤1 hour) and confirm `summaries` aggregation runs without errors (`wrangler tail`).
+- [ ] If OAuth tokens are needed (multi-user mode): re-authenticate each linked provider account, since `ENCRYPTION_KEY` rotation would otherwise leave them undecryptable.
+
+---
+
+## What gets lost between backups
+
+A backup taken at T₀ does **not** include:
+
+- Heartbeats sent between T₀ and the failure / restore moment.
+- Sessions created after T₀ (users will have to log in again — minor friction).
+- Cron `last_aggregated_at` advances after T₀; the next cron run will re-aggregate the gap.
+
+Worker secrets (`ENCRYPTION_KEY`, OAuth client secrets, `RESEND_API_KEY`) are not in the dump. Keep them in your password manager alongside the database backups.
+
+---
+
+## Migration to a new instance
+
+The same export → import flow works to move CloudTime between Cloudflare accounts:
+
+1. Export from the source: `wrangler d1 export cloudtime-db --remote --output snapshot.sql` (with the **source** wrangler login).
+2. On the destination account, complete steps 1–5 of [`deployment-guide.md`](./deployment-guide.md) up to and including secrets, but use the **same `ENCRYPTION_KEY`** as the source so encrypted tokens decrypt correctly.
+3. Initialise the destination D1 schema, then import: `wrangler d1 execute cloudtime-db --remote --file=snapshot.sql`.
+4. Update DNS / `APP_URL` to point at the new Worker URL.
+5. Re-confirm OAuth app redirect URIs match the new URL.
+6. Verify with the post-restore checklist above.
+
+If you intentionally want a fresh `ENCRYPTION_KEY` on the destination, you must accept that all stored OAuth tokens become un-decryptable. Users can re-authenticate via OAuth to repopulate them.
+
+---
+
+## Storage cost considerations
+
+A 100 MB daily backup retained for 90 days = ~9 GB of artifact storage. GitHub Actions artifacts include 500 MB free; beyond that bring your own R2 / S3 / equivalent. If you prefer differential backups, run `wrangler d1 export` weekly and a delta query for incremental rows in between, but for most personal deployments full daily dumps are simpler and cheap enough.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -62,7 +62,7 @@ Set these via `wrangler secret put <NAME>` (each command will prompt for the val
 | `DISCORD_CLIENT_ID` | for Discord login | from Discord Developer Portal |
 | `DISCORD_CLIENT_SECRET` | for Discord login | |
 | `ENCRYPTION_KEY` | **yes** | 64 hex characters (256 bits). Generate with `openssl rand -hex 32` |
-| `APP_URL` | recommended | The public origin of your Worker (e.g. `https://time.example.com`). Used for OAuth redirect URI computation and CSRF origin checks. |
+| `APP_URL` | **yes in production** | The public origin of your Worker (e.g. `https://time.example.com`). Required for OAuth redirect URI computation and CSRF origin checks outside local development. |
 | `GOOGLE_HOSTED_DOMAIN` | optional | Restricts Google login to one Workspace domain. See `specs/037-google-hosted-domain/`. |
 | `EMAIL_PROVIDER` | multi-user only | `resend` is currently the only supported value. |
 | `EMAIL_FROM` | multi-user only | Sender address on a domain you control. |
@@ -153,14 +153,14 @@ If you want to keep accumulated heartbeats but kick out an unintended owner, con
 
 ---
 
-## 9. Configure your WakaTime plugin
+## 9. Configure your WakaTime-compatible editor plugin
 
-Point your editor's WakaTime plugin at your Worker. In `~/.wakatime.cfg`:
+Point your editor's WakaTime-compatible plugin at your Worker. In `~/.wakatime.cfg`:
 
 ```ini
 [settings]
 api_url = https://your-worker.example.com/api/v1
-api_key = ck_<your plaintext key from step 9 of section 8>
+api_key = ck_<your plaintext key from step 3 above>
 ```
 
 Restart your editor. Your IDE's status bar should start showing today's coding time within a few seconds of typing.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,188 @@
+# Deployment Guide
+
+This guide walks an operator through deploying CloudTime to Cloudflare Workers from scratch. It assumes you have a Cloudflare account, the `wrangler` CLI installed, and Node.js 22+ locally.
+
+> **Critical**: read the [First-login owner race](#critical-first-login-owner-race) section before you announce or share the deployment URL. The instance becomes "owned" by whoever completes OAuth login first.
+
+---
+
+## 1. Prerequisites
+
+- Cloudflare account (free plan is sufficient for personal use)
+- `wrangler` CLI ≥ 4.0 (`npm install -g wrangler@latest`)
+- Node.js 22+
+- A registered OAuth app on at least one provider (GitHub / Google / Discord) configured with a redirect URI matching your future Worker URL
+- For multi-user mode: a Resend API key and a verified sender domain (see [`email-setup.md`](./email-setup.md))
+
+## 2. Clone and install
+
+```bash
+git clone https://github.com/sudolifeagain/cloudtime.git
+cd cloudtime
+npm ci
+```
+
+## 3. Provision Cloudflare resources
+
+Create the D1 database and KV namespace, then paste their IDs into `wrangler.toml`.
+
+```bash
+wrangler d1 create cloudtime-db
+# → copy the database_id into wrangler.toml under [[d1_databases]]
+
+wrangler kv namespace create CLOUDTIME_KV
+# → copy the id into wrangler.toml under [[kv_namespaces]]
+```
+
+## 4. Initialise the schema
+
+The schema lives in `src/db/schema.sql`. Run it against your new D1.
+
+```bash
+npm run db:init:remote        # applies src/db/schema.sql to the remote D1
+```
+
+If you redeploy later and there are migration files in `migrations/`, apply them in order:
+
+```bash
+wrangler d1 execute cloudtime-db --remote --file=./migrations/0001_add_email_verified.sql
+wrangler d1 execute cloudtime-db --remote --file=./migrations/0002_pending_link_email_verification.sql
+```
+
+## 5. Configure secrets
+
+Set these via `wrangler secret put <NAME>` (each command will prompt for the value). All are required unless marked optional.
+
+| Secret | Required | Notes |
+|---|---|---|
+| `GITHUB_CLIENT_ID` | for GitHub login | from your GitHub OAuth App |
+| `GITHUB_CLIENT_SECRET` | for GitHub login | |
+| `GOOGLE_CLIENT_ID` | for Google login | from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | for Google login | |
+| `DISCORD_CLIENT_ID` | for Discord login | from Discord Developer Portal |
+| `DISCORD_CLIENT_SECRET` | for Discord login | |
+| `ENCRYPTION_KEY` | **yes** | 64 hex characters (256 bits). Generate with `openssl rand -hex 32` |
+| `APP_URL` | recommended | The public origin of your Worker (e.g. `https://time.example.com`). Used for OAuth redirect URI computation and CSRF origin checks. |
+| `GOOGLE_HOSTED_DOMAIN` | optional | Restricts Google login to one Workspace domain. See `specs/037-google-hosted-domain/`. |
+| `EMAIL_PROVIDER` | multi-user only | `resend` is currently the only supported value. |
+| `EMAIL_FROM` | multi-user only | Sender address on a domain you control. |
+| `RESEND_API_KEY` | multi-user only | From your Resend dashboard. |
+
+You only need OAuth secrets for the providers you actually plan to enable; users can sign in with any provider that has credentials configured.
+
+## 6. Choose instance mode
+
+CloudTime defaults to **single-user mode** (`INSTANCE_MODE=single` in `wrangler.toml`). This is the right choice if:
+
+- You're hosting it just for yourself
+- You don't want anyone else to be able to register
+
+In single-user mode the first OAuth login becomes the owner; all subsequent OAuth logins for previously-unknown `(provider, provider_user_id)` pairs are rejected with `403 Registration closed`.
+
+For multi-user mode, set `INSTANCE_MODE=multi` in `wrangler.toml` `[vars]` and additionally configure the email provider (see [`email-setup.md`](./email-setup.md)).
+
+## 7. Deploy
+
+```bash
+wrangler deploy
+```
+
+The Worker URL will be printed (something like `https://cloudtime.<your-subdomain>.workers.dev`). Add a custom domain via the Cloudflare dashboard if you want a stable URL.
+
+## 8. Verify the deployment
+
+```bash
+curl -i https://your-worker.example.com/api/v1/health
+# Expect: HTTP/2 200, body: {"status":"ok"}
+```
+
+If the health check returns 200, the Worker is reachable. **Do not announce the URL yet** — proceed to step 9 first.
+
+---
+
+## Critical: First-login owner race
+
+CloudTime's single-user mode uses the atomic SQL:
+
+```sql
+INSERT INTO users (id, username, …)
+SELECT ?, ?, …
+WHERE (SELECT COUNT(*) FROM users) = 0
+```
+
+Whoever completes OAuth login first becomes the permanent owner. The race window is **from the moment your Worker URL is reachable until you complete OAuth login from your own browser**.
+
+### What you must do
+
+1. **Do not share the Worker URL** in public channels, README files, status pages, or DM screenshots until step 2 is complete.
+2. **Immediately log in yourself** via an OAuth provider whose credentials you control:
+   - Open `https://your-worker.example.com/api/v1/auth/github` (or `/google` / `/discord`) in a private browser tab.
+   - Complete the OAuth flow.
+   - Confirm you receive a `__Host-session` cookie and `GET /api/v1/auth/session` returns your user profile.
+3. **Generate your API key** (once):
+   ```bash
+   curl -X POST \
+     -H "Cookie: __Host-session=<your session token>" \
+     -H "Origin: https://your-worker.example.com" \
+     https://your-worker.example.com/api/v1/auth/api-key
+   ```
+   The plaintext `ck_…` value is shown **once**. Store it in your password manager and your `~/.wakatime.cfg`.
+
+### Why this matters
+
+If a third party who knows or guesses your Worker URL completes OAuth login first:
+
+- They become the owner. Their `user_id` is in the `users` table.
+- Subsequent attempts (including yours) are rejected with `403 Registration closed`.
+- The OAuth `oauth_accounts` row points to *their* provider account, not yours.
+
+Cloudflare Workers default URLs (`*.workers.dev`) are technically enumerable by determined attackers; the practical risk for a hobbyist host is low, but the recovery cost is high enough that the "log in immediately yourself" discipline is worth following.
+
+### Re-bootstrap recovery (destructive)
+
+If the race is lost, the only way back is to wipe the `users` table:
+
+```bash
+wrangler d1 execute cloudtime-db --remote \
+  --command "DELETE FROM users;"
+```
+
+`ON DELETE CASCADE` removes all child rows (sessions, oauth_accounts, heartbeats, summaries, goals, user_agents, …). You'll have a completely empty instance again. **Do this only if you intentionally want to discard all data on the instance.** After deletion, re-run step 2 above to register yourself.
+
+If you want to keep accumulated heartbeats but kick out an unintended owner, contact the heartbeat data owner (you) and decide whether you trust the existing data; selectively re-attributing rows is operationally hard and not officially supported.
+
+---
+
+## 9. Configure your WakaTime plugin
+
+Point your editor's WakaTime plugin at your Worker. In `~/.wakatime.cfg`:
+
+```ini
+[settings]
+api_url = https://your-worker.example.com/api/v1
+api_key = ck_<your plaintext key from step 9 of section 8>
+```
+
+Restart your editor. Your IDE's status bar should start showing today's coding time within a few seconds of typing.
+
+---
+
+## 10. Ongoing operations
+
+- **Backups**: see [`backup-restore.md`](./backup-restore.md). Schedule periodic D1 exports — the Cloudflare account-level snapshots are not a substitute for operator-owned exports.
+- **Heartbeat retention** (when [Issue #108](https://github.com/sudolifeagain/cloudtime/issues/108) ships): consider setting `HEARTBEAT_RETENTION_DAYS` to bound table growth.
+- **Email deliverability**: if you've enabled multi-user mode, monitor Resend's bounce / complaint rate and the `[email]` log lines.
+- **Rate-limit metrics**: monitor `[rate-limit]` warnings in `wrangler tail` to detect abuse. Tune the `[[ratelimits]]` blocks in `wrangler.toml` if legitimate traffic gets rejected.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `403 Registration closed` on your own first OAuth login | Someone else completed login first. See "Re-bootstrap recovery". |
+| `400 OAuth authorization failed` | Provider's OAuth app redirect URI does not match `APP_URL`/`<worker URL>/api/v1/auth/<provider>/callback`. Update the OAuth app config. |
+| `429 Too many requests` on OAuth | Rate limiter rejected your client IP. Wait 60 seconds; if recurring, widen the limit in `wrangler.toml`. |
+| Heartbeat 500 errors | Check `wrangler tail` — usually D1 connectivity or a schema mismatch (re-run `npm run db:init:remote`). |
+| `GET /heartbeats` returns the wrong day's data | Set your timezone via `PATCH /api/v1/users/current/profile` (`{"timezone": "Asia/Tokyo"}`). The endpoint defaults to your profile timezone since PR #112. |
+| Status bar in IDE shows 0 minutes | Confirm your `api_url` is exactly `<worker>/api/v1` (no trailing slash, no `/heartbeats`). |


### PR DESCRIPTION
## Summary

Two operator-facing markdown documents. No code, schema, or test changes.

### #109 — `docs/deployment-guide.md`

End-to-end walkthrough from `wrangler d1 create` through first heartbeat. The centrepiece is a **"Critical: First-login owner race"** section that explicitly warns operators to be the first OAuth login on their own instance — the atomic `INSERT … WHERE (SELECT COUNT(*) FROM users) = 0` correctly prevents the race once a user exists, but the responsibility to be that first user was previously not called out anywhere in docs.

Sections:
- Prerequisites
- Clone / install
- Provision D1 + KV
- Initialise schema (schema.sql + migrations/)
- Configure secrets (every current env var enumerated)
- Choose instance mode (single vs multi)
- Deploy
- Verify health
- **Critical: First-login owner race** — what to do + re-bootstrap recovery
- Configure WakaTime plugin
- Ongoing operations pointers (links to other docs)
- Troubleshooting table

### #110 — `docs/backup-restore.md`

D1 export / restore procedures with operational guidance. Notably:

- **`ENCRYPTION_KEY` criticality**: losing it breaks decryption of all stored OAuth tokens; rotating it without re-encryption breaks existing rows. Documented prominently because the consequences are non-obvious.
- KV is intentionally NOT backed up (cache only).
- Two scheduled options: a complete GitHub Actions workflow, plus a cron recipe for a self-managed host.
- Destructive restore procedure with two strategies (same DB vs fresh DB).
- Post-restore verification checklist.
- Migration between Cloudflare accounts (covers the `ENCRYPTION_KEY` equality requirement for token preservation).
- Storage cost considerations.

## Out of scope

- Heartbeat retention (#108) — referenced as future tuning, not documented here.
- Custom-domain DNS — Cloudflare's own docs cover this; not CloudTime-specific.

## Test plan

- [x] No code/schema changes; `tsc`/`test` not exercised
- [x] All cross-references (`./email-setup.md`, `./backup-restore.md`, `./deployment-guide.md`, `specs/037-google-hosted-domain/`) resolve to actual paths
- [x] Commands quoted in the guides are runnable as written

Closes #109.
Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)