### PR TITLE
spec: Goals CRUD endpoints (PR1/2) #100

### DIFF
--- a/schemas/components/schemas/GoalInput.yaml
+++ b/schemas/components/schemas/GoalInput.yaml
@@ -1,0 +1,66 @@
+type: object
+description: |
+  Request body for creating a goal. Server-generated fields (`id`,
+  `created_at`, `modified_at`) are omitted and ignored if sent.
+
+  Conditional filter requirement (enforced server-side, returns 400 on
+  violation):
+  - `type=coding`: `languages` / `editors` / `projects` MUST be omitted or
+    empty.
+  - `type=languages`: `languages` MUST be a non-empty array; `editors` and
+    `projects` MUST be omitted or empty.
+  - `type=editors`: `editors` MUST be a non-empty array; the others empty.
+  - `type=projects`: `projects` MUST be a non-empty array; the others empty.
+required:
+  - title
+  - type
+  - delta
+  - target_seconds
+properties:
+  title:
+    type: string
+    minLength: 1
+    maxLength: 200
+  type:
+    type: string
+    enum:
+      - coding
+      - languages
+      - editors
+      - projects
+  delta:
+    type: string
+    enum:
+      - day
+      - week
+  target_seconds:
+    type: number
+    format: double
+    exclusiveMinimum: 0
+    maximum: 604800
+    description: |
+      Target coding seconds per `delta` period. Must be greater than 0 and
+      at most 604800 (one week in seconds).
+  is_enabled:
+    type: boolean
+    description: Defaults to `true` when omitted.
+  is_snoozed:
+    type: boolean
+    description: Defaults to `false` when omitted.
+  is_inverse:
+    type: boolean
+    description: |
+      When true the goal is a cap ("stay under target") rather than a
+      floor ("reach target"). Defaults to `false` when omitted.
+  languages:
+    type: array
+    items:
+      type: string
+  editors:
+    type: array
+    items:
+      type: string
+  projects:
+    type: array
+    items:
+      type: string

--- a/schemas/components/schemas/GoalUpdate.yaml
+++ b/schemas/components/schemas/GoalUpdate.yaml
@@ -1,0 +1,42 @@
+type: object
+description: |
+  Request body for partially updating a goal. Only the fields present in the
+  body are changed; omitted fields keep their current value. At least one
+  mutable field MUST be provided (an empty body returns 400).
+
+  `type` and `delta` are immutable after creation — changing them would
+  reinterpret the goal's historical chart, so callers must delete and
+  recreate instead. Both are rejected with 400 if present.
+
+  Filter arrays must stay consistent with the goal's existing `type` (the
+  same rule documented on `GoalInput`). Setting a filter array on a
+  `type=coding` goal, or clearing the required array of a filtered goal,
+  returns 400.
+properties:
+  title:
+    type: string
+    minLength: 1
+    maxLength: 200
+  target_seconds:
+    type: number
+    format: double
+    exclusiveMinimum: 0
+    maximum: 604800
+  is_enabled:
+    type: boolean
+  is_snoozed:
+    type: boolean
+  is_inverse:
+    type: boolean
+  languages:
+    type: array
+    items:
+      type: string
+  editors:
+    type: array
+    items:
+      type: string
+  projects:
+    type: array
+    items:
+      type: string

--- a/schemas/paths/goals/goal.yaml
+++ b/schemas/paths/goals/goal.yaml
@@ -37,3 +37,73 @@ get:
       $ref: ../../components/responses/Unauthorized.yaml
     '404':
       $ref: ../../components/responses/NotFound.yaml
+patch:
+  operationId: updateGoal
+  tags:
+    - goals
+  summary: Update a goal
+  description: |
+    Partially updates a goal owned by the authenticated user. Only the
+    fields present in the body change; omitted fields are left untouched.
+    Returns the updated goal in the `Goal` shape (no `chart_data`).
+
+    `type` and `delta` are immutable — sending either returns 400. An empty
+    body, or filter arrays inconsistent with the goal's `type`, also return
+    400.
+
+    Requests for a goal owned by a different user return 404 (not 403) to
+    avoid leaking goal-id existence.
+  parameters:
+    - name: goal_id
+      in: path
+      required: true
+      schema:
+        type: string
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/GoalUpdate.yaml
+  responses:
+    '200':
+      description: Updated goal
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Goal.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+delete:
+  operationId: deleteGoal
+  tags:
+    - goals
+  summary: Delete a goal
+  description: |
+    Permanently deletes a goal owned by the authenticated user. Returns 204
+    with no body on success.
+
+    Requests for a goal owned by a different user (or an unknown id) return
+    404 (not 403) to avoid leaking goal-id existence.
+  parameters:
+    - name: goal_id
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    '204':
+      description: Goal deleted
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml

--- a/schemas/paths/goals/goals.yaml
+++ b/schemas/paths/goals/goals.yaml
@@ -47,3 +47,41 @@ get:
                   $ref: ../../components/schemas/Goal.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
+post:
+  operationId: createGoal
+  tags:
+    - goals
+  summary: Create a goal
+  description: |
+    Creates a goal for the authenticated user and returns it in the same
+    `Goal` shape as the list endpoint (persisted fields only, no
+    `chart_data`).
+
+    Server-generated fields (`id`, `created_at`, `modified_at`) are assigned
+    by the server and ignored if present in the request body. Booleans
+    default to `is_enabled=true`, `is_snoozed=false`, `is_inverse=false`.
+
+    Validation failures (empty title, out-of-range `target_seconds`, unknown
+    `type` / `delta`, or filter arrays inconsistent with `type`) return 400.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/GoalInput.yaml
+  responses:
+    '201':
+      description: Goal created
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Goal.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/specs/100-goals-crud/checklists/requirements.md
+++ b/specs/100-goals-crud/checklists/requirements.md
@@ -1,0 +1,60 @@
+# Acceptance Checklist: Goals CRUD Endpoints
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-017 with no `[NEEDS CLARIFICATION]` markers.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 8 design decisions (immutability, 404, hard delete, empty-PATCH 400, pure validation module, JSON filter storage, two schemas, server-side defaults).
+- [x] `data-model.md` confirms no schema change and documents the write-path field treatment + filter/type matrix.
+- [x] `quickstart.md` enumerates scenarios A–I.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the POST/PATCH/DELETE additions and the `GoalInput` / `GoalUpdate` schemas.
+- [x] `schemas/paths/goals/goals.yaml` declares `post` (`createGoal`).
+- [x] `schemas/paths/goals/goal.yaml` declares `patch` (`updateGoal`) and `delete` (`deleteGoal`).
+- [x] `schemas/components/schemas/GoalInput.yaml` and `GoalUpdate.yaml` exist and encode the request contracts.
+- [x] `npm run generate` produces generated types with `createGoal`/`updateGoal`/`deleteGoal` operations and `GoalInput`/`GoalUpdate` components; `GoalInput` booleans are optional.
+- [x] `npm run typecheck` passes.
+- [x] PR1 contains no changes under `src/routes/goals.ts`, `src/utils/goal-input.ts`, or `src/index.ts`.
+- [x] PR1 references issue #100 and the read-path PRs (#95 / #96).
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/goal-input.ts` exports `validateGoalInput` and `validateGoalUpdate` returning a discriminated `{ ok, value | error }` result.
+- [ ] `src/routes/goals.ts` adds `POST /goals`, `PATCH /goals/:goal_id`, `DELETE /goals/:goal_id`, all behind the existing `authMiddleware`.
+- [ ] Create generates `id` via `crypto.randomUUID()` and ignores body-supplied `id`/`created_at`/`modified_at`.
+- [ ] PATCH builds its `SET` clause from a fixed column allowlist (no user-supplied column names) and always bumps `modified_at`.
+- [ ] All three statements are scoped by `user_id`; cross-user PATCH/DELETE returns 404.
+- [ ] Create/update responses reuse the existing `rowToGoal` decoder (no duplicate decoder).
+- [ ] `npm run typecheck` passes with zero errors.
+- [ ] No diff in the read handlers' behaviour, `goal-chart.ts`, or any auth-flow file.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] Scenario A: minimal create returns 201 with defaults applied.
+- [ ] Scenario B: filtered create persists and echoes the filter array.
+- [ ] Scenario C: each validation failure returns 400 and creates nothing.
+- [ ] Scenario D: PATCH changes only the provided fields and bumps `modified_at`.
+- [ ] Scenario E: PATCH with `type`/`delta`/empty body returns 400.
+- [ ] Scenario F: DELETE returns 204 and the goal is gone.
+- [ ] Scenario G: cross-user PATCH/DELETE returns 404, target untouched.
+- [ ] Scenario H: unauthenticated POST/PATCH/DELETE returns 401.
+- [ ] Scenario I: created goal round-trips through the read endpoints.
+
+### Tests
+
+- [ ] `tests/aggregation/goal-input.test.ts` (or `tests/security/`) covers the pure validation rules: title trim/length, target range incl. boundary 604800, type/delta enums, filter/type matrix, de-duplication, default application, immutable-field rejection, empty-update rejection.
+- [ ] `tests/integration/goals-crud.test.ts` covers scenarios A–H against a seeded in-memory D1 (two users for the cross-user case).
+- [ ] `npm test` stays green and adds coverage (existing suite + new unit + integration).
+
+### Documentation
+
+- [ ] No new operator runbook required (no env vars / bindings added).
+- [ ] `quickstart.md` commands verified against a staging worker for at least Scenarios A, D, F, G.
+
+## Post-deployment gate
+
+- [ ] Create a goal through the API on a real instance and confirm it appears in `GET /goals`.
+- [ ] Confirm no 500s logged for the mutation endpoints in the first 7 days.
+- [ ] Confirm a cross-user DELETE attempt (if reproducible) returns 404 and does not remove the row.

--- a/specs/100-goals-crud/contracts/openapi-diff.md
+++ b/specs/100-goals-crud/contracts/openapi-diff.md
@@ -1,0 +1,77 @@
+# OpenAPI Diff
+
+This PR adds the Goals mutation surface to `schemas/openapi.yaml` via the
+existing goals path files, plus two new request-body schemas. The read
+operations are unchanged.
+
+## Files touched
+
+1. `schemas/paths/goals/goals.yaml` — add `post` (`createGoal`).
+2. `schemas/paths/goals/goal.yaml` — add `patch` (`updateGoal`) and `delete`
+   (`deleteGoal`).
+3. `schemas/components/schemas/GoalInput.yaml` — **new**, the create body.
+4. `schemas/components/schemas/GoalUpdate.yaml` — **new**, the partial-update body.
+
+No change to `Goal.yaml`, `GoalWithChart.yaml`, or the `getGoals` / `getGoal`
+operations.
+
+## Contract shape
+
+### `POST /users/current/goals` → `createGoal`
+
+- Request body (`required: true`): `GoalInput`.
+- `201` → `{"data": Goal}` (persisted fields only; no `chart_data`).
+- `400` → BadRequest (validation failure).
+- `401` → Unauthorized.
+
+`GoalInput` required: `title`, `type`, `delta`, `target_seconds`. Optional:
+`is_enabled` (default true), `is_snoozed` (default false), `is_inverse`
+(default false), `languages`, `editors`, `projects`. Constraints:
+`title` 1–200 chars; `target_seconds` `(0, 604800]`; filter arrays must be
+consistent with `type` (enforced server-side, documented in the schema
+description).
+
+### `PATCH /users/current/goals/{goal_id}` → `updateGoal`
+
+- Request body (`required: true`): `GoalUpdate`.
+- `200` → `{"data": Goal}` (merged state).
+- `400` → BadRequest (empty body, immutable `type`/`delta`, or invalid field).
+- `401` → Unauthorized.
+- `404` → NotFound (cross-user or unknown id).
+
+`GoalUpdate` has no required fields and **omits `type` and `delta`** — they
+are immutable. Every other mutable field is optional.
+
+### `DELETE /users/current/goals/{goal_id}` → `deleteGoal`
+
+- `204` → no body.
+- `401` → Unauthorized.
+- `404` → NotFound (cross-user or unknown id).
+
+## Generated-types impact
+
+`npm run generate` adds to `src/types/generated.ts`:
+
+- `components["schemas"]["GoalInput"]` — required `title`/`type`/`delta`/
+  `target_seconds`, optional booleans + filter arrays.
+- `components["schemas"]["GoalUpdate"]` — all optional, no `type`/`delta`.
+- `operations["createGoal"]` — `GoalInput` request body, `201` returns `Goal`.
+- `operations["updateGoal"]` — `GoalUpdate` request body, `200` returns `Goal`.
+- `operations["deleteGoal"]` — `204` no content.
+- The `/users/current/goals` path item gains `post`; the
+  `/users/current/goals/{goal_id}` path item gains `patch` and `delete`.
+
+No change to the existing `Goal` / `GoalWithChart` shapes or the read
+operations.
+
+## Why two request schemas
+
+`GoalInput` (create) and `GoalUpdate` (PATCH) are deliberately distinct so the
+generated types encode each verb's contract: create must set `type`/`delta`;
+update cannot touch them. See [research.md](../research.md) Decision 7.
+
+## SDD compliance note
+
+Per repository rules: PR1 lands SpecKit + schema + generated types. PR2 lands
+the route handlers (`createGoal`/`updateGoal`/`deleteGoal`) and the
+`goal-input` validation helper. No runtime code in PR1.

--- a/specs/100-goals-crud/data-model.md
+++ b/specs/100-goals-crud/data-model.md
@@ -1,0 +1,93 @@
+# Data Model: Goals CRUD Endpoints
+
+No schema changes. This document describes how the write path uses the existing `goals` table.
+
+## `goals` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS goals (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'coding',       -- coding | languages | editors | projects
+  delta TEXT NOT NULL DEFAULT 'day',         -- day | week
+  target_seconds REAL NOT NULL,
+  is_enabled INTEGER NOT NULL DEFAULT 1,
+  is_snoozed INTEGER NOT NULL DEFAULT 0,
+  is_inverse INTEGER NOT NULL DEFAULT 0,
+  languages TEXT,                            -- JSON array (nullable)
+  editors TEXT,                              -- JSON array (nullable)
+  projects TEXT,                             -- JSON array (nullable)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_goals_user ON goals(user_id);
+```
+
+The table already supports everything the CRUD endpoints need. The DB-level defaults (`type='coding'`, `is_enabled=1`, the timestamps) are a backstop; the application supplies explicit values so behaviour does not depend on DB defaults.
+
+## Write-path field treatment
+
+| Field | Create (`POST`) | Update (`PATCH`) |
+|---|---|---|
+| `id` | Server `crypto.randomUUID()`; body value ignored | Path param; never in body |
+| `user_id` | From the authenticated session; always bound in `WHERE`/`INSERT` | Always bound in `WHERE` |
+| `title` | Required, trimmed, 1–200 chars | Optional; same rule when present |
+| `type` | Required enum | **Rejected if present (400)** |
+| `delta` | Required enum | **Rejected if present (400)** |
+| `target_seconds` | Required, `0 < x <= 604800` | Optional; same rule when present |
+| `is_enabled` | Optional, default `true` → stored as 1/0 | Optional → 1/0 |
+| `is_snoozed` | Optional, default `false` → 1/0 | Optional → 1/0 |
+| `is_inverse` | Optional, default `false` → 1/0 | Optional → 1/0 |
+| `languages`/`editors`/`projects` | Validated against `type`, de-duplicated, `JSON.stringify` (or NULL when empty/omitted for `coding`) | Same; must stay consistent with the goal's existing `type`; a filtered goal's array must stay non-empty |
+| `created_at` | DB/`datetime('now')`; body value ignored | Never changed |
+| `modified_at` | Set on insert | Set to `datetime('now')` on every successful update |
+
+### Filter-array ↔ `type` consistency matrix
+
+| `type` | `languages` | `editors` | `projects` |
+|---|---|---|---|
+| `coding` | empty/omit | empty/omit | empty/omit |
+| `languages` | **non-empty** | empty/omit | empty/omit |
+| `editors` | empty/omit | **non-empty** | empty/omit |
+| `projects` | empty/omit | empty/omit | **non-empty** |
+
+Any cell violated → 400. Empty arrays are stored as SQL `NULL` (the read path's `parseFilterArray` treats `NULL` and `[]` identically).
+
+## Statements issued
+
+### Create
+```sql
+INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+                   is_enabled, is_snoozed, is_inverse, languages, editors, projects)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?);
+-- followed by the existing single-goal SELECT to echo the persisted row
+```
+
+### Update
+```sql
+-- 1) ownership + current type:
+SELECT <GOAL_COLUMNS> FROM goals WHERE id = ? AND user_id = ?;   -- 404 if no row
+-- 2) dynamic SET built from provided fields only, always including modified_at:
+UPDATE goals SET <field = ?>, ..., modified_at = datetime('now')
+ WHERE id = ? AND user_id = ?;
+-- 3) re-SELECT to return merged state
+```
+
+### Delete
+```sql
+DELETE FROM goals WHERE id = ? AND user_id = ?;   -- 404 if meta.changes === 0
+```
+
+All statements are parameter-bound; no string interpolation of user input into SQL. The dynamic `UPDATE` builds its `SET` list from a fixed allowlist of column names, binding values positionally — column names are never taken from user input.
+
+## Reuse of the read path
+
+- `rowToGoal(row)` (already in `src/routes/goals.ts`) serialises a row to the `Goal` response shape, including decoding the JSON filter columns. Create and update responses go through it unchanged.
+- `GOAL_COLUMNS` and the single-goal `SELECT` are reused for the post-write re-read and the PATCH ownership check.
+
+## Cleanup / cascade
+
+`goals` has `ON DELETE CASCADE` from `users`; deleting a user still removes their goals automatically. The new `DELETE` endpoint removes a single goal explicitly. No additional cleanup logic.

--- a/specs/100-goals-crud/plan.md
+++ b/specs/100-goals-crud/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: Goals CRUD Endpoints
+
+**Branch**: `100-goals-crud` | **Date**: 2026-05-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/100-goals-crud/spec.md`
+
+## Summary
+
+Adds the mutation half of the Goals surface on top of the read path shipped in PR #96. Three new handlers (`createGoal`, `updateGoal`, `deleteGoal`) write to the existing `goals` D1 table. A small validation module turns a parsed request body into a validated, normalised row (or a 400). The `Goal` response shape is reused unchanged.
+
+PR1 (this PR) lands the SpecKit artifacts, the OpenAPI additions (`POST` on `goals.yaml`, `PATCH` + `DELETE` on `goal.yaml`, new `GoalInput` / `GoalUpdate` request schemas), and the regenerated types. PR2 lands the handlers and tests after PR1 merges.
+
+No DB migration, no new env var, no new dependency.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers runtime)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (existing `goals` table only)
+**Testing**: Vitest + workers pool; unit tests for the validation module, integration tests for all three endpoints against a seeded in-memory D1
+**Target Platform**: Cloudflare Workers (edge compute)
+**Project Type**: Web service (REST API)
+**Performance Goals**: <10ms CPU per request — single-row INSERT/UPDATE/DELETE, at most one prior ownership SELECT for PATCH
+**Constraints**: Workers free-tier CPU budget; mutations always scoped by `user_id`
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI updated first (this PR). `npm run generate` produces real new types (`createGoal`/`updateGoal`/`deleteGoal`, `GoalInput`, `GoalUpdate`). Handlers land only in PR2. |
+| II. Cloudflare-Native | PASS | Pure D1 writes + `crypto.randomUUID()`. No new bindings, services, or KV. |
+| III. Type Safety | PASS | Handlers consume `components["schemas"]["GoalInput"]`, `["GoalUpdate"]`, `["Goal"]` from `src/types/generated.ts`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Original contract derived from our own schema. "WakaTime-compatible" stays in docs only. No source/asset borrowing. |
+| V. Simplicity First | PASS | Reuses the read path's `rowToGoal` decoder; new code is one validation module + three thin handlers. No new abstraction beyond a `validateGoalInput` / `validateGoalUpdate` pair. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/100-goals-crud/
+├── plan.md
+├── spec.md
+├── research.md            # immutability of type/delta, 404 vs 403, hard delete, validation placement
+├── data-model.md          # uses existing goals table; no schema change; write-path field treatment
+├── quickstart.md          # operator/QA scenarios for POST/PATCH/DELETE
+├── tasks.md               # PR1/PR2 split
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── goals.ts             # EXTEND: add createGoal / updateGoal / deleteGoal handlers
+└── utils/
+    └── goal-input.ts        # NEW: validateGoalInput(body) + validateGoalUpdate(body, existingType)
+```
+
+**Structure Decision**: The CRUD handlers live in the existing `src/routes/goals.ts` next to the read handlers (one router per resource, matching `heartbeats.ts`). Validation is split into a pure `src/utils/goal-input.ts` so it is unit-testable without D1 and mirrors the existing `goal-chart.ts` helper split.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **`type` and `delta` are immutable** via PATCH (400 if present) — changing them silently reinterprets chart history.
+2. **Cross-user / unknown target returns 404, not 403** — consistent with the read path; no goal-id existence leak.
+3. **`DELETE` is a hard delete** returning 204 — `is_enabled=false` already covers "hide without deleting."
+4. **Empty PATCH body is a 400**, not a silent no-op — surfaces client mistakes.
+5. **Validation is a pure module** returning a discriminated result, keeping handlers thin and the rules unit-testable.
+6. **Filter arrays are de-duplicated and stored as JSON TEXT**, matching what the read decoder already expects.
+7. **Two request schemas** (`GoalInput` for create with required fields, `GoalUpdate` for PATCH with all-optional mutable fields) instead of one all-optional schema — the type system then encodes "create needs these, update may change those."
+
+## Phase 1 — Design Outputs
+
+### Validation module sketch
+
+```ts
+// src/utils/goal-input.ts
+export type GoalType = "coding" | "languages" | "editors" | "projects";
+export type GoalDelta = "day" | "week";
+const MAX_TARGET_SECONDS = 604800;
+const MAX_TITLE = 200;
+
+export interface ValidatedGoalCreate {
+  title: string;
+  type: GoalType;
+  delta: GoalDelta;
+  target_seconds: number;
+  is_enabled: boolean;
+  is_snoozed: boolean;
+  is_inverse: boolean;
+  languages: string[];
+  editors: string[];
+  projects: string[];
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+export function validateGoalInput(body: unknown): ValidationResult<ValidatedGoalCreate> { … }
+
+// existingType is needed so PATCH can enforce filter-array/type consistency
+export function validateGoalUpdate(
+  body: unknown,
+  existingType: GoalType,
+): ValidationResult<Partial<ValidatedGoalCreate>> { … }
+```
+
+### Handler sketch
+
+```ts
+// src/routes/goals.ts (added below the existing read handlers)
+goals.post("/goals", async (c) => {
+  const userId = c.get("userId");
+  const parsed = validateGoalInput(await c.req.json().catch(() => null));
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  const g = parsed.value;
+  const id = crypto.randomUUID();
+  await c.env.DB.prepare(
+    `INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+       is_enabled, is_snoozed, is_inverse, languages, editors, projects)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+  ).bind(id, userId, g.title, g.type, g.delta, g.target_seconds,
+         g.is_enabled ? 1 : 0, g.is_snoozed ? 1 : 0, g.is_inverse ? 1 : 0,
+         jsonOrNull(g.languages), jsonOrNull(g.editors), jsonOrNull(g.projects)).run();
+  const row = await selectGoalRow(c.env.DB, id, userId);   // reuse read SELECT
+  return c.json({ data: rowToGoal(row!) }, 201);
+});
+
+goals.patch("/goals/:goal_id", async (c) => {
+  const userId = c.get("userId");
+  const existing = await selectGoalRow(c.env.DB, c.req.param("goal_id"), userId);
+  if (!existing) return c.json({ error: "Not found" }, 404);
+  const parsed = validateGoalUpdate(await c.req.json().catch(() => null), existing.type as GoalType);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  // build SET clause from provided keys only, always append modified_at = datetime('now')
+  …
+  return c.json({ data: rowToGoal(updatedRow) });
+});
+
+goals.delete("/goals/:goal_id", async (c) => {
+  const userId = c.get("userId");
+  const res = await c.env.DB.prepare(
+    `DELETE FROM goals WHERE id = ? AND user_id = ?`,
+  ).bind(c.req.param("goal_id"), userId).run();
+  if (res.meta.changes === 0) return c.json({ error: "Not found" }, 404);
+  return c.body(null, 204);
+});
+```
+
+### OpenAPI surface
+
+Declared in this PR — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). `POST` on the collection path, `PATCH` + `DELETE` on the item path, plus the new `GoalInput` / `GoalUpdate` request schemas. The create/update responses reuse `Goal`.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+No constitution violations. Complexity is bounded to input validation (string/number range checks + filter-array/type consistency). The write path is three single-row statements with `user_id` scoping; no transactions, no fan-out.

--- a/specs/100-goals-crud/quickstart.md
+++ b/specs/100-goals-crud/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Goals CRUD Endpoints
+
+This guide walks through manually verifying `POST`, `PATCH`, and `DELETE` on goals once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+- A deployed CloudTime worker (single-user or multi-user — goal endpoints are user-scoped, not gated by `INSTANCE_MODE`).
+- A user account with a valid API key (e.g. `ck_…`). Export it:
+
+  ```bash
+  export API_KEY=ck_xxx
+  export BASE=https://cloudtime.example.dev/api/v1
+  ```
+
+## Scenario A — Create a minimal coding goal
+
+```bash
+curl -sX POST "$BASE/users/current/goals" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Code 1 hour per day","type":"coding","delta":"day","target_seconds":3600}'
+```
+
+**Expected**: HTTP 201, body `{"data": {...}}` where the goal has a UUID `id`, `is_enabled=true`, `is_snoozed=false`, `is_inverse=false`, empty `languages`/`editors`/`projects`, and `created_at` ≈ `modified_at`. Capture the id:
+
+```bash
+export GOAL_ID=<id from the response>
+```
+
+## Scenario B — Create a language-scoped goal
+
+```bash
+curl -sX POST "$BASE/users/current/goals" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d '{"title":"5h TypeScript / week","type":"languages","delta":"week",
+       "target_seconds":18000,"languages":["TypeScript"]}'
+```
+
+**Expected**: 201; response echoes `type:"languages"`, `languages:["TypeScript"]`.
+
+## Scenario C — Create validation failures (each returns 400)
+
+```bash
+# empty title
+-d '{"title":"   ","type":"coding","delta":"day","target_seconds":3600}'
+# target out of range
+-d '{"title":"x","type":"coding","delta":"day","target_seconds":0}'
+-d '{"title":"x","type":"coding","delta":"day","target_seconds":700000}'
+# unknown type / delta
+-d '{"title":"x","type":"music","delta":"day","target_seconds":3600}'
+-d '{"title":"x","type":"coding","delta":"fortnight","target_seconds":3600}'
+# filter array on a coding goal
+-d '{"title":"x","type":"coding","delta":"day","target_seconds":3600,"languages":["Go"]}'
+# languages goal with no languages
+-d '{"title":"x","type":"languages","delta":"day","target_seconds":3600}'
+```
+
+**Expected**: each returns HTTP 400 with `{"error":"<message naming the field>"}` and creates nothing.
+
+## Scenario D — Edit mutable fields
+
+```bash
+curl -sX PATCH "$BASE/users/current/goals/$GOAL_ID" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d '{"target_seconds":7200,"is_snoozed":true}'
+```
+
+**Expected**: 200; `data.target_seconds=7200`, `data.is_snoozed=true`, all other fields unchanged, `modified_at` advanced beyond `created_at`.
+
+## Scenario E — Reject immutable fields and empty body
+
+```bash
+# type is immutable
+curl -sX PATCH "$BASE/users/current/goals/$GOAL_ID" -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" -d '{"type":"languages"}'
+# delta is immutable
+... -d '{"delta":"week"}'
+# empty body
+... -d '{}'
+```
+
+**Expected**: each returns HTTP 400 and changes nothing (re-`GET` the goal to confirm).
+
+## Scenario F — Delete
+
+```bash
+curl -siX DELETE "$BASE/users/current/goals/$GOAL_ID" -H "Authorization: Bearer $API_KEY"
+```
+
+**Expected**: HTTP 204, empty body. A follow-up `GET $BASE/users/current/goals/$GOAL_ID` returns 404, and the goal is gone from `GET $BASE/users/current/goals`.
+
+## Scenario G — Cross-user isolation
+
+As user A, attempt to PATCH or DELETE a goal id that belongs to user B:
+
+```bash
+curl -siX DELETE "$BASE/users/current/goals/$B_GOAL_ID" -H "Authorization: Bearer $A_API_KEY"
+curl -siX PATCH  "$BASE/users/current/goals/$B_GOAL_ID" -H "Authorization: Bearer $A_API_KEY" \
+  -H "Content-Type: application/json" -d '{"title":"hijack"}'
+```
+
+**Expected**: both return 404. Re-reading the goal as user B shows it untouched.
+
+## Scenario H — Unauthenticated
+
+```bash
+curl -siX POST   "$BASE/users/current/goals" -H "Content-Type: application/json" -d '{}'
+curl -siX PATCH  "$BASE/users/current/goals/anything" -H "Content-Type: application/json" -d '{}'
+curl -siX DELETE "$BASE/users/current/goals/anything"
+```
+
+**Expected**: each returns 401 and mutates nothing.
+
+## Scenario I — Round-trip with the read path
+
+Create a goal (Scenario A), then:
+
+```bash
+curl -sH "Authorization: Bearer $API_KEY" "$BASE/users/current/goals"          # appears in list
+curl -sH "Authorization: Bearer $API_KEY" "$BASE/users/current/goals/$GOAL_ID"  # has chart_data
+```
+
+**Expected**: the newly created goal appears in the list (ordered by `created_at`) and the single-goal read returns it with computed `chart_data` of length 7.
+
+## Reverting / cleanup
+
+No data migration to revert. Removing the `post` / `patch` / `delete` handlers from `src/routes/goals.ts` disables the mutation surface without data loss; existing goals remain readable.

--- a/specs/100-goals-crud/research.md
+++ b/specs/100-goals-crud/research.md
@@ -1,0 +1,107 @@
+# Research: Goals CRUD Endpoints
+
+## Decision 1: `type` and `delta` are immutable
+
+**Decision**: `PATCH` rejects any body containing `type` or `delta` with a 400. To change either, the client deletes the goal and creates a new one.
+
+**Rationale**:
+- The goal's chart is computed by reinterpreting historical `summaries` against the goal's `type` filter and `delta` period. Mutating `type` from `coding` to `languages`, or `delta` from `day` to `week`, would silently rewrite the meaning of every past period — the same row would suddenly show different history.
+- Keeping them immutable means the read path never has to reason about "what was the type when this period happened."
+- The issue (#100) lists the editable fields as `title`, `target_seconds`, `is_enabled`, `is_snoozed`, `is_inverse`, and the filter arrays — `type` / `delta` are deliberately absent.
+
+**Alternative considered**:
+- **Allow `type` / `delta` change**: would require either versioning goals or accepting that historical charts shift. Rejected as surprising; recreate is cheap.
+
+---
+
+## Decision 2: Cross-user / unknown target returns 404, not 403
+
+**Decision**: `PATCH` and `DELETE` against a `goal_id` the caller does not own — or one that does not exist — both return 404. The SQL `WHERE` clause always includes `user_id = ?`, so "not yours" and "not found" are indistinguishable by construction.
+
+**Rationale**:
+- Matches the read path (`getGoal`), which the spec for 100-goals-read fixed at 404 to avoid leaking goal-id existence.
+- A single `WHERE id = ? AND user_id = ?` clause is the simplest correct implementation and removes the temptation to fetch-then-check (a TOCTOU window).
+
+**Alternative considered**:
+- **403 for owned-by-other**: clearer for debugging but leaks that the id exists. Rejected on least-information grounds, consistent with read.
+
+---
+
+## Decision 3: `DELETE` is a hard delete returning 204
+
+**Decision**: `DELETE` removes the row outright and returns 204 with no body. There is no soft-delete / archive flag.
+
+**Rationale**:
+- `is_enabled=false` already provides "keep the goal but hide/dim it" semantics (the read path returns disabled goals so clients can choose to hide them). A separate archive state would duplicate that.
+- 204 is the conventional REST response for a successful delete with no representation to return; it mirrors `deleteCustomRule` in the existing schema.
+- `goals` has `ON DELETE CASCADE` from `users`, so there are no dependent rows to clean up.
+
+**Alternative considered**:
+- **Soft delete (`deleted_at`)**: adds a column and forces every read query to filter it. Rejected — `is_enabled` covers the real use case.
+
+---
+
+## Decision 4: Empty PATCH body is a 400, not a silent no-op
+
+**Decision**: A `PATCH` whose body contains no recognised mutable field (including `{}`) returns 400.
+
+**Rationale**:
+- An empty update almost always indicates a client bug (wrong field names, serialisation error). Returning 200 for it hides the mistake.
+- It keeps the "PATCH advanced `modified_at`" guarantee meaningful — we never bump `modified_at` for a request that changed nothing.
+
+**Alternative considered**:
+- **200 no-op**: friendlier but masks client errors and muddies `modified_at` semantics. Rejected.
+
+---
+
+## Decision 5: Validation is a pure module returning a discriminated result
+
+**Decision**: `src/utils/goal-input.ts` exports `validateGoalInput` and `validateGoalUpdate`, each returning `{ ok: true, value } | { ok: false, error }`. Handlers only translate the result into a 400 or a DB write.
+
+**Rationale**:
+- The validation rules (title length, target range, type/delta enums, filter-array/type consistency) are the bulk of the logic and are pure functions of the input — ideal for fast unit tests without spinning up D1.
+- Keeps handlers thin and mirrors the read path's `goal-chart.ts` pure-helper split.
+- A discriminated result avoids throwing for expected validation failures.
+
+**Alternative considered**:
+- **Inline validation in the handler**: harder to unit-test and tends to drift between POST and PATCH. Rejected.
+- **A schema-validation library (zod, etc.)**: a new dependency for rules we can express in a few guards. Rejected per Simplicity First; the OpenAPI schema already documents the contract.
+
+---
+
+## Decision 6: Filter arrays are de-duplicated and stored as JSON TEXT
+
+**Decision**: `languages` / `editors` / `projects` are validated as arrays of strings, de-duplicated (order-preserving), and stored as JSON-encoded TEXT — the exact encoding the read path's `parseFilterArray` already decodes.
+
+**Rationale**:
+- The read decoder is the contract for the column format; the write path must produce what it consumes. Storing JSON TEXT keeps a single source of truth for the encoding.
+- De-duplication avoids a `language IN ('Go','Go')` situation that would not change results but is noise.
+
+**Alternative considered**:
+- **A join table (`goal_filters`)**: normalised but adds a table, a migration, and multi-row writes for a feature that the read path already models as JSON. Rejected — out of scope and contradicts the existing column shape.
+
+---
+
+## Decision 7: Two request schemas (`GoalInput` + `GoalUpdate`)
+
+**Decision**: `GoalInput` (create) declares `title`, `type`, `delta`, `target_seconds` as required with optional booleans/arrays. `GoalUpdate` (PATCH) declares every mutable field optional and omits `type` / `delta` entirely.
+
+**Rationale**:
+- The two operations have genuinely different contracts: create must establish `type`/`delta`; update must not touch them. Encoding that in two schemas makes the generated TypeScript types tell the truth (`GoalInput.type` is required; `GoalUpdate` has no `type`).
+- A single all-optional schema would force the handler — and every reader of the generated types — to re-derive which fields are required for which verb.
+
+**Alternative considered**:
+- **One `GoalInput` reused for both** (issue's literal wording): would either make create's required fields optional (losing the contract) or force PATCH clients to resend `type`/`delta`. The issue's intent (edit a subset, don't touch type/delta) is better served by the split; documented here so the deviation from the issue's single-schema phrasing is intentional and reviewable.
+
+---
+
+## Decision 8: Defaults applied server-side, not via schema `default`
+
+**Decision**: `is_enabled=true`, `is_snoozed=false`, `is_inverse=false` defaults are applied in the validation module, and the booleans are optional in `GoalInput` (no OpenAPI `default` keyword).
+
+**Rationale**:
+- `openapi-typescript` emits properties carrying a `default` as required in the generated type, which is wrong for an optional create field. Documenting the default in the property description keeps the field optional in the type while still telling clients what omission means.
+- No other `*Input` schema in the repo uses `default:`, so this stays consistent.
+
+**Alternative considered**:
+- **Keep schema `default:`**: nicer for doc renderers but pollutes the generated request type with required booleans. Rejected for type accuracy and repo consistency.

--- a/specs/100-goals-crud/spec.md
+++ b/specs/100-goals-crud/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Goals CRUD Endpoints
+
+**Feature Branch**: `100-goals-crud`
+**Created**: 2026-05-28
+**Status**: Draft
+**Input**: PR #95 / #96 shipped the Goals **read** path (`getGoals`, `getGoal`) and explicitly deferred mutation. The `goals` D1 table already carries every persisted column. This feature adds the create / update / delete surface so self-hosted operators stop managing goals with raw `wrangler d1 execute`.
+
+## Background
+
+A goal expresses an intent to spend at least (or, when `is_inverse`, at most) `target_seconds` of coding time per `delta` period, optionally scoped to a set of languages, editors, or projects. The read endpoints already serialise these rows and compute progress charts. Today the only way to create, edit, or remove a goal is a direct SQL statement against D1 — impractical and unsafe for operators.
+
+This spec covers the **mutation path only**: `POST /users/current/goals`, `PATCH /users/current/goals/{goal_id}`, and `DELETE /users/current/goals/{goal_id}`. It reuses the existing `Goal` response shape and the existing `goals` table. No schema migration is required.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create a goal (Priority: P1)
+
+As an authenticated user, I want to create a goal through the API so that the goals UI and the read endpoints have something to show without me touching the database.
+
+**Why this priority**: Create is the entry point — without it the read endpoints only ever reflect manually-seeded rows.
+
+**Independent Test**: Authenticate, `POST /users/current/goals` with a minimal valid body (`title`, `type=coding`, `delta=day`, `target_seconds=3600`), and verify a 201 with the persisted `Goal` echoed back, including a server-generated `id`, `created_at`, `modified_at`, and the defaulted booleans.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `type=coding` body, **When** the user POSTs it, **Then** the server returns 201 with `{"data": Goal}`, a fresh UUID `id`, `is_enabled=true`, `is_snoozed=false`, `is_inverse=false`, and empty filter arrays.
+2. **Given** a body that omits the booleans, **When** the goal is created, **Then** defaults are applied (`is_enabled=true`, the others `false`).
+3. **Given** a `type=languages` body with `languages=["TypeScript"]`, **When** created, **Then** the persisted goal stores the JSON array and the response echoes `languages: ["TypeScript"]`.
+4. **Given** any server-generated field (`id` / `created_at` / `modified_at`) in the request body, **When** created, **Then** the server ignores them and assigns its own values.
+5. **Given** an unauthenticated request, **When** POSTing, **Then** the server returns 401 and creates nothing.
+
+---
+
+### User Story 2 - Edit a goal (Priority: P1)
+
+As an authenticated user, I want to adjust a goal's title, target, flags, or filter sets without recreating it, so I keep its chart history.
+
+**Why this priority**: Goals are long-lived; users routinely retune targets and snooze/unsnooze. Editing is the most frequent mutation.
+
+**Independent Test**: Create a goal, `PATCH` it with `{"target_seconds": 7200, "is_snoozed": true}`, and verify a 200 with only those two fields changed, `modified_at` advanced, and every untouched field preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owned goal, **When** the user PATCHes a subset of mutable fields, **Then** only those fields change, `modified_at` is bumped, and the response is `{"data": Goal}` with the merged state.
+2. **Given** a PATCH body containing `type` or `delta`, **When** submitted, **Then** the server returns 400 (both are immutable) and changes nothing.
+3. **Given** an empty PATCH body `{}`, **When** submitted, **Then** the server returns 400 (no-op updates are rejected, not silently accepted).
+4. **Given** a goal owned by a different user, **When** the caller PATCHes it, **Then** the server returns 404 (not 403) and changes nothing.
+5. **Given** an unknown `goal_id`, **When** PATCHed, **Then** the server returns 404.
+6. **Given** an unauthenticated request, **When** PATCHing, **Then** the server returns 401.
+
+---
+
+### User Story 3 - Delete a goal (Priority: P1)
+
+As an authenticated user, I want to remove a goal I no longer care about so it stops appearing in lists and charts.
+
+**Why this priority**: Without delete, abandoned goals accumulate and clutter every list response forever.
+
+**Independent Test**: Create a goal, `DELETE` it, observe 204, then confirm a follow-up `GET /goals/{id}` returns 404 and the list no longer contains it.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owned goal, **When** the user DELETEs it, **Then** the server returns 204 with no body and the row is gone.
+2. **Given** a goal owned by a different user, **When** the caller DELETEs it, **Then** the server returns 404 and deletes nothing.
+3. **Given** an unknown `goal_id`, **When** DELETEd, **Then** the server returns 404 (idempotent-looking but never reports success for a row it did not delete).
+4. **Given** an unauthenticated request, **When** DELETEing, **Then** the server returns 401.
+
+---
+
+### Edge Cases
+
+- **Title whitespace-only**: `"   "` is treated as empty after trim → 400.
+- **`target_seconds` boundaries**: `0` and negative → 400. Exactly `604800` (one week) is accepted; above it → 400.
+- **Filter array on the wrong type**: `type=coding` with a non-empty `languages` array → 400. `type=languages` with an empty or omitted `languages` array → 400.
+- **Filter array with non-string members**: arrays must be of strings; a number/object member → 400.
+- **Duplicate filter values**: `["Go","Go"]` is de-duplicated server-side; not an error.
+- **PATCH that switches a filtered goal's array to empty**: a `type=languages` goal PATCHed with `languages=[]` → 400 (a filtered goal must keep a non-empty allowlist; to stop filtering, delete and recreate as `type=coding`).
+- **PATCH unknown/unexpected keys**: ignored (forward-compatible) — only recognised mutable fields are read.
+- **Concurrent PATCH/DELETE**: last write wins; a PATCH against a row deleted concurrently returns 404.
+- **Body not valid JSON / wrong content type**: 400.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `POST /api/v1/users/current/goals` MUST create one goal owned by the authenticated user and return `201` with `{"data": Goal}` (persisted fields only, no `chart_data`).
+- **FR-002**: The server MUST generate `id` (UUID), `created_at`, and `modified_at`; any of these present in the request body MUST be ignored.
+- **FR-003**: `title` MUST be a non-empty string after trimming, at most 200 characters; otherwise 400.
+- **FR-004**: `type` MUST be one of `coding | languages | editors | projects`; `delta` MUST be one of `day | week`; otherwise 400.
+- **FR-005**: `target_seconds` MUST be a number with `0 < target_seconds <= 604800`; otherwise 400.
+- **FR-006**: Filter-array consistency MUST be enforced on create: `type=coding` requires all of `languages` / `editors` / `projects` to be empty or omitted; `type=languages|editors|projects` requires the matching array to be a non-empty array of strings and the other two to be empty or omitted. Violations return 400.
+- **FR-007**: Booleans default when omitted: `is_enabled=true`, `is_snoozed=false`, `is_inverse=false`.
+- **FR-008**: `PATCH /api/v1/users/current/goals/{goal_id}` MUST partially update an owned goal and return `200` with `{"data": Goal}` reflecting the merged state. Only `title`, `target_seconds`, `is_enabled`, `is_snoozed`, `is_inverse`, `languages`, `editors`, `projects` are mutable.
+- **FR-009**: `type` and `delta` are immutable. A PATCH body containing either MUST return 400 and mutate nothing.
+- **FR-010**: A PATCH body with no recognised mutable field (including `{}`) MUST return 400.
+- **FR-011**: PATCH MUST apply the same per-field validation as create (FR-003, FR-005) to any field it does set, and MUST keep filter arrays consistent with the goal's existing `type` (FR-006). A filtered goal's array MUST remain non-empty.
+- **FR-012**: PATCH MUST advance `modified_at` and leave `created_at` unchanged.
+- **FR-013**: `DELETE /api/v1/users/current/goals/{goal_id}` MUST delete an owned goal and return `204` with no body.
+- **FR-014**: PATCH and DELETE against a goal not owned by the caller, or an unknown `goal_id`, MUST return 404 (never 403, never 200/204) and mutate nothing.
+- **FR-015**: All three endpoints MUST require API-key or session authentication; an unauthenticated request returns 401 and mutates nothing.
+- **FR-016**: `languages` / `editors` / `projects` MUST be persisted as JSON-encoded TEXT (same encoding the read path decodes), with duplicate members removed before storage.
+- **FR-017**: Validation errors MUST return the project's standard `400` body (`{"error": "<message>"}`) with a message that names the offending field, and MUST NOT echo back secrets or the raw body.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Each endpoint MUST complete within the Workers free-tier 10ms CPU budget. Create/update/delete are single-row writes; create issues at most one `INSERT`, update one `UPDATE` (after one ownership `SELECT`), delete one `DELETE`.
+- **NFR-002**: Mutations MUST be scoped by `user_id` in the SQL `WHERE` clause so cross-user access is impossible even if a `goal_id` is guessed.
+- **NFR-003**: No new dependency, env var, or D1 migration. The feature uses only the existing `goals` table and `crypto.randomUUID()`.
+
+### Key Entities *(no schema change)*
+
+No schema changes. The `goals` table already has `id`, `user_id`, `title`, `type`, `delta`, `target_seconds`, `is_enabled`, `is_snoozed`, `is_inverse`, `languages`, `editors`, `projects`, `created_at`, `modified_at`, and `ON DELETE CASCADE` from `users`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can create, edit, and delete a goal end-to-end through the API with no direct D1 access.
+- **SC-002**: A created goal is immediately visible via `GET /goals` and `GET /goals/{id}` with the values supplied.
+- **SC-003**: Every validation rule in FR-003..FR-006, FR-009..FR-011 returns 400 with a field-naming message (covered by integration tests).
+- **SC-004**: Cross-user PATCH/DELETE returns 404 and leaves the target row untouched (verified by a second-user read).
+- **SC-005**: A deleted goal returns 404 on a subsequent GET and is absent from the list.
+- **SC-006**: New handler code in `src/routes/goals.ts` reuses the existing `rowToGoal` decoder and adds shared validation helpers; no duplication of the read decoder.
+
+## Out of Scope
+
+- **Bulk create / bulk delete**. One goal per request; batch endpoints are deferred.
+- **`type` / `delta` mutation**. Immutable by design; recreate to change them.
+- **Goal templates, suggestions, or auto-creation** from activity.
+- **Notifications / reminders** when a goal flips status.
+- **Soft delete / archive**. `DELETE` is a hard delete; "hide without deleting" is what `is_enabled=false` already provides.
+- **Reordering goals**. List order stays `created_at` ascending.
+- **Custom week-start** or per-goal timezone. Inherited from the read-path decisions.

--- a/specs/100-goals-crud/tasks.md
+++ b/specs/100-goals-crud/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Goals CRUD Endpoints
+
+**Branch**: `100-goals-crud`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-28
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (3 user stories, FR-001..FR-017, NFRs, edge cases).
+- [x] **T-002**: Author `plan.md` (Constitution Check, validation + handler sketches).
+- [x] **T-003**: Author `research.md` (8 documented decisions).
+- [x] **T-004**: Author `data-model.md` (existing table; write-path field treatment + filter/type matrix).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–I).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add `GoalInput` and `GoalUpdate` request schemas; add `post` to `goals.yaml` and `patch` + `delete` to `goal.yaml`. Reuse `Goal` for create/update responses.
+- [x] **T-009**: Run `npm run generate`. Verify `createGoal` / `updateGoal` / `deleteGoal` and `GoalInput` / `GoalUpdate` appear in `src/types/generated.ts` and that `GoalInput` booleans are optional. Run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Validation helper
+
+- [ ] **T-101**: Create `src/utils/goal-input.ts` exporting:
+  - `validateGoalInput(body): { ok: true, value: ValidatedGoalCreate } | { ok: false, error }`
+  - `validateGoalUpdate(body, existingType): { ok: true, value: Partial<...> } | { ok: false, error }`
+  - shared constants `MAX_TITLE = 200`, `MAX_TARGET_SECONDS = 604800`
+- [ ] **T-102**: Unit tests in `tests/aggregation/goal-input.test.ts` (or `tests/security/`): title trim/length, target range incl. boundary, type/delta enums, filter/type matrix, de-duplication, defaults, immutable-field rejection, empty-update rejection, non-JSON body.
+
+### Route handlers (extend existing `src/routes/goals.ts`)
+
+- [ ] **T-103**: `POST /goals` — validate, `crypto.randomUUID()`, single `INSERT` (filter arrays as JSON TEXT or NULL), re-SELECT, return `201 {data: Goal}`.
+- [ ] **T-104**: `PATCH /goals/:goal_id` — ownership SELECT (404 if absent), validate against existing `type`, dynamic `SET` from a fixed allowlist + `modified_at = datetime('now')`, re-SELECT, return `200 {data: Goal}`.
+- [ ] **T-105**: `DELETE /goals/:goal_id` — single `DELETE ... WHERE id = ? AND user_id = ?`; `204` on `changes>0`, else `404`.
+- [ ] **T-106**: Reuse `rowToGoal`, `GOAL_COLUMNS`, and the single-goal SELECT; factor a small `selectGoalRow(db, id, userId)` helper if it reduces duplication.
+
+### Tests
+
+- [ ] **T-107**: Integration test `tests/integration/goals-crud.test.ts` covering scenarios A–H (two users seeded for cross-user 404).
+
+### Verification
+
+- [ ] **T-108**: `npm run typecheck` — zero errors.
+- [ ] **T-109**: `npm test` — full suite green incl. new unit + integration.
+- [ ] **T-110**: Manual run of `quickstart.md` Scenarios A, D, F, G against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-111**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #100.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                       (PR1)
+T-010 → T-101 .. T-111                        (PR2 starts after PR1 merge)
+T-101 → T-102                                 (helper before its tests)
+T-101 → T-103 / T-104                         (handlers depend on validation)
+T-103 / T-104 / T-105 → T-106                 (shared SELECT helper)
+T-102 / T-103 / T-104 / T-105 → T-107         (integration needs full surface)
+T-107 → T-108 → T-109 → T-110 → T-111
+```
+
+## Out of scope
+
+- Bulk create / bulk delete.
+- `type` / `delta` mutation (immutable; recreate instead).
+- Goal templates, suggestions, notifications.
+- Soft delete / archive (use `is_enabled=false`).
+- Goal reordering or custom week-start.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -620,7 +620,20 @@ export interface paths {
          */
         get: operations["getGoals"];
         put?: never;
-        post?: never;
+        /**
+         * Create a goal
+         * @description Creates a goal for the authenticated user and returns it in the same
+         *     `Goal` shape as the list endpoint (persisted fields only, no
+         *     `chart_data`).
+         *
+         *     Server-generated fields (`id`, `created_at`, `modified_at`) are assigned
+         *     by the server and ignored if present in the request body. Booleans
+         *     default to `is_enabled=true`, `is_snoozed=false`, `is_inverse=false`.
+         *
+         *     Validation failures (empty title, out-of-range `target_seconds`, unknown
+         *     `type` / `delta`, or filter arrays inconsistent with `type`) return 400.
+         */
+        post: operations["createGoal"];
         delete?: never;
         options?: never;
         head?: never;
@@ -651,10 +664,31 @@ export interface paths {
         get: operations["getGoal"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete a goal
+         * @description Permanently deletes a goal owned by the authenticated user. Returns 204
+         *     with no body on success.
+         *
+         *     Requests for a goal owned by a different user (or an unknown id) return
+         *     404 (not 403) to avoid leaking goal-id existence.
+         */
+        delete: operations["deleteGoal"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update a goal
+         * @description Partially updates a goal owned by the authenticated user. Only the
+         *     fields present in the body change; omitted fields are left untouched.
+         *     Returns the updated goal in the `Goal` shape (no `chart_data`).
+         *
+         *     `type` and `delta` are immutable — sending either returns 400. An empty
+         *     body, or filter arrays inconsistent with the goal's `type`, also return
+         *     400.
+         *
+         *     Requests for a goal owned by a different user return 404 (not 403) to
+         *     avoid leaking goal-id existence.
+         */
+        patch: operations["updateGoal"];
         trace?: never;
     };
     "/leaders": {
@@ -1342,6 +1376,44 @@ export interface components {
             /** Format: date-time */
             modified_at?: string;
         };
+        /**
+         * @description Request body for creating a goal. Server-generated fields (`id`,
+         *     `created_at`, `modified_at`) are omitted and ignored if sent.
+         *
+         *     Conditional filter requirement (enforced server-side, returns 400 on
+         *     violation):
+         *     - `type=coding`: `languages` / `editors` / `projects` MUST be omitted or
+         *       empty.
+         *     - `type=languages`: `languages` MUST be a non-empty array; `editors` and
+         *       `projects` MUST be omitted or empty.
+         *     - `type=editors`: `editors` MUST be a non-empty array; the others empty.
+         *     - `type=projects`: `projects` MUST be a non-empty array; the others empty.
+         */
+        GoalInput: {
+            title: string;
+            /** @enum {string} */
+            type: "coding" | "languages" | "editors" | "projects";
+            /** @enum {string} */
+            delta: "day" | "week";
+            /**
+             * Format: double
+             * @description Target coding seconds per `delta` period. Must be greater than 0 and
+             *     at most 604800 (one week in seconds).
+             */
+            target_seconds: number;
+            /** @description Defaults to `true` when omitted. */
+            is_enabled?: boolean;
+            /** @description Defaults to `false` when omitted. */
+            is_snoozed?: boolean;
+            /**
+             * @description When true the goal is a cap ("stay under target") rather than a
+             *     floor ("reach target"). Defaults to `false` when omitted.
+             */
+            is_inverse?: boolean;
+            languages?: string[];
+            editors?: string[];
+            projects?: string[];
+        };
         GoalWithChart: components["schemas"]["Goal"] & {
             /**
              * @description Always 7 entries in chronological order; the last entry is always
@@ -1362,6 +1434,31 @@ export interface components {
              * @enum {string}
              */
             status: "success" | "fail" | "pending";
+        };
+        /**
+         * @description Request body for partially updating a goal. Only the fields present in the
+         *     body are changed; omitted fields keep their current value. At least one
+         *     mutable field MUST be provided (an empty body returns 400).
+         *
+         *     `type` and `delta` are immutable after creation — changing them would
+         *     reinterpret the goal's historical chart, so callers must delete and
+         *     recreate instead. Both are rejected with 400 if present.
+         *
+         *     Filter arrays must stay consistent with the goal's existing `type` (the
+         *     same rule documented on `GoalInput`). Setting a filter array on a
+         *     `type=coding` goal, or clearing the required array of a filtered goal,
+         *     returns 400.
+         */
+        GoalUpdate: {
+            title?: string;
+            /** Format: double */
+            target_seconds?: number;
+            is_enabled?: boolean;
+            is_snoozed?: boolean;
+            is_inverse?: boolean;
+            languages?: string[];
+            editors?: string[];
+            projects?: string[];
         };
         LeaderboardEntry: {
             rank?: number;
@@ -2599,6 +2696,34 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
         };
     };
+    createGoal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoalInput"];
+            };
+        };
+        responses: {
+            /** @description Goal created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["Goal"];
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
     getGoal: {
         parameters: {
             query?: never;
@@ -2621,6 +2746,59 @@ export interface operations {
                     };
                 };
             };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteGoal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Goal deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateGoal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoalUpdate"];
+            };
+        };
+        responses: {
+            /** @description Updated goal */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["Goal"];
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             404: components["responses"]["NotFound"];
         };


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Goals CRUD** (issue #100), following the SpecKit 2-PR workflow. Adds the OpenAPI surface and generated types for creating, updating, and deleting goals. **No implementation code** — handlers land in PR2 after this merges.

Follow-up to the read path shipped in #95 (spec) / #96 (impl).

## What's in this PR

- **OpenAPI**
  - `POST /users/current/goals` → `createGoal` (201, reuses `Goal` response)
  - `PATCH /users/current/goals/{goal_id}` → `updateGoal` (200, reuses `Goal`)
  - `DELETE /users/current/goals/{goal_id}` → `deleteGoal` (204)
  - New request schemas `GoalInput` (create) and `GoalUpdate` (PATCH)
- **Generated types** regenerated via `npm run generate` (do not hand-edit)
- **SpecKit artifacts** under `specs/100-goals-crud/` (spec, plan, research, data-model, quickstart, openapi-diff, checklist, tasks)

## Key design decisions (see `research.md`)

- `type` and `delta` are **immutable** — `GoalUpdate` omits them; PATCH with either returns 400. Recreate to change them.
- Cross-user / unknown `goal_id` on PATCH/DELETE returns **404** (not 403), consistent with the read path — no goal-id existence leak.
- `DELETE` is a **hard delete** (204); `is_enabled=false` already covers "hide without deleting".
- Empty PATCH body is a **400**, not a silent no-op.
- Two request schemas instead of one so the generated types encode each verb's contract (create requires `type`/`delta`; update can't touch them).
- Filter arrays validated against `type`, de-duplicated, stored as JSON TEXT (matches what the read decoder consumes).

## No schema change

Uses the existing `goals` D1 table. No migration, no new env var, no new dependency.

## SDD / commit order

Two commits: `spec:` (SpecKit + OpenAPI) then `chore:` (regenerated types). No runtime code per the PR1 contract.

## Test plan

- [x] `npm run generate` produces `createGoal`/`updateGoal`/`deleteGoal` + `GoalInput`/`GoalUpdate`; `GoalInput` booleans are optional
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly (`redocly bundle`)
- [ ] PR2 will add the validation helper, handlers, and unit + integration tests