### PR TITLE
feat: Goals CRUD endpoints (PR2/2) #100

### DIFF
--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -4,6 +4,7 @@ import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
 import { isValidTimezone } from "../utils/time-format";
 import { normalizeDateTime } from "../utils/user";
+import { validateGoalInput, validateGoalUpdate, type GoalType } from "../utils/goal-input";
 import {
   buildChart,
   buildDayRanges,
@@ -79,6 +80,23 @@ function rowToGoal(row: GoalRow): Goal {
 const GOAL_COLUMNS = `id, user_id, title, type, delta, target_seconds,
   is_enabled, is_snoozed, is_inverse, languages, editors, projects,
   created_at, modified_at`;
+
+/** Encode a filter array as JSON TEXT, or NULL when empty. */
+function jsonOrNull(values: string[]): string | null {
+  return values.length > 0 ? JSON.stringify(values) : null;
+}
+
+/** Fetch a single goal row scoped to its owner; null when absent or not owned. */
+async function selectGoalRow(
+  db: D1Database,
+  goalId: string,
+  userId: string,
+): Promise<GoalRow | null> {
+  return db
+    .prepare(`SELECT ${GOAL_COLUMNS} FROM goals WHERE id = ? AND user_id = ?`)
+    .bind(goalId, userId)
+    .first<GoalRow>();
+}
 
 const goals = new Hono<AuthEnv>();
 
@@ -241,6 +259,158 @@ goals.get("/goals/:goal_id", async (c) => {
     return c.json({ data: response });
   } catch (err) {
     console.error("GET /goals/:goal_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+goals.post("/goals", async (c) => {
+  const userId = c.get("userId");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const parsed = validateGoalInput(body);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+  const g = parsed.value;
+  const id = crypto.randomUUID();
+
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO goals (id, user_id, title, type, delta, target_seconds,
+         is_enabled, is_snoozed, is_inverse, languages, editors, projects)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        id,
+        userId,
+        g.title,
+        g.type,
+        g.delta,
+        g.target_seconds,
+        g.is_enabled ? 1 : 0,
+        g.is_snoozed ? 1 : 0,
+        g.is_inverse ? 1 : 0,
+        jsonOrNull(g.languages),
+        jsonOrNull(g.editors),
+        jsonOrNull(g.projects),
+      )
+      .run();
+
+    const row = await selectGoalRow(c.env.DB, id, userId);
+    if (!row) {
+      console.error("POST /goals error: inserted goal not found on re-read", id);
+      return c.json({ error: "Internal server error" }, 500);
+    }
+    return c.json({ data: rowToGoal(row) }, 201);
+  } catch (err) {
+    console.error("POST /goals error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+goals.patch("/goals/:goal_id", async (c) => {
+  const userId = c.get("userId");
+  const goalId = c.req.param("goal_id");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  try {
+    const existing = await selectGoalRow(c.env.DB, goalId, userId);
+    if (!existing) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    const existingType = (VALID_TYPES.has(existing.type) ? existing.type : "coding") as GoalType;
+
+    const parsed = validateGoalUpdate(body, existingType);
+    if (!parsed.ok) {
+      return c.json({ error: parsed.error }, 400);
+    }
+    const v = parsed.value;
+
+    // Build the SET clause from a fixed column allowlist — column names are
+    // never taken from user input, only the bound values are.
+    const sets: string[] = [];
+    const binds: (string | number | null)[] = [];
+    if (v.title !== undefined) {
+      sets.push("title = ?");
+      binds.push(v.title);
+    }
+    if (v.target_seconds !== undefined) {
+      sets.push("target_seconds = ?");
+      binds.push(v.target_seconds);
+    }
+    if (v.is_enabled !== undefined) {
+      sets.push("is_enabled = ?");
+      binds.push(v.is_enabled ? 1 : 0);
+    }
+    if (v.is_snoozed !== undefined) {
+      sets.push("is_snoozed = ?");
+      binds.push(v.is_snoozed ? 1 : 0);
+    }
+    if (v.is_inverse !== undefined) {
+      sets.push("is_inverse = ?");
+      binds.push(v.is_inverse ? 1 : 0);
+    }
+    if (v.languages !== undefined) {
+      sets.push("languages = ?");
+      binds.push(jsonOrNull(v.languages));
+    }
+    if (v.editors !== undefined) {
+      sets.push("editors = ?");
+      binds.push(jsonOrNull(v.editors));
+    }
+    if (v.projects !== undefined) {
+      sets.push("projects = ?");
+      binds.push(jsonOrNull(v.projects));
+    }
+    sets.push("modified_at = datetime('now')");
+    binds.push(goalId, userId);
+
+    await c.env.DB.prepare(
+      `UPDATE goals SET ${sets.join(", ")} WHERE id = ? AND user_id = ?`,
+    )
+      .bind(...binds)
+      .run();
+
+    const row = await selectGoalRow(c.env.DB, goalId, userId);
+    if (!row) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json({ data: rowToGoal(row) });
+  } catch (err) {
+    console.error("PATCH /goals/:goal_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+goals.delete("/goals/:goal_id", async (c) => {
+  const userId = c.get("userId");
+  const goalId = c.req.param("goal_id");
+
+  try {
+    const res = await c.env.DB.prepare(
+      `DELETE FROM goals WHERE id = ? AND user_id = ?`,
+    )
+      .bind(goalId, userId)
+      .run();
+
+    if (res.meta.changes === 0) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.body(null, 204);
+  } catch (err) {
+    console.error("DELETE /goals/:goal_id error:", err);
     return c.json({ error: "Internal server error" }, 500);
   }
 });

--- a/src/utils/goal-input.ts
+++ b/src/utils/goal-input.ts
@@ -1,0 +1,256 @@
+/**
+ * Validation for the Goals CRUD request bodies (specs/100-goals-crud/).
+ *
+ * Pure functions: they turn an untrusted parsed JSON value into either a
+ * normalised, ready-to-persist object or a 400-worthy error message. No D1,
+ * no I/O — unit-testable in isolation. Handlers translate the result into a
+ * response.
+ */
+
+export type GoalType = "coding" | "languages" | "editors" | "projects";
+export type GoalDelta = "day" | "week";
+
+export const MAX_TITLE = 200;
+export const MAX_TARGET_SECONDS = 604800; // one week in seconds
+
+const GOAL_TYPES: readonly GoalType[] = ["coding", "languages", "editors", "projects"];
+const GOAL_DELTAS: readonly GoalDelta[] = ["day", "week"];
+
+/** Maps a filtered goal type to the array field that must be non-empty. */
+const FILTER_FIELD: Record<GoalType, FilterField | null> = {
+  coding: null,
+  languages: "languages",
+  editors: "editors",
+  projects: "projects",
+};
+
+type FilterField = "languages" | "editors" | "projects";
+const FILTER_FIELDS: readonly FilterField[] = ["languages", "editors", "projects"];
+
+export interface ValidatedGoalCreate {
+  title: string;
+  type: GoalType;
+  delta: GoalDelta;
+  target_seconds: number;
+  is_enabled: boolean;
+  is_snoozed: boolean;
+  is_inverse: boolean;
+  languages: string[];
+  editors: string[];
+  projects: string[];
+}
+
+/** Only the fields a PATCH actually provided, normalised. */
+export type ValidatedGoalUpdate = Partial<
+  Pick<
+    ValidatedGoalCreate,
+    | "title"
+    | "target_seconds"
+    | "is_enabled"
+    | "is_snoozed"
+    | "is_inverse"
+    | "languages"
+    | "editors"
+    | "projects"
+  >
+>;
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function fail(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validateTitle(raw: unknown): ValidationResult<string> {
+  if (typeof raw !== "string") return fail("title is required and must be a string");
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return fail("title must not be empty");
+  if (trimmed.length > MAX_TITLE) return fail(`title must be at most ${MAX_TITLE} characters`);
+  return { ok: true, value: trimmed };
+}
+
+function validateTargetSeconds(raw: unknown): ValidationResult<number> {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return fail("target_seconds must be a number");
+  }
+  if (raw <= 0 || raw > MAX_TARGET_SECONDS) {
+    return fail(`target_seconds must be greater than 0 and at most ${MAX_TARGET_SECONDS}`);
+  }
+  return { ok: true, value: raw };
+}
+
+function validateBool(raw: unknown, field: string): ValidationResult<boolean> {
+  if (typeof raw !== "boolean") return fail(`${field} must be a boolean`);
+  return { ok: true, value: raw };
+}
+
+/** Validate an array-of-strings field and de-duplicate (order-preserving). */
+function validateStringArray(raw: unknown, field: string): ValidationResult<string[]> {
+  if (!Array.isArray(raw)) return fail(`${field} must be an array of strings`);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (typeof item !== "string") return fail(`${field} must contain only strings`);
+    if (!seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return { ok: true, value: out };
+}
+
+/**
+ * Enforce the filter-array ↔ type matrix:
+ * - coding: every filter array must be empty.
+ * - languages/editors/projects: the matching array must be non-empty, the
+ *   other two empty.
+ * `arrays` only contains fields the caller actually supplied.
+ */
+function checkFilterConsistency(
+  type: GoalType,
+  arrays: Partial<Record<FilterField, string[]>>,
+): string | null {
+  const required = FILTER_FIELD[type];
+  for (const field of FILTER_FIELDS) {
+    const provided = arrays[field];
+    if (provided === undefined) continue;
+    if (field === required) {
+      if (provided.length === 0) {
+        return `${field} must be a non-empty array for a ${type} goal`;
+      }
+    } else if (provided.length > 0) {
+      return `${field} must be empty for a ${type} goal`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate a create (POST) body. Server-generated fields (id, created_at,
+ * modified_at) are ignored if present. Booleans default when omitted.
+ */
+export function validateGoalInput(body: unknown): ValidationResult<ValidatedGoalCreate> {
+  if (!isPlainObject(body)) return fail("Request body must be a JSON object");
+
+  const title = validateTitle(body.title);
+  if (!title.ok) return title;
+
+  if (!GOAL_TYPES.includes(body.type as GoalType)) {
+    return fail(`type must be one of ${GOAL_TYPES.join(", ")}`);
+  }
+  const type = body.type as GoalType;
+
+  if (!GOAL_DELTAS.includes(body.delta as GoalDelta)) {
+    return fail(`delta must be one of ${GOAL_DELTAS.join(", ")}`);
+  }
+  const delta = body.delta as GoalDelta;
+
+  const target = validateTargetSeconds(body.target_seconds);
+  if (!target.ok) return target;
+
+  const booleans: Record<"is_enabled" | "is_snoozed" | "is_inverse", boolean> = {
+    is_enabled: true,
+    is_snoozed: false,
+    is_inverse: false,
+  };
+  for (const field of ["is_enabled", "is_snoozed", "is_inverse"] as const) {
+    if (body[field] !== undefined) {
+      const b = validateBool(body[field], field);
+      if (!b.ok) return b;
+      booleans[field] = b.value;
+    }
+  }
+
+  const arrays: Record<FilterField, string[]> = { languages: [], editors: [], projects: [] };
+  for (const field of FILTER_FIELDS) {
+    if (body[field] !== undefined) {
+      const arr = validateStringArray(body[field], field);
+      if (!arr.ok) return arr;
+      arrays[field] = arr.value;
+    }
+  }
+
+  // Create validates the full set: an omitted required filter array defaults
+  // to [] and must therefore fail the non-empty check.
+  const consistencyError = checkFilterConsistency(type, arrays);
+  if (consistencyError) return fail(consistencyError);
+
+  return {
+    ok: true,
+    value: {
+      title: title.value,
+      type,
+      delta,
+      target_seconds: target.value,
+      is_enabled: booleans.is_enabled,
+      is_snoozed: booleans.is_snoozed,
+      is_inverse: booleans.is_inverse,
+      languages: arrays.languages,
+      editors: arrays.editors,
+      projects: arrays.projects,
+    },
+  };
+}
+
+/**
+ * Validate a partial update (PATCH) body against the goal's existing type.
+ * `type` and `delta` are immutable; an empty update is rejected. Only the
+ * provided fields appear in the result.
+ */
+export function validateGoalUpdate(
+  body: unknown,
+  existingType: GoalType,
+): ValidationResult<ValidatedGoalUpdate> {
+  if (!isPlainObject(body)) return fail("Request body must be a JSON object");
+
+  if ("type" in body || "delta" in body) {
+    return fail("type and delta are immutable; delete and recreate to change them");
+  }
+
+  const value: ValidatedGoalUpdate = {};
+  const suppliedArrays: Partial<Record<FilterField, string[]>> = {};
+
+  if (body.title !== undefined) {
+    const title = validateTitle(body.title);
+    if (!title.ok) return title;
+    value.title = title.value;
+  }
+
+  if (body.target_seconds !== undefined) {
+    const target = validateTargetSeconds(body.target_seconds);
+    if (!target.ok) return target;
+    value.target_seconds = target.value;
+  }
+
+  for (const field of ["is_enabled", "is_snoozed", "is_inverse"] as const) {
+    if (body[field] !== undefined) {
+      const b = validateBool(body[field], field);
+      if (!b.ok) return b;
+      value[field] = b.value;
+    }
+  }
+
+  for (const field of FILTER_FIELDS) {
+    if (body[field] !== undefined) {
+      const arr = validateStringArray(body[field], field);
+      if (!arr.ok) return arr;
+      value[field] = arr.value;
+      suppliedArrays[field] = arr.value;
+    }
+  }
+
+  if (Object.keys(value).length === 0) {
+    return fail("Request body must contain at least one mutable field");
+  }
+
+  const consistencyError = checkFilterConsistency(existingType, suppliedArrays);
+  if (consistencyError) return fail(consistencyError);
+
+  return { ok: true, value };
+}

--- a/tests/aggregation/goal-input.test.ts
+++ b/tests/aggregation/goal-input.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for src/utils/goal-input.ts — pure validation for the Goals
+ * CRUD request bodies (specs/100-goals-crud/). No D1, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  validateGoalInput,
+  validateGoalUpdate,
+  MAX_TARGET_SECONDS,
+  MAX_TITLE,
+} from "../../src/utils/goal-input";
+
+const minimal = {
+  title: "Code daily",
+  type: "coding",
+  delta: "day",
+  target_seconds: 3600,
+};
+
+function expectFail<T>(result: { ok: boolean; error?: string }, fragment?: string) {
+  expect(result.ok).toBe(false);
+  if (fragment && !result.ok) {
+    expect(result.error).toContain(fragment);
+  }
+}
+
+describe("validateGoalInput", () => {
+  it("accepts a minimal coding goal and applies boolean defaults", () => {
+    const r = validateGoalInput(minimal);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toEqual({
+      title: "Code daily",
+      type: "coding",
+      delta: "day",
+      target_seconds: 3600,
+      is_enabled: true,
+      is_snoozed: false,
+      is_inverse: false,
+      languages: [],
+      editors: [],
+      projects: [],
+    });
+  });
+
+  it("honours explicitly provided booleans", () => {
+    const r = validateGoalInput({ ...minimal, is_enabled: false, is_snoozed: true, is_inverse: true });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.is_enabled).toBe(false);
+    expect(r.value.is_snoozed).toBe(true);
+    expect(r.value.is_inverse).toBe(true);
+  });
+
+  it("trims the title and rejects empty / whitespace / overlong titles", () => {
+    const trimmed = validateGoalInput({ ...minimal, title: "  spaced  " });
+    expect(trimmed.ok).toBe(true);
+    if (trimmed.ok) expect(trimmed.value.title).toBe("spaced");
+
+    expectFail(validateGoalInput({ ...minimal, title: "" }));
+    expectFail(validateGoalInput({ ...minimal, title: "   " }));
+    expectFail(validateGoalInput({ ...minimal, title: 123 as unknown as string }), "title");
+    expectFail(validateGoalInput({ ...minimal, title: "x".repeat(MAX_TITLE + 1) }), "200");
+  });
+
+  it("rejects unknown type and delta", () => {
+    expectFail(validateGoalInput({ ...minimal, type: "music" }), "type");
+    expectFail(validateGoalInput({ ...minimal, delta: "fortnight" }), "delta");
+  });
+
+  it("enforces target_seconds bounds (0, 604800]", () => {
+    expectFail(validateGoalInput({ ...minimal, target_seconds: 0 }), "target_seconds");
+    expectFail(validateGoalInput({ ...minimal, target_seconds: -1 }));
+    expectFail(validateGoalInput({ ...minimal, target_seconds: MAX_TARGET_SECONDS + 1 }));
+    expectFail(validateGoalInput({ ...minimal, target_seconds: "3600" as unknown as number }));
+    const boundary = validateGoalInput({ ...minimal, target_seconds: MAX_TARGET_SECONDS });
+    expect(boundary.ok).toBe(true);
+  });
+
+  it("rejects non-boolean flags", () => {
+    expectFail(validateGoalInput({ ...minimal, is_enabled: "yes" as unknown as boolean }), "is_enabled");
+  });
+
+  it("requires a non-empty matching array for filtered goal types", () => {
+    expectFail(validateGoalInput({ ...minimal, type: "languages" }), "languages");
+    expectFail(validateGoalInput({ ...minimal, type: "languages", languages: [] }), "languages");
+    const ok = validateGoalInput({ ...minimal, type: "languages", languages: ["TypeScript"] });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.value.languages).toEqual(["TypeScript"]);
+  });
+
+  it("rejects filter arrays that do not match the type", () => {
+    expectFail(validateGoalInput({ ...minimal, type: "coding", languages: ["Go"] }), "languages");
+    expectFail(
+      validateGoalInput({ ...minimal, type: "languages", languages: ["Go"], editors: ["VSCode"] }),
+      "editors",
+    );
+  });
+
+  it("rejects non-string array members and de-duplicates valid ones", () => {
+    expectFail(
+      validateGoalInput({ ...minimal, type: "languages", languages: ["Go", 7 as unknown as string] }),
+      "languages",
+    );
+    const dedup = validateGoalInput({ ...minimal, type: "editors", editors: ["VSCode", "VSCode", "Vim"] });
+    expect(dedup.ok).toBe(true);
+    if (dedup.ok) expect(dedup.value.editors).toEqual(["VSCode", "Vim"]);
+  });
+
+  it("rejects a non-object body", () => {
+    expectFail(validateGoalInput(null), "JSON object");
+    expectFail(validateGoalInput([1, 2]), "JSON object");
+    expectFail(validateGoalInput("string"), "JSON object");
+  });
+});
+
+describe("validateGoalUpdate", () => {
+  it("rejects a non-object body", () => {
+    expectFail(validateGoalUpdate(null, "coding"), "JSON object");
+  });
+
+  it("rejects immutable type and delta", () => {
+    expectFail(validateGoalUpdate({ type: "languages" }, "coding"), "immutable");
+    expectFail(validateGoalUpdate({ delta: "week" }, "coding"), "immutable");
+  });
+
+  it("rejects an empty body or one with only unrecognised keys", () => {
+    expectFail(validateGoalUpdate({}, "coding"), "at least one");
+    expectFail(validateGoalUpdate({ nonsense: true } as Record<string, unknown>, "coding"), "at least one");
+  });
+
+  it("returns only the provided mutable fields", () => {
+    const r = validateGoalUpdate({ target_seconds: 7200, is_snoozed: true }, "coding");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toEqual({ target_seconds: 7200, is_snoozed: true });
+    expect(r.value).not.toHaveProperty("title");
+  });
+
+  it("validates provided fields with the create rules", () => {
+    expectFail(validateGoalUpdate({ title: "   " }, "coding"));
+    expectFail(validateGoalUpdate({ target_seconds: 0 }, "coding"), "target_seconds");
+    expectFail(validateGoalUpdate({ is_enabled: 1 as unknown as boolean }, "coding"), "is_enabled");
+  });
+
+  it("keeps filter arrays consistent with the goal's existing type", () => {
+    // existing type is languages: matching array must stay non-empty
+    expectFail(validateGoalUpdate({ languages: [] }, "languages"), "languages");
+    const ok = validateGoalUpdate({ languages: ["Go", "Go", "Rust"] }, "languages");
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.value.languages).toEqual(["Go", "Rust"]);
+
+    // existing type is coding: cannot introduce a filter array
+    expectFail(validateGoalUpdate({ languages: ["Go"] }, "coding"), "languages");
+
+    // existing type is languages: cannot set a different dimension's array
+    expectFail(validateGoalUpdate({ editors: ["VSCode"] }, "languages"), "editors");
+  });
+});

--- a/tests/integration/goals-crud.test.ts
+++ b/tests/integration/goals-crud.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration tests for the Goals CRUD endpoints (specs/100-goals-crud/).
+ * Exercises create / update / delete against an in-memory D1, including
+ * validation failures, immutable-field rejection, cross-user 404 isolation,
+ * and authentication. Mirrors the scenarios in quickstart.md (A–H).
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const GOALS = "/api/v1/users/current/goals";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("goals", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authJson(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+interface GoalShape {
+  id: string;
+  title: string;
+  type: string;
+  delta: string;
+  target_seconds: number;
+  is_enabled: boolean;
+  is_snoozed: boolean;
+  is_inverse: boolean;
+  languages: string[];
+  editors: string[];
+  projects: string[];
+  created_at: string;
+  modified_at: string;
+}
+
+async function createGoal(apiKey: string, body: Record<string, unknown>): Promise<Response> {
+  return call(GOALS, { method: "POST", headers: authJson(apiKey), body: JSON.stringify(body) });
+}
+
+// --- Scenario A: minimal create ---------------------------------------------
+
+describe("POST /goals (create)", () => {
+  it("creates a minimal coding goal with defaults applied (201)", async () => {
+    const res = await createGoal(user.apiKey, {
+      title: "Code 1 hour per day",
+      type: "coding",
+      delta: "day",
+      target_seconds: 3600,
+    });
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: GoalShape };
+    expect(data.id).toMatch(/[0-9a-f-]{36}/);
+    expect(data.title).toBe("Code 1 hour per day");
+    expect(data.is_enabled).toBe(true);
+    expect(data.is_snoozed).toBe(false);
+    expect(data.is_inverse).toBe(false);
+    expect(data.languages).toEqual([]);
+    expect(data.created_at).toBeTruthy();
+    expect(data.modified_at).toBeTruthy();
+  });
+
+  // --- Scenario B: filtered create ---
+  it("persists and echoes a language filter (201)", async () => {
+    const res = await createGoal(user.apiKey, {
+      title: "5h TypeScript / week",
+      type: "languages",
+      delta: "week",
+      target_seconds: 18000,
+      languages: ["TypeScript", "TypeScript"],
+    });
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: GoalShape };
+    expect(data.type).toBe("languages");
+    expect(data.languages).toEqual(["TypeScript"]); // de-duplicated
+  });
+
+  it("ignores server-generated fields supplied in the body", async () => {
+    const res = await createGoal(user.apiKey, {
+      id: "client-chosen-id",
+      created_at: "2000-01-01T00:00:00Z",
+      title: "x",
+      type: "coding",
+      delta: "day",
+      target_seconds: 60,
+    });
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: GoalShape };
+    expect(data.id).not.toBe("client-chosen-id");
+    expect(data.created_at).not.toBe("2000-01-01T00:00:00Z");
+  });
+
+  // --- Scenario C: validation failures ---
+  it("rejects invalid bodies with 400", async () => {
+    const bad: Array<Record<string, unknown>> = [
+      { title: "   ", type: "coding", delta: "day", target_seconds: 3600 },
+      { title: "x", type: "coding", delta: "day", target_seconds: 0 },
+      { title: "x", type: "coding", delta: "day", target_seconds: 700000 },
+      { title: "x", type: "music", delta: "day", target_seconds: 3600 },
+      { title: "x", type: "coding", delta: "fortnight", target_seconds: 3600 },
+      { title: "x", type: "coding", delta: "day", target_seconds: 3600, languages: ["Go"] },
+      { title: "x", type: "languages", delta: "day", target_seconds: 3600 },
+    ];
+    for (const body of bad) {
+      const res = await createGoal(user.apiKey, body);
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error: string };
+      expect(typeof json.error).toBe("string");
+    }
+    // None of the bad requests created a row.
+    const list = await call(GOALS, { headers: { Authorization: `Bearer ${user.apiKey}` } });
+    expect((await list.json()) as unknown).toEqual({ data: [] });
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await call(GOALS, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // --- Scenario H: unauthenticated ---
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call(GOALS, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "x", type: "coding", delta: "day", target_seconds: 60 }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- Scenario D & E: update --------------------------------------------------
+
+describe("PATCH /goals/:goal_id (update)", () => {
+  async function createDefault(): Promise<string> {
+    const res = await createGoal(user.apiKey, {
+      title: "Original",
+      type: "languages",
+      delta: "day",
+      target_seconds: 3600,
+      languages: ["Go"],
+    });
+    return ((await res.json()) as { data: GoalShape }).data.id;
+  }
+
+  it("updates only the provided fields and advances modified_at", async () => {
+    const id = await createDefault();
+    // Force an old modified_at so the advance is unambiguous.
+    await env.DB.prepare("UPDATE goals SET modified_at = '2026-01-01 00:00:00' WHERE id = ?")
+      .bind(id)
+      .run();
+
+    const res = await call(`${GOALS}/${id}`, {
+      method: "PATCH",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ target_seconds: 7200, is_snoozed: true }),
+    });
+    expect(res.status).toBe(200);
+    const { data } = (await res.json()) as { data: GoalShape };
+    expect(data.target_seconds).toBe(7200);
+    expect(data.is_snoozed).toBe(true);
+    expect(data.title).toBe("Original"); // untouched
+    expect(data.languages).toEqual(["Go"]); // untouched
+    expect(data.modified_at > "2026-01-01T00:00:00Z").toBe(true);
+  });
+
+  it("rejects immutable type/delta and an empty body with 400", async () => {
+    const id = await createDefault();
+    for (const body of [{ type: "coding" }, { delta: "week" }, {}]) {
+      const res = await call(`${GOALS}/${id}`, {
+        method: "PATCH",
+        headers: authJson(user.apiKey),
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("rejects clearing a filtered goal's array with 400", async () => {
+    const id = await createDefault();
+    const res = await call(`${GOALS}/${id}`, {
+      method: "PATCH",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ languages: [] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown goal id", async () => {
+    const res = await call(`${GOALS}/missing`, {
+      method: "PATCH",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call(`${GOALS}/anything`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- Scenario F: delete ------------------------------------------------------
+
+describe("DELETE /goals/:goal_id", () => {
+  it("deletes an owned goal (204) and removes it from subsequent reads", async () => {
+    const created = await createGoal(user.apiKey, {
+      title: "to delete",
+      type: "coding",
+      delta: "day",
+      target_seconds: 60,
+    });
+    const id = ((await created.json()) as { data: GoalShape }).data.id;
+
+    const del = await call(`${GOALS}/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(del.status).toBe(204);
+    expect(await del.text()).toBe("");
+
+    const get = await call(`${GOALS}/${id}`, { headers: { Authorization: `Bearer ${user.apiKey}` } });
+    expect(get.status).toBe(404);
+
+    const list = await call(GOALS, { headers: { Authorization: `Bearer ${user.apiKey}` } });
+    const { data } = (await list.json()) as { data: GoalShape[] };
+    expect(data.find((g) => g.id === id)).toBeUndefined();
+  });
+
+  it("returns 404 for an unknown goal id", async () => {
+    const res = await call(`${GOALS}/missing`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    // application/json content-type bypasses the form-style CSRF guard, so the
+    // request reaches authMiddleware (the path real API clients take).
+    const res = await call(`${GOALS}/anything`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- Scenario G: cross-user isolation ---------------------------------------
+
+describe("cross-user isolation", () => {
+  it("returns 404 (and leaves the row untouched) for PATCH/DELETE on another user's goal", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    const created = await createGoal(bob.apiKey, {
+      title: "bob's goal",
+      type: "coding",
+      delta: "day",
+      target_seconds: 3600,
+    });
+    const bobGoalId = ((await created.json()) as { data: GoalShape }).data.id;
+
+    const patch = await call(`${GOALS}/${bobGoalId}`, {
+      method: "PATCH",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ title: "hijacked" }),
+    });
+    expect(patch.status).toBe(404);
+
+    const del = await call(`${GOALS}/${bobGoalId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(del.status).toBe(404);
+
+    // Bob still sees his goal unchanged.
+    const bobRead = await call(`${GOALS}/${bobGoalId}`, {
+      headers: { Authorization: `Bearer ${bob.apiKey}` },
+    });
+    expect(bobRead.status).toBe(200);
+    const { data } = (await bobRead.json()) as { data: GoalShape };
+    expect(data.title).toBe("bob's goal");
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for **Goals CRUD** (issue #100), following the SpecKit 2-PR workflow. Wires the create / update / delete handlers spec'd in #116 (merged). Adds the validation module, the three handlers, and unit + integration tests.

Follow-up to the read path (#95 / #96) and the spec PR (#116).

## Endpoints

| Method | Path | Result |
|---|---|---|
| `POST` | `/users/current/goals` | 201 `{data: Goal}` |
| `PATCH` | `/users/current/goals/{goal_id}` | 200 `{data: Goal}` |
| `DELETE` | `/users/current/goals/{goal_id}` | 204 |

## What's in this PR

- **`src/utils/goal-input.ts`** — pure `validateGoalInput` / `validateGoalUpdate` returning a discriminated `{ ok, value | error }`. Enforces: title trimmed 1–200, `target_seconds` in `(0, 604800]`, `type`/`delta` enums, filter-array ↔ type consistency, array de-duplication, boolean defaults (`is_enabled=true`, others `false`), immutable `type`/`delta`, and non-empty PATCH.
- **`src/routes/goals.ts`** — three handlers added next to the read path. All scoped by `user_id` (cross-user PATCH/DELETE → 404, no existence leak). PATCH builds its `SET` clause from a fixed column allowlist and always bumps `modified_at`. Create/update reuse the existing `rowToGoal` decoder via a shared `selectGoalRow` helper. `crypto.randomUUID()` for ids; body-supplied `id`/`created_at`/`modified_at` ignored.
- **Tests** — `tests/aggregation/goal-input.test.ts` (validation rules incl. the 604800 boundary, filter/type matrix, de-dup, immutable rejection, empty-update) and `tests/integration/goals-crud.test.ts` (quickstart scenarios A–H, including cross-user 404 with two seeded users and malformed-JSON 400).

## No schema / type change

The OpenAPI surface and generated types landed in PR1 (#116). This PR is implementation + tests only — no `schemas/` or `src/types/generated.ts` diff.

## Notes

- The route was already mounted at `/api/v1/users/current` for the read path, so no `src/index.ts` change.
- Unauthenticated mutation requests reach `authMiddleware` (401) when sent with `application/json`; the form-style global CSRF guard is intentionally not exercised by JSON API clients.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 168 passing (existing + new unit + integration)
- [ ] Manual `quickstart.md` Scenarios A / D / F / G against a staging worker