### PR TITLE
spec: Custom Rules CRUD + heartbeat remap (PR1/2) #101

### DIFF
--- a/schemas/components/schemas/CustomRule.yaml
+++ b/schemas/components/schemas/CustomRule.yaml
@@ -12,11 +12,16 @@ properties:
     type: string
   action:
     type: string
+    description: |
+      `change` remaps the matched heartbeat's `destination` column to
+      `destination_value`. `hide` drops the heartbeat from persistence
+      (it is not stored or aggregated).
     enum:
       - change
-      - delete
+      - hide
   source:
     type: string
+    description: The heartbeat dimension matched against `source_value`.
     enum:
       - project
       - language
@@ -26,15 +31,22 @@ properties:
       - entity
   operation:
     type: string
+    description: |
+      How `source_value` is compared to the heartbeat's `source` field.
+      Regex is intentionally unsupported in this version (Workers CPU
+      budget); adding it later is additive.
     enum:
       - equals
       - contains
-      - starts with
-      - ends with
+      - starts_with
+      - ends_with
   source_value:
     type: string
   destination:
     type: string
+    description: |
+      The heartbeat dimension rewritten by a `change` action. Ignored for
+      `hide` actions.
     enum:
       - project
       - language
@@ -46,3 +58,9 @@ properties:
     type: string
   priority:
     type: integer
+    description: |
+      Rules are applied in ascending priority order (lowest first). Ties
+      break by `created_at`.
+  created_at:
+    type: string
+    format: date-time

--- a/schemas/components/schemas/CustomRuleInput.yaml
+++ b/schemas/components/schemas/CustomRuleInput.yaml
@@ -1,20 +1,23 @@
 type: object
+description: |
+  One rule in a `PUT /users/current/custom_rules` payload. The PUT replaces
+  the entire rule set, so `id` and `created_at` are server-managed and
+  ignored on input.
+
+  Conditional requirement (enforced server-side, returns 400 on violation):
+  `change` actions require `destination` and a non-empty `destination_value`;
+  `hide` actions ignore both (omit them).
 required:
   - action
   - source
   - operation
   - source_value
-  - destination
-  - destination_value
 properties:
-  id:
-    type: string
-    description: Include to update existing rule
   action:
     type: string
     enum:
       - change
-      - delete
+      - hide
   source:
     type: string
     enum:
@@ -29,12 +32,14 @@ properties:
     enum:
       - equals
       - contains
-      - starts with
-      - ends with
+      - starts_with
+      - ends_with
   source_value:
     type: string
+    minLength: 1
   destination:
     type: string
+    description: Required for `change` actions; ignored for `hide`.
     enum:
       - project
       - language
@@ -44,5 +49,7 @@ properties:
       - entity
   destination_value:
     type: string
+    description: Required (non-empty) for `change` actions; ignored for `hide`.
   priority:
     type: integer
+    description: Ascending order of application. Defaults to the array index when omitted.

--- a/schemas/paths/insights/custom-rule.yaml
+++ b/schemas/paths/insights/custom-rule.yaml
@@ -3,6 +3,11 @@ delete:
   tags:
     - custom_rules
   summary: Delete a custom rule
+  description: |
+    Deletes a single rule owned by the authenticated user and returns 204.
+    A rule owned by a different user (or an unknown id) returns 404 (not
+    403) to avoid leaking rule-id existence. Deleting a rule invalidates the
+    user's cached rule set used by heartbeat ingestion.
   parameters:
     - name: rule_id
       in: path
@@ -14,3 +19,5 @@ delete:
       description: Rule deleted
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml

--- a/schemas/paths/insights/custom-rules.yaml
+++ b/schemas/paths/insights/custom-rules.yaml
@@ -3,6 +3,10 @@ get:
   tags:
     - custom_rules
   summary: List user's custom rules
+  description: |
+    Returns the authenticated user's custom rules ordered by `priority`
+    ascending (ties broken by `created_at`). This is the order in which the
+    rules are applied to incoming heartbeats.
   responses:
     '200':
       description: List of custom rules
@@ -24,6 +28,16 @@ put:
   tags:
     - custom_rules
   summary: Replace user's custom rules
+  description: |
+    Replaces the authenticated user's entire rule set with the supplied
+    array (full-replace semantics, not a merge). An empty array clears all
+    rules. Server assigns each rule a fresh `id` and `created_at`; when
+    `priority` is omitted the array index is used. Returns the persisted
+    rules in application order.
+
+    Validation failures (unknown enum value, `change` rule missing
+    `destination` / `destination_value`, or empty `source_value`) return 400
+    and leave the existing rule set unchanged.
   requestBody:
     required: true
     content:
@@ -46,5 +60,7 @@ put:
                 type: array
                 items:
                   $ref: ../../components/schemas/CustomRule.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/specs/101-custom-rules-crud/checklists/requirements.md
+++ b/specs/101-custom-rules-crud/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Acceptance Checklist: Custom Rules CRUD + Heartbeat Remap
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-012 (CRUD + remap) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` documents the `action`/`operation` reconciliations and the regex deferral.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 8 design decisions.
+- [x] `data-model.md` confirms no schema change and documents the write-path, KV cache, and remap field treatment.
+- [x] `quickstart.md` enumerates scenarios A–J (CRUD + change/hide ingestion).
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the enum reconciliation and the `400`/`404` additions.
+- [x] `CustomRule.yaml` / `CustomRuleInput.yaml` updated (`change|hide`, underscore operations, conditional destination).
+- [x] `custom-rules.yaml` PUT has `400`; `custom-rule.yaml` DELETE has `404`.
+- [x] `npm run generate` reflects the new enums and responses; `npm run typecheck` passes.
+- [x] PR1 contains no changes under `src/routes/` or `src/utils/` (no runtime code).
+- [x] PR1 references issue #101.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/custom-rule-input.ts` validates a PUT array → normalised rows | error (enum checks, `change` requires destination + non-empty destination_value, `source_value` non-empty, ≤ 50 rules).
+- [ ] `src/utils/custom-rules.ts` exports a pure `applyRules(heartbeat, rules)` (returns mutated heartbeat or `null` for hide) + `loadRules` / `invalidateRules` KV helpers.
+- [ ] `src/routes/custom-rules.ts` exports a Hono sub-app: `GET` (ordered), `PUT` (atomic `db.batch` replace + cache invalidate), `DELETE` (`204`/`404` + cache invalidate), all behind `authMiddleware`.
+- [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
+- [ ] `src/routes/heartbeats.ts` applies rules before INSERT on `POST /heartbeats` and `/heartbeats.bulk`; hidden heartbeats are filtered from the batch; per-item response order preserved.
+- [ ] Hide-response shape verified against the documented WakaTime-compatible bulk contract (not by reading WakaTime source).
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: PUT replaces; B: list ordered by priority; C: invalid PUT → 400, set unchanged; D: `[]` clears.
+- [ ] E: `change` rewrites an ingested heartbeat; F: `hide` drops one (request still succeeds, no leak).
+- [ ] G: bulk mix persists/changes/hides correctly with preserved order.
+- [ ] H: DELETE 204 + cache invalidated; I: cross-user 404; J: unauthenticated 401.
+
+### Tests
+
+- [ ] `tests/aggregation/custom-rules.test.ts` (or `tests/security/`): pure matcher — each operation, change vs hide, sequential priority, short-circuit on hide, null source field, dedupe/cap.
+- [ ] `tests/security/custom-rule-input.test.ts`: validation rules incl. cap and conditional destination.
+- [ ] `tests/integration/custom-rules.test.ts`: CRUD scenarios A–D, H, I, J + cross-user.
+- [ ] `tests/integration/custom-rules-heartbeat.test.ts`: ingestion scenarios E, F, G (change/hide on POST + bulk).
+- [ ] `npm test` stays green with the new coverage.
+
+### Performance
+
+- [ ] No per-rule D1 read in the ingestion loop; rules loaded once per request via KV.
+- [ ] Rule-count cap enforced; regex not accepted.
+
+## Post-deployment gate
+
+- [ ] Create a rename rule on a real instance; confirm a new heartbeat lands under the remapped value.
+- [ ] Confirm a `hide` rule keeps matched heartbeats out of `summaries` after the next aggregation cycle.
+- [ ] No 500s on the custom-rules endpoints or the heartbeat hot path in the first 7 days.

--- a/specs/101-custom-rules-crud/checklists/requirements.md
+++ b/specs/101-custom-rules-crud/checklists/requirements.md
@@ -25,7 +25,7 @@
 - [ ] `src/routes/custom-rules.ts` exports a Hono sub-app: `GET` (ordered), `PUT` (atomic `db.batch` replace + cache invalidate), `DELETE` (`204`/`404` + cache invalidate), all behind `authMiddleware`.
 - [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
 - [ ] `src/routes/heartbeats.ts` applies rules before INSERT on `POST /heartbeats` and `/heartbeats.bulk`; hidden heartbeats are filtered from the batch; per-item response order preserved.
-- [ ] Hide-response shape verified against the documented WakaTime-compatible bulk contract (not by reading WakaTime source).
+- [ ] Hide-response shape verified against the documented WakaTime-compatible bulk contract (not by reading upstream source).
 - [ ] `npm run typecheck` passes; no hand-edited generated types.
 
 ### Behaviour (per `quickstart.md`)

--- a/specs/101-custom-rules-crud/contracts/openapi-diff.md
+++ b/specs/101-custom-rules-crud/contracts/openapi-diff.md
@@ -1,0 +1,66 @@
+# OpenAPI Diff
+
+This PR reconciles the pre-declared custom-rules surface and adds the missing
+error responses. The operations themselves (`getCustomRules`,
+`updateCustomRules`, `deleteCustomRule`) already existed.
+
+## Files touched
+
+1. `schemas/components/schemas/CustomRule.yaml` — enum + field reconciliation.
+2. `schemas/components/schemas/CustomRuleInput.yaml` — enum reconciliation + conditional fields.
+3. `schemas/paths/insights/custom-rules.yaml` — add `400` to `PUT`; clarify GET/PUT descriptions.
+4. `schemas/paths/insights/custom-rule.yaml` — add `404` to `DELETE`.
+
+No new path items (all three operations were already declared and mounted in
+`schemas/openapi.yaml`).
+
+## Schema changes
+
+### `CustomRule` (response)
+
+- `action`: `change | delete` → **`change | hide`** (+ description).
+- `operation`: `equals | contains | starts with | ends with` →
+  **`equals | contains | starts_with | ends_with`** (+ "no regex" note).
+- `destination` / `destination_value`: documented as ignored for `hide`.
+- Added `created_at` (date-time) — exposed for the priority tie-break ordering.
+
+### `CustomRuleInput` (PUT body element)
+
+- Same `action` / `operation` reconciliation.
+- `destination` / `destination_value` moved **out of `required`** — required for
+  `change`, ignored for `hide` (server-enforced; documented in the schema).
+- `source_value`: `minLength: 1`.
+- `priority`: documented to default to the array index when omitted.
+- Removed the `id` input field — PUT is a full replace; ids are server-assigned.
+
+## Response additions
+
+- `PUT /users/current/custom_rules`: add `400` (validation) — set is left
+  unchanged on failure.
+- `DELETE /users/current/custom_rules/{rule_id}`: add `404` (cross-user /
+  unknown id; no existence leak).
+
+## Generated-types impact
+
+`npm run generate` updates `src/types/generated.ts`:
+
+- `components["schemas"]["CustomRule"].action` → `"change" | "hide"`;
+  `.operation` → `"equals" | "contains" | "starts_with" | "ends_with"`; adds
+  optional `created_at`.
+- `components["schemas"]["CustomRuleInput"]` → same enums; `destination` /
+  `destination_value` optional; no `id`.
+- `operations["updateCustomRules"]` gains a `400` response;
+  `operations["deleteCustomRule"]` gains a `404` response.
+
+## Heartbeat remap — no contract change in PR1
+
+The ingestion-time enforcement (rewrite/drop on `POST /heartbeats` and
+`/heartbeats.bulk`) is behavioural and lands in PR2. The bulk-response shape
+for hidden heartbeats will be verified against the documented
+WakaTime-compatible contract in PR2; no heartbeat schema change is anticipated.
+
+## SDD compliance note
+
+PR1 lands SpecKit + schema reconciliation + generated types. PR2 lands the
+CRUD handlers, the validation + matcher modules, the ingestion hook, and tests.
+No runtime code in PR1.

--- a/specs/101-custom-rules-crud/data-model.md
+++ b/specs/101-custom-rules-crud/data-model.md
@@ -1,0 +1,81 @@
+# Data Model: Custom Rules CRUD + Heartbeat Remap
+
+No schema changes. Uses the existing `custom_rules` table and existing `heartbeats` columns.
+
+## `custom_rules` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS custom_rules (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  action TEXT NOT NULL DEFAULT 'change',     -- change | hide
+  source TEXT NOT NULL,                       -- project | language | editor | operating_system | category | entity
+  operation TEXT NOT NULL,                    -- equals | contains | starts_with | ends_with
+  source_value TEXT NOT NULL,
+  destination TEXT NOT NULL,                  -- change: target column; hide: "" (ignored)
+  destination_value TEXT NOT NULL,            -- change: new value; hide: "" (ignored)
+  priority INTEGER NOT NULL DEFAULT 0,        -- ascending application order
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_custom_rules_user ON custom_rules(user_id);
+```
+
+Note: the table has no `modified_at`. Because PUT is a full replace (rows are recreated), `created_at` alone is sufficient and acts as the deterministic tie-breaker within a priority.
+
+### Write-path field treatment
+
+| Column | PUT (per array element) |
+|---|---|
+| `id` | Server `crypto.randomUUID()`; input ignored |
+| `user_id` | Authenticated user; bound in every INSERT |
+| `action` | Required enum `change` / `hide` |
+| `source` | Required dimension enum |
+| `operation` | Required enum (no regex) |
+| `source_value` | Required, non-empty |
+| `destination` | Required for `change`; stored `""` for `hide` |
+| `destination_value` | Required non-empty for `change`; stored `""` for `hide` |
+| `priority` | Provided integer, else the array index |
+| `created_at` | `datetime('now')`; input ignored |
+
+## Statements issued
+
+### List
+```sql
+SELECT id, action, source, operation, source_value, destination, destination_value,
+       priority, created_at
+  FROM custom_rules
+ WHERE user_id = ?
+ ORDER BY priority ASC, created_at ASC;
+```
+
+### Replace (PUT) — atomic batch
+```sql
+-- single db.batch([...]):
+DELETE FROM custom_rules WHERE user_id = ?;
+INSERT INTO custom_rules (id, user_id, action, source, operation, source_value,
+                          destination, destination_value, priority)
+VALUES (?,?,?,?,?,?,?,?,?);   -- one INSERT per validated element
+```
+Validation runs fully before the batch; a 400 means no statement executed.
+
+### Delete
+```sql
+DELETE FROM custom_rules WHERE id = ? AND user_id = ?;   -- 404 when meta.changes === 0
+```
+
+## KV cache
+
+- **Key**: `customrules:${user_id}`
+- **Value**: JSON array of compiled rules, pre-sorted by `priority` then `created_at`.
+- **Read**: heartbeat ingestion reads the cache; on miss it runs the List SELECT, sorts, and repopulates.
+- **Invalidate**: `PUT` and `DELETE` delete the key. (An optional short TTL can be added later as a safety net; correctness comes from explicit invalidation.)
+
+## Heartbeat remap (read of rules, mutation in memory)
+
+The matcher reads these `heartbeats` columns as both match `source` and rewrite `destination` targets: `project`, `language`, `editor`, `operating_system`, `category`, `entity`. The heartbeat row is mutated **in memory** before the existing INSERT; no new columns, no extra D1 reads inside the loop. `hide` matches remove the heartbeat from the batch entirely.
+
+## Cleanup / cascade
+
+`custom_rules` has `ON DELETE CASCADE` from `users`; deleting a user removes their rules and (separately) their cache key expires naturally / is unused once the user is gone.

--- a/specs/101-custom-rules-crud/plan.md
+++ b/specs/101-custom-rules-crud/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Custom Rules CRUD + Heartbeat Remap
+
+**Branch**: `101-custom-rules-crud` | **Date**: 2026-05-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/101-custom-rules-crud/spec.md`
+
+## Summary
+
+Two parts: (1) a CRUD surface for `custom_rules` (`GET` list, `PUT` full-replace, `DELETE` one), and (2) ingestion-time enforcement that rewrites or drops heartbeats per the user's rules on `POST /heartbeats` and `POST /heartbeats.bulk`. Rules are KV-cached per user and invalidated on mutation so the heartbeat hot path avoids a D1 read.
+
+PR1 (this PR): SpecKit artifacts + the reconciled OpenAPI (`action: change|hide`, underscore `operation` tokens, conditional `destination`, `400`/`404` responses) + regenerated types. No runtime code. PR2: validation module, CRUD handlers, the remap helper, the ingestion hook, and tests.
+
+No D1 migration, no new binding (KV already bound).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`custom_rules`, existing); KV (rule-set cache, existing binding)
+**Testing**: Vitest + workers pool — unit tests for matching/validation, integration tests for CRUD + ingestion remap
+**Performance Goals**: <10ms CPU per heartbeat request; no per-rule D1 read; string ops only
+**Constraints**: Workers CPU budget; D1 batch for the PUT replace
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI reconciled first (this PR); `npm run generate` re-emits `CustomRule` / `CustomRuleInput` and the `400`/`404` responses. Handlers land in PR2. |
+| II. Cloudflare-Native | PASS | D1 + existing KV cache. PUT uses `db.batch()` for the atomic replace. No new services. |
+| III. Type Safety | PASS | Handlers consume `components["schemas"]["CustomRule"]` / `["CustomRuleInput"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Rule semantics designed from our own schema + issue #101. The one wire-protocol touch point (hide-response shape) is verified against the documented WakaTime-compatible contract, never by reading their source. |
+| V. Simplicity First | PASS | One validation module, one pure `applyRules` matcher, three thin handlers, one ingestion hook. Regex deferred to avoid an engine + time-boxing. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/101-custom-rules-crud/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── custom-rules.ts        # NEW: getCustomRules / updateCustomRules / deleteCustomRule
+├── utils/
+│   ├── custom-rule-input.ts   # NEW: validateCustomRules(body) → normalised rows | error
+│   └── custom-rules.ts        # NEW: loadRules(cache) + applyRules(heartbeat, rules) (pure matcher)
+├── routes/heartbeats.ts       # EXTEND: apply rules before INSERT (single + bulk)
+└── index.ts                   # NEW route mount: app.route("/api/v1/users/current", customRules)
+```
+
+**Structure Decision**: CRUD handlers in a new `custom-rules.ts` router (one router per resource). The matcher (`applyRules`) is a pure function over a heartbeat-like object + rule list so it is unit-testable without D1 or KV. Cache load/invalidate helpers wrap KV.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. `action` = **`change | hide`** (reconciled from `delete`).
+2. `operation` = **`equals | contains | starts_with | ends_with`**; **regex deferred**.
+3. **PUT is full-replace** via `db.batch([DELETE all, INSERT each])`; validate before writing.
+4. Cross-user / unknown DELETE → **404**.
+5. **KV-cached rule set** keyed by `user_id`, invalidated on PUT/DELETE.
+6. **Sequential application** by priority; first `hide` short-circuits.
+7. **hide-response shape** mirrors the WakaTime-compatible bulk contract — verified in PR2.
+8. **Validation cap** ≤ 50 rules; `hide` stores empty-string destination to satisfy NOT NULL.
+
+## Phase 1 — Design Outputs
+
+### Matcher sketch (pure, unit-testable)
+
+```ts
+// src/utils/custom-rules.ts
+export interface CompiledRule {
+  action: "change" | "hide";
+  source: HeartbeatField;
+  operation: "equals" | "contains" | "starts_with" | "ends_with";
+  source_value: string;
+  destination: HeartbeatField;
+  destination_value: string;
+  priority: number;
+}
+
+type Mutable = Record<HeartbeatField, string | null | undefined>;
+
+/** Returns the mutated heartbeat, or null when a hide rule matched. */
+export function applyRules<T extends Mutable>(hb: T, rules: CompiledRule[]): T | null {
+  for (const rule of rules) {            // pre-sorted by priority, created_at
+    const field = hb[rule.source];
+    if (typeof field !== "string" || !matches(field, rule.operation, rule.source_value)) continue;
+    if (rule.action === "hide") return null;
+    (hb as Mutable)[rule.destination] = rule.destination_value;
+  }
+  return hb;
+}
+```
+
+### Cache helpers
+
+```ts
+// key: `customrules:${userId}` in KV; value: JSON CompiledRule[]
+loadRules(env, userId): Promise<CompiledRule[]>      // KV hit → parse; miss → D1 SELECT + populate
+invalidateRules(env, userId): Promise<void>          // KV delete; called by PUT + DELETE
+```
+
+### CRUD handler sketch
+
+```ts
+customRules.get("/custom_rules", … ORDER BY priority ASC, created_at ASC);
+customRules.put("/custom_rules", async (c) => {
+  const parsed = validateCustomRules(await c.req.json().catch(() => null));
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  const rows = parsed.value.map((r, i) => ({ id: crypto.randomUUID(), priority: r.priority ?? i, ...r }));
+  await c.env.DB.batch([deleteAllForUser, ...rows.map(insert)]);
+  await invalidateRules(c.env, userId);
+  return c.json({ data: rows.map(rowToCustomRule) });
+});
+customRules.delete("/custom_rules/:rule_id", async (c) => {
+  const res = await db.prepare("DELETE … WHERE id=? AND user_id=?").run();
+  if (res.meta.changes === 0) return c.json({ error: "Not found" }, 404);
+  await invalidateRules(c.env, userId);
+  return c.body(null, 204);
+});
+```
+
+### Ingestion hook
+
+`POST /heartbeats` and `/heartbeats.bulk` call `loadRules` once per request, then `applyRules` per heartbeat. `null` results are filtered out before the batch INSERT; the per-item response still reports success at the original index (shape confirmed against the WakaTime-compatible contract in PR2).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+The only non-trivial piece is the ingestion hook touching an existing hot path. Mitigations: pure matcher (testable in isolation), KV cache (no per-request D1 read), regex excluded (bounded CPU), and a rule-count cap.

--- a/specs/101-custom-rules-crud/quickstart.md
+++ b/specs/101-custom-rules-crud/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart: Custom Rules CRUD + Heartbeat Remap
+
+Manual verification once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+export HJ="$H
+Content-Type: application/json"
+```
+
+## Scenario A — Replace rule set
+
+```bash
+curl -sX PUT "$BASE/users/current/custom_rules" -H "$H" -H "Content-Type: application/json" -d '[
+  {"action":"change","source":"project","operation":"equals","source_value":"cloudtime-old",
+   "destination":"project","destination_value":"cloudtime"},
+  {"action":"hide","source":"project","operation":"starts_with","source_value":"work/"}
+]'
+```
+
+**Expected**: 200, `data` has two rules, each with a server `id` and `created_at`, `priority` 0 and 1.
+
+## Scenario B — List (ordered by priority)
+
+```bash
+curl -sH "$H" "$BASE/users/current/custom_rules"
+```
+
+**Expected**: the two rules in ascending priority order.
+
+## Scenario C — Validation failures (400, set unchanged)
+
+```bash
+# change rule missing destination_value
+-d '[{"action":"change","source":"project","operation":"equals","source_value":"x","destination":"project"}]'
+# unknown action
+-d '[{"action":"drop","source":"project","operation":"equals","source_value":"x"}]'
+# empty source_value
+-d '[{"action":"hide","source":"project","operation":"equals","source_value":""}]'
+```
+
+**Expected**: each returns 400; a follow-up `GET` still shows the Scenario A rules (unchanged).
+
+## Scenario D — Empty array clears all
+
+```bash
+curl -sX PUT "$BASE/users/current/custom_rules" -H "$H" -H "Content-Type: application/json" -d '[]'
+curl -sH "$H" "$BASE/users/current/custom_rules"
+```
+
+**Expected**: PUT 200; GET returns `{"data":[]}`.
+
+## Scenario E — `change` rewrites an ingested heartbeat
+
+Re-apply Scenario A, then:
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/x.ts","type":"file","time":'"$(date +%s)"',"project":"cloudtime-old"}'
+# then read today's heartbeats:
+curl -sH "$H" "$BASE/users/current/heartbeats?date=$(date +%F)"
+```
+
+**Expected**: the stored heartbeat has `project":"cloudtime"` (remapped), not `cloudtime-old`.
+
+## Scenario F — `hide` drops an ingested heartbeat
+
+```bash
+curl -siX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/y.ts","type":"file","time":'"$(date +%s)"',"project":"work/secret"}'
+curl -sH "$H" "$BASE/users/current/heartbeats?date=$(date +%F)"
+```
+
+**Expected**: the POST reports success (no error), but the heartbeat does **not** appear in the day's list — it was hidden. The response gives no indication which item was dropped.
+
+## Scenario G — Bulk mix
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats.bulk" -H "$H" -H "Content-Type: application/json" -d '[
+  {"entity":"/a.ts","type":"file","time":'"$(date +%s)"',"project":"cloudtime-old"},
+  {"entity":"/b.ts","type":"file","time":'"$(date +%s)"',"project":"work/secret"},
+  {"entity":"/c.ts","type":"file","time":'"$(date +%s)"',"project":"keep"}
+]'
+```
+
+**Expected**: per-item responses in order; reading back shows `/a.ts` stored as `project=cloudtime`, `/b.ts` absent (hidden), `/c.ts` stored as `keep`.
+
+## Scenario H — Delete one rule
+
+```bash
+RULE_ID=$(curl -sH "$H" "$BASE/users/current/custom_rules" | jq -r '.data[0].id')
+curl -siX DELETE "$BASE/users/current/custom_rules/$RULE_ID" -H "$H"
+```
+
+**Expected**: 204; the rule is gone from `GET`; subsequent ingestion no longer applies it (cache invalidated).
+
+## Scenario I — Cross-user 404
+
+```bash
+curl -siX DELETE "$BASE/users/current/custom_rules/$OTHER_USERS_RULE_ID" -H "$H"
+```
+
+**Expected**: 404; the other user's rule is untouched.
+
+## Scenario J — Unauthenticated
+
+```bash
+curl -si "$BASE/users/current/custom_rules"   # GET, no auth
+```
+
+**Expected**: 401.
+
+## Reverting / cleanup
+
+`PUT []` clears all rules; once cleared, ingestion is a no-op pass-through. Removing the router mount and the ingestion hook disables the feature without data loss (existing heartbeats are unaffected — rules only act at ingestion time).

--- a/specs/101-custom-rules-crud/research.md
+++ b/specs/101-custom-rules-crud/research.md
@@ -77,7 +77,7 @@
 
 ## Decision 7: `hide` success-response shape verified against the WakaTime-compatible contract
 
-**Decision**: When a `hide` rule drops a heartbeat, the endpoint still returns a per-item *success* result (so callers cannot enumerate what was dropped). The **exact** shape (status code per item, `data` null vs echoed) will be finalised in PR2 by checking the documented WakaTime-compatible bulk-heartbeat response and `wakatime-cli`'s expectations — **not** by reading WakaTime source.
+**Decision**: When a `hide` rule drops a heartbeat, the endpoint still returns a per-item *success* result (so callers cannot enumerate what was dropped). The **exact** shape (status code per item, `data` null vs echoed) will be finalised in PR2 by checking the documented WakaTime-compatible bulk-heartbeat response and compatible CLI expectations — **not** by reading upstream source.
 
 **Rationale**:
 - The bulk heartbeat response is wire-protocol consumed by editor plugins; diverging risks plugin errors. Project rule: verify wire-protocol behaviour against the CLI/API docs first.

--- a/specs/101-custom-rules-crud/research.md
+++ b/specs/101-custom-rules-crud/research.md
@@ -1,0 +1,98 @@
+# Research: Custom Rules CRUD + Heartbeat Remap
+
+## Decision 1: `action` = `change | hide` (reconciled from `change | delete`)
+
+**Decision**: The action enum is `change` and `hide`. `hide` drops the heartbeat from persistence.
+
+**Rationale**:
+- The issue (#101) describes the two semantics as "remap" and "drop the heartbeat" and names the latter `hide`.
+- `delete` was ambiguous in the pre-existing schema — it reads as "delete the rule" rather than "discard the heartbeat." `hide` is unambiguous and matches the intent.
+- This is a spec-first PR, the correct place to reconcile a schema-level wording issue per the repo's SDD rules.
+
+**Alternative considered**: keep `delete`. Rejected for ambiguity.
+
+---
+
+## Decision 2: `operation` set + regex deferral
+
+**Decision**: `operation` ∈ `equals | contains | starts_with | ends_with` (underscored tokens). `regex` is **not** included in this version.
+
+**Rationale**:
+- The pre-existing tokens used embedded spaces (`starts with`) which are awkward as API enum values and JSON keys; underscores are conventional.
+- The issue flags regex as a CPU risk on Workers (10ms budget) and explicitly allows restricting to non-regex operators in the first cut. Unbounded user regex against every heartbeat field is a ReDoS / budget hazard that would need engine time-boxing we are not adding now.
+- Adding `regex` later is a purely additive enum change — no break for existing clients.
+
+**Alternative considered**: include `regex` with a length/timeout guard. Deferred — the guard is its own design problem and not needed for the rename/hide use cases that motivate the issue.
+
+---
+
+## Decision 3: PUT is full-replace, validated before write
+
+**Decision**: `PUT /custom_rules` replaces the entire rule set. The server validates the whole array first; only if every element is valid does it run an atomic `db.batch([DELETE all for user, INSERT each])`. `[]` clears the set.
+
+**Rationale**:
+- The declared operation is `updateCustomRules` ("Replace user's custom rules") — replace, not merge. Full-replace is the simplest model for a client that edits a list and saves it.
+- Validate-then-write guarantees FR-003's "existing set unchanged on 400" — we never half-apply.
+- `db.batch()` is the Cloudflare-native way to make the delete+insert atomic, and matches the project rule to batch bulk writes.
+
+**Alternative considered**: per-rule POST/PATCH with merge semantics. Rejected — not the declared contract, and more endpoints/state for no added value here.
+
+---
+
+## Decision 4: Cross-user / unknown DELETE → 404
+
+**Decision**: `DELETE /custom_rules/{rule_id}` for a rule the caller does not own, or an unknown id, returns 404. The `WHERE id = ? AND user_id = ?` clause makes "not yours" and "not found" indistinguishable.
+
+**Rationale**: Consistent with the Goals and read endpoints (no id-existence leak). One scoped statement, no fetch-then-check TOCTOU.
+
+**Alternative considered**: 403 for owned-by-other. Rejected — leaks existence.
+
+---
+
+## Decision 5: KV-cached rule set, invalidated on mutation
+
+**Decision**: The compiled rule set is cached in KV under `customrules:${user_id}` (JSON array, pre-sorted). Ingestion reads the cache; a miss falls back to a D1 `SELECT` and repopulates. `PUT` and `DELETE` delete the cache key.
+
+**Rationale**:
+- Heartbeat ingestion is the hot path and is CPU-budgeted. A D1 read per heartbeat request to fetch rules would be wasteful when rules change rarely.
+- Rules are single-digit per user, so the cached payload is tiny.
+- Explicit invalidation on every mutation keeps the cache correct without TTL guesswork; a short TTL can be layered on later as a safety net.
+
+**Alternative considered**: read rules from D1 on every ingestion. Simpler but adds a D1 round-trip to the hottest path. Rejected on performance.
+
+---
+
+## Decision 6: Sequential application; first `hide` short-circuits
+
+**Decision**: Rules are applied in ascending `priority` (ties by `created_at`). Each `change` mutates the in-memory heartbeat so later rules see the new value. The first matching `hide` ends processing and drops the heartbeat.
+
+**Rationale**:
+- A deterministic, documented order is essential — users compose rules (rename A→B, then a rule on B). Sequential-by-priority is the least surprising model.
+- Short-circuiting on `hide` is both correct (a dropped heartbeat needs no further rewrites) and cheaper.
+- No fixpoint re-evaluation: bounded, predictable cost.
+
+**Alternative considered**: independent rule evaluation against the original values. Rejected — breaks rule composition and is surprising.
+
+---
+
+## Decision 7: `hide` success-response shape verified against the WakaTime-compatible contract
+
+**Decision**: When a `hide` rule drops a heartbeat, the endpoint still returns a per-item *success* result (so callers cannot enumerate what was dropped). The **exact** shape (status code per item, `data` null vs echoed) will be finalised in PR2 by checking the documented WakaTime-compatible bulk-heartbeat response and `wakatime-cli`'s expectations — **not** by reading WakaTime source.
+
+**Rationale**:
+- The bulk heartbeat response is wire-protocol consumed by editor plugins; diverging risks plugin errors. Project rule: verify wire-protocol behaviour against the CLI/API docs first.
+- Not disclosing which items were dropped avoids leaking rule internals to a caller.
+
+**Alternative considered**: return an explicit "hidden" marker per item. Rejected — leaks rule behaviour and risks confusing plugins that expect a stored-heartbeat shape.
+
+---
+
+## Decision 8: Validation cap and NOT NULL handling for `hide`
+
+**Decision**: Cap the rule set at 50 per user (PUT returns 400 above the cap). `hide` rules store empty strings in the NOT NULL `destination` / `destination_value` columns.
+
+**Rationale**:
+- The cap bounds both the PUT payload and the per-heartbeat matching loop, protecting the CPU budget; 50 is far above realistic usage.
+- `destination` / `destination_value` are NOT NULL in `custom_rules`; since `hide` ignores them, storing `""` satisfies the constraint without a migration and the API never surfaces them as meaningful for `hide`.
+
+**Alternative considered**: make the columns nullable via migration. Rejected — unnecessary schema churn; empty string is sufficient and the API marks them optional/ignored for `hide`.

--- a/specs/101-custom-rules-crud/spec.md
+++ b/specs/101-custom-rules-crud/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Custom Rules CRUD + Heartbeat Remap
+
+**Feature Branch**: `101-custom-rules-crud`
+**Created**: 2026-05-28
+**Status**: Draft
+**Input**: The `custom_rules` D1 table exists and `getCustomRules` / `updateCustomRules` / `deleteCustomRule` OpenAPI operations are declared, but no route handler is mounted and the heartbeat-ingestion remap they are meant to drive is missing.
+
+## Background
+
+Custom rules let a user rewrite or drop heartbeats as they are ingested, without editing their local WakaTime-compatible plugin config. The two motivating cases:
+
+- **Remap (`change`)**: a project was renamed (`cloudtime-old` → `cloudtime`); a rule remaps the old name so history and new activity roll up together instead of double-counting.
+- **Hide (`hide`)**: drop heartbeats matching a pattern (e.g. a `work/` project during personal-time tracking) so they never enter storage or aggregation.
+
+This feature wires the CRUD surface (`GET` / `PUT` / `DELETE`) and the ingestion-time enforcement on `POST /heartbeats` and `POST /heartbeats.bulk`.
+
+## Spec-level reconciliations (resolved in this PR)
+
+The pre-existing schema declared values that this spec finalises:
+
+- **`action`**: `change | delete` → **`change | hide`**. "hide" unambiguously means "drop the heartbeat" (vs `delete`, which reads like "delete the rule").
+- **`operation`**: `equals | contains | starts with | ends with` → **`equals | contains | starts_with | ends_with`** (underscore tokens; no embedded spaces). **`regex` is intentionally deferred** — unbounded regex risks the Workers 10ms CPU budget. Adding it later is an additive enum change.
+- **`destination` / `destination_value`**: now optional on input — required for `change`, ignored for `hide`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List my rules (Priority: P1)
+
+As an authenticated user, I want to see my custom rules in the order they are applied so I can reason about their combined effect.
+
+**Independent Test**: Seed three rules with priorities 2, 0, 1. `GET /custom_rules` returns them ordered 0,1,2 as `{"data": CustomRule[]}`.
+
+**Acceptance Scenarios**:
+1. **Given** rules with mixed priorities, **When** listing, **Then** they return in ascending `priority` order (ties broken by `created_at`).
+2. **Given** no rules, **When** listing, **Then** the response is `{"data": []}` with 200.
+3. **Given** another user's rules exist, **When** listing, **Then** none of them appear.
+4. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 2 - Replace my rule set (Priority: P1)
+
+As an authenticated user, I want to submit my full set of rules in one call so the client can manage them as a single editable list.
+
+**Independent Test**: `PUT /custom_rules` with a two-rule array; verify 200, the response echoes both with server-assigned `id` + `created_at`, and a subsequent `GET` returns exactly those two.
+
+**Acceptance Scenarios**:
+1. **Given** a valid array, **When** PUT, **Then** the prior set is fully replaced and the response lists the new rules in application order.
+2. **Given** an empty array `[]`, **When** PUT, **Then** all rules are cleared (200, `{"data": []}`).
+3. **Given** a `change` rule missing `destination_value`, **When** PUT, **Then** 400 and the existing set is unchanged.
+4. **Given** an unknown enum value (e.g. `action: "drop"`), **When** PUT, **Then** 400.
+5. **Given** a `hide` rule with no `destination`, **When** PUT, **Then** 200 (destination not required for hide).
+6. **Given** rules without `priority`, **When** PUT, **Then** each is assigned its array index as priority.
+7. **Given** an unauthenticated request, **Then** 401 and no change.
+
+---
+
+### User Story 3 - Delete a single rule (Priority: P2)
+
+As an authenticated user, I want to remove one rule without resubmitting the whole set.
+
+**Acceptance Scenarios**:
+1. **Given** an owned rule, **When** DELETE, **Then** 204 and it is gone from `GET`.
+2. **Given** a rule owned by another user (or unknown id), **When** DELETE, **Then** 404, nothing deleted.
+3. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 4 - Rules rewrite/drop heartbeats at ingestion (Priority: P1)
+
+As an authenticated user, I want my rules applied to incoming heartbeats so renames roll up and hidden activity never lands.
+
+**Independent Test**: With a `change` rule (`source=project, operation=equals, source_value=old, destination=project, destination_value=new`), POST a heartbeat with `project=old`; read it back and confirm it stored as `project=new`. With a `hide` rule matching `project=secret`, POST a heartbeat with `project=secret`; confirm it is not persisted while the request still reports success.
+
+**Acceptance Scenarios**:
+1. **Given** a matching `change` rule, **When** a heartbeat is ingested, **Then** the named `destination` column is rewritten before INSERT.
+2. **Given** a matching `hide` rule, **When** a heartbeat is ingested, **Then** it is not stored or aggregated, and the response does not reveal which items were dropped.
+3. **Given** multiple rules, **When** ingesting, **Then** they apply in ascending priority order; a `change` may set up a later rule's match; once a `hide` matches, remaining rules are skipped for that heartbeat.
+4. **Given** no rules, **When** ingesting, **Then** heartbeats are stored unchanged.
+5. **Given** a bulk POST mixing matched and unmatched heartbeats, **When** ingested, **Then** only the unmatched/changed ones persist and per-item response order is preserved.
+
+---
+
+### Edge Cases
+
+- **`change` rule whose `source` field is null on the heartbeat** (e.g. no `project`): no match; rule skipped.
+- **`change` to the same column it matched** (`source=project`, `destination=project`): allowed (this is the rename case).
+- **`change` across columns** (`source=entity`, `destination=project`): allowed; rewrites `project` when `entity` matches.
+- **Conflicting rules**: lower-priority (earlier) rules win on the order defined; later rules see already-mutated values. Deterministic by priority then `created_at`.
+- **Duplicate priorities**: allowed; `created_at` (then insert order) breaks ties deterministically.
+- **Very large rule set**: bounded by validation cap (e.g. 50 rules) to protect the ingestion hot path.
+- **Malformed JSON / not an array on PUT**: 400.
+- **Stale KV cache after PUT/DELETE**: cache is invalidated on every mutation so the next ingestion reloads.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements — CRUD
+
+- **FR-001**: `GET /api/v1/users/current/custom_rules` MUST return the user's rules as `{"data": CustomRule[]}` ordered by `priority` ascending, ties broken by `created_at`.
+- **FR-002**: `PUT /api/v1/users/current/custom_rules` MUST replace the entire rule set with the supplied array (full replace, not merge); `[]` clears all rules. The server MUST assign each rule a fresh `id` and `created_at`, and MUST default `priority` to the array index when omitted. Returns `200` with the persisted rules in application order.
+- **FR-003**: PUT MUST validate every element: `action` ∈ {change, hide}; `source` / `destination` ∈ the dimension enum; `operation` ∈ {equals, contains, starts_with, ends_with}; `source_value` non-empty; `change` rules require `destination` and non-empty `destination_value`; `hide` rules ignore both. Any violation MUST return `400` and leave the existing rule set unchanged (validate-then-write).
+- **FR-004**: `DELETE /api/v1/users/current/custom_rules/{rule_id}` MUST delete an owned rule (`204`). A rule not owned by the caller or an unknown id MUST return `404` (never 403), scoped by `user_id` in the `WHERE` clause.
+- **FR-005**: All endpoints MUST require API-key or session authentication; unauthenticated requests return `401` and mutate nothing.
+- **FR-006**: PUT and DELETE MUST invalidate the user's cached rule set so subsequent ingestion uses the new rules.
+
+### Functional Requirements — Heartbeat remap
+
+- **FR-007**: `POST /heartbeats` and `POST /heartbeats.bulk` MUST load the user's rule set (cache-backed) and apply rules in ascending priority order to each heartbeat before INSERT.
+- **FR-008**: A `change` rule whose heartbeat `source` field satisfies `operation`/`source_value` MUST rewrite the heartbeat's `destination` column to `destination_value` in memory before persistence.
+- **FR-009**: A `hide` rule that matches MUST cause the heartbeat to be skipped (not stored, not aggregated). The endpoint MUST still return a per-item success result so a caller cannot tell which heartbeats were dropped. **The exact success-response shape MUST match the WakaTime-compatible bulk-heartbeat contract** — verified against the documented response (and `wakatime-cli` expectations) during PR2, not by copying WakaTime source.
+- **FR-010**: Rules apply sequentially: a `change` result is visible to later rules; the first matching `hide` ends processing for that heartbeat.
+- **FR-011**: Matching is case-sensitive: `equals` exact, `contains` substring, `starts_with` prefix, `ends_with` suffix. No regex.
+- **FR-012**: With an empty rule set, heartbeats MUST be stored unchanged (no behavioural change from today).
+
+### Non-Functional Requirements
+
+- **NFR-001**: The rule set MUST be cached (KV) keyed by `user_id`, invalidated on PUT/DELETE, so the ingestion hot path avoids a D1 read per request.
+- **NFR-002**: Rule application MUST stay within the Workers 10ms CPU budget: single-digit rule counts, string operations only (no regex), no extra D1 round-trips in the matching loop.
+- **NFR-003**: A validation cap (≤ 50 rules per user) MUST bound the per-heartbeat work and the PUT payload.
+- **NFR-004**: No D1 schema migration. Uses the existing `custom_rules` table and existing heartbeat columns.
+
+### Key Entities *(no schema change)*
+
+The existing `custom_rules` table (`id`, `user_id`, `action`, `source`, `operation`, `source_value`, `destination`, `destination_value`, `priority`, `created_at`, `ON DELETE CASCADE`) covers everything. `hide` rules store empty strings for `destination` / `destination_value` to satisfy the NOT NULL columns.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A user can list, fully replace, and delete rules through the API with no direct D1 access.
+- **SC-002**: A `change` rule renames the matched dimension on newly ingested heartbeats (verified by reading the heartbeat back).
+- **SC-003**: A `hide` rule prevents matched heartbeats from being stored, while the request still succeeds and does not disclose which items were dropped.
+- **SC-004**: Invalid PUT payloads return 400 and never partially apply.
+- **SC-005**: Cross-user DELETE returns 404 and removes nothing.
+- **SC-006**: Ingestion latency stays within budget with a representative rule set (≤ 50 rules), with no per-rule D1 reads.
+
+## Out of Scope
+
+- **`regex` operator** (deferred; additive later).
+- **Retroactive application** to already-stored heartbeats or `summaries`. Rules affect only new ingestion.
+- **Per-rule enable/disable**, dry-run/preview, or a "test this rule" endpoint.
+- **POST/PATCH of a single rule.** Mutation is via full-set `PUT` plus single `DELETE`, matching the declared operations.
+- **Cross-dimension cascades beyond the documented sequential semantics** (no fixpoint re-evaluation).

--- a/specs/101-custom-rules-crud/spec.md
+++ b/specs/101-custom-rules-crud/spec.md
@@ -109,7 +109,7 @@ As an authenticated user, I want my rules applied to incoming heartbeats so rena
 
 - **FR-007**: `POST /heartbeats` and `POST /heartbeats.bulk` MUST load the user's rule set (cache-backed) and apply rules in ascending priority order to each heartbeat before INSERT.
 - **FR-008**: A `change` rule whose heartbeat `source` field satisfies `operation`/`source_value` MUST rewrite the heartbeat's `destination` column to `destination_value` in memory before persistence.
-- **FR-009**: A `hide` rule that matches MUST cause the heartbeat to be skipped (not stored, not aggregated). The endpoint MUST still return a per-item success result so a caller cannot tell which heartbeats were dropped. **The exact success-response shape MUST match the WakaTime-compatible bulk-heartbeat contract** — verified against the documented response (and `wakatime-cli` expectations) during PR2, not by copying WakaTime source.
+- **FR-009**: A `hide` rule that matches MUST cause the heartbeat to be skipped (not stored, not aggregated). The endpoint MUST still return a per-item success result so a caller cannot tell which heartbeats were dropped. **The exact success-response shape MUST match the WakaTime-compatible bulk-heartbeat contract** — verified against the documented response and compatible CLI expectations during PR2, not by copying upstream source.
 - **FR-010**: Rules apply sequentially: a `change` result is visible to later rules; the first matching `hide` ends processing for that heartbeat.
 - **FR-011**: Matching is case-sensitive: `equals` exact, `contains` substring, `starts_with` prefix, `ends_with` suffix. No regex.
 - **FR-012**: With an empty rule set, heartbeats MUST be stored unchanged (no behavioural change from today).

--- a/specs/101-custom-rules-crud/tasks.md
+++ b/specs/101-custom-rules-crud/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: Custom Rules CRUD + Heartbeat Remap
+
+**Branch**: `101-custom-rules-crud`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-28
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (4 user stories, FR-001..FR-012, NFRs, edge cases, reconciliations).
+- [x] **T-002**: Author `plan.md` (Constitution Check, matcher/cache/handler sketches).
+- [x] **T-003**: Author `research.md` (8 documented decisions).
+- [x] **T-004**: Author `data-model.md` (existing table; write-path, KV cache, remap field treatment).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–J).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Reconcile `CustomRule.yaml` / `CustomRuleInput.yaml` (`change|hide`, underscore operations, conditional destination, `created_at`); add `400` to PUT and `404` to DELETE.
+- [x] **T-009**: Run `npm run generate`; verify enums + responses in `src/types/generated.ts`; run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Validation + matcher
+
+- [ ] **T-101**: `src/utils/custom-rule-input.ts` — `validateCustomRules(body)` → normalised rows | error. Enum checks, `change` requires `destination` + non-empty `destination_value`, `source_value` non-empty, ≤ 50 rules, `priority` defaulting.
+- [ ] **T-102**: `src/utils/custom-rules.ts` — pure `applyRules(hb, rules)` (mutate or `null`) + `loadRules` / `invalidateRules` KV helpers (key `customrules:${userId}`).
+- [ ] **T-103**: Unit tests for the matcher (each operation, change/hide, sequential priority, hide short-circuit, null source) and validation (cap, conditional destination).
+
+### CRUD handlers
+
+- [ ] **T-104**: `src/routes/custom-rules.ts` — `GET` (ORDER BY priority, created_at), `PUT` (validate → `db.batch([DELETE all, INSERT each])` → invalidate cache → return persisted), `DELETE` (`WHERE id=? AND user_id=?`; 204/404; invalidate cache). All behind `authMiddleware`.
+- [ ] **T-105**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", customRules)`.
+
+### Heartbeat integration
+
+- [ ] **T-106**: In `src/routes/heartbeats.ts`, load rules once per request and apply per heartbeat on `POST /heartbeats` and `/heartbeats.bulk`; filter `null` (hidden) from the batch; preserve per-item response order.
+- [ ] **T-107**: Verify the hidden-heartbeat success-response shape against the documented WakaTime-compatible bulk contract (API docs / `wakatime-cli` behaviour — not source).
+
+### Tests
+
+- [ ] **T-108**: `tests/integration/custom-rules.test.ts` — CRUD scenarios A–D, H, I, J + cross-user.
+- [ ] **T-109**: `tests/integration/custom-rules-heartbeat.test.ts` — ingestion scenarios E, F, G.
+
+### Verification
+
+- [ ] **T-110**: `npm run typecheck` — zero errors.
+- [ ] **T-111**: `npm test` — full suite green incl. new unit + integration.
+- [ ] **T-112**: Manual run of `quickstart.md` E / F / G against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-113**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #101.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                         (PR1)
+T-010 → T-101 .. T-113                          (PR2 after PR1 merge)
+T-101 / T-102 → T-103
+T-101 / T-102 → T-104 → T-105
+T-102 → T-106 → T-107
+T-104 / T-105 → T-108
+T-106 / T-107 → T-109
+T-108 / T-109 → T-110 → T-111 → T-112 → T-113
+```
+
+## Out of scope
+
+- `regex` operator (additive later).
+- Retroactive application to stored heartbeats / summaries.
+- Per-rule enable/disable, dry-run/preview, single-rule POST/PATCH.
+- Fixpoint re-evaluation beyond the documented sequential semantics.

--- a/specs/101-custom-rules-crud/tasks.md
+++ b/specs/101-custom-rules-crud/tasks.md
@@ -33,7 +33,7 @@
 ### Heartbeat integration
 
 - [ ] **T-106**: In `src/routes/heartbeats.ts`, load rules once per request and apply per heartbeat on `POST /heartbeats` and `/heartbeats.bulk`; filter `null` (hidden) from the batch; preserve per-item response order.
-- [ ] **T-107**: Verify the hidden-heartbeat success-response shape against the documented WakaTime-compatible bulk contract (API docs / `wakatime-cli` behaviour — not source).
+- [ ] **T-107**: Verify the hidden-heartbeat success-response shape against the documented WakaTime-compatible bulk contract (API docs / compatible CLI behaviour — not source).
 
 ### Tests
 

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -766,9 +766,25 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List user's custom rules */
+        /**
+         * List user's custom rules
+         * @description Returns the authenticated user's custom rules ordered by `priority`
+         *     ascending (ties broken by `created_at`). This is the order in which the
+         *     rules are applied to incoming heartbeats.
+         */
         get: operations["getCustomRules"];
-        /** Replace user's custom rules */
+        /**
+         * Replace user's custom rules
+         * @description Replaces the authenticated user's entire rule set with the supplied
+         *     array (full-replace semantics, not a merge). An empty array clears all
+         *     rules. Server assigns each rule a fresh `id` and `created_at`; when
+         *     `priority` is omitted the array index is used. Returns the persisted
+         *     rules in application order.
+         *
+         *     Validation failures (unknown enum value, `change` rule missing
+         *     `destination` / `destination_value`, or empty `source_value`) return 400
+         *     and leave the existing rule set unchanged.
+         */
         put: operations["updateCustomRules"];
         post?: never;
         delete?: never;
@@ -787,7 +803,13 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Delete a custom rule */
+        /**
+         * Delete a custom rule
+         * @description Deletes a single rule owned by the authenticated user and returns 204.
+         *     A rule owned by a different user (or an unknown id) returns 404 (not
+         *     403) to avoid leaking rule-id existence. Deleting a rule invalidates the
+         *     user's cached rule set used by heartbeat ingestion.
+         */
         delete: operations["deleteCustomRule"];
         options?: never;
         head?: never;
@@ -1521,31 +1543,66 @@ export interface components {
         };
         CustomRule: {
             id: string;
-            /** @enum {string} */
-            action: "change" | "delete";
-            /** @enum {string} */
+            /**
+             * @description `change` remaps the matched heartbeat's `destination` column to
+             *     `destination_value`. `hide` drops the heartbeat from persistence
+             *     (it is not stored or aggregated).
+             * @enum {string}
+             */
+            action: "change" | "hide";
+            /**
+             * @description The heartbeat dimension matched against `source_value`.
+             * @enum {string}
+             */
             source: "project" | "language" | "editor" | "operating_system" | "category" | "entity";
-            /** @enum {string} */
-            operation: "equals" | "contains" | "starts with" | "ends with";
+            /**
+             * @description How `source_value` is compared to the heartbeat's `source` field.
+             *     Regex is intentionally unsupported in this version (Workers CPU
+             *     budget); adding it later is additive.
+             * @enum {string}
+             */
+            operation: "equals" | "contains" | "starts_with" | "ends_with";
             source_value: string;
-            /** @enum {string} */
+            /**
+             * @description The heartbeat dimension rewritten by a `change` action. Ignored for
+             *     `hide` actions.
+             * @enum {string}
+             */
             destination: "project" | "language" | "editor" | "operating_system" | "category" | "entity";
             destination_value: string;
+            /**
+             * @description Rules are applied in ascending priority order (lowest first). Ties
+             *     break by `created_at`.
+             */
             priority?: number;
+            /** Format: date-time */
+            created_at?: string;
         };
+        /**
+         * @description One rule in a `PUT /users/current/custom_rules` payload. The PUT replaces
+         *     the entire rule set, so `id` and `created_at` are server-managed and
+         *     ignored on input.
+         *
+         *     Conditional requirement (enforced server-side, returns 400 on violation):
+         *     `change` actions require `destination` and a non-empty `destination_value`;
+         *     `hide` actions ignore both (omit them).
+         */
         CustomRuleInput: {
-            /** @description Include to update existing rule */
-            id?: string;
             /** @enum {string} */
-            action: "change" | "delete";
+            action: "change" | "hide";
             /** @enum {string} */
             source: "project" | "language" | "editor" | "operating_system" | "category" | "entity";
             /** @enum {string} */
-            operation: "equals" | "contains" | "starts with" | "ends with";
+            operation: "equals" | "contains" | "starts_with" | "ends_with";
             source_value: string;
-            /** @enum {string} */
-            destination: "project" | "language" | "editor" | "operating_system" | "category" | "entity";
-            destination_value: string;
+            /**
+             * @description Required for `change` actions; ignored for `hide`.
+             * @enum {string}
+             */
+            destination?: "project" | "language" | "editor" | "operating_system" | "category" | "entity";
+            /** @description Required (non-empty) for `change` actions; ignored for `hide`. */
+            destination_value?: string;
+            /** @description Ascending order of application. Defaults to the array index when omitted. */
             priority?: number;
         };
         Machine: {
@@ -2969,6 +3026,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };
@@ -2991,6 +3049,7 @@ export interface operations {
                 content?: never;
             };
             401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
         };
     };
     getMachineNames: {


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Custom Rules** (issue #101), following the SpecKit 2-PR workflow. Reconciles the pre-declared `custom_rules` OpenAPI surface, adds the missing error responses, and lands the SpecKit design for both the CRUD endpoints and the heartbeat-ingestion remap. **No implementation code** — handlers, the matcher, and the ingestion hook land in PR2.

## Spec-level reconciliations (please sanity-check these)

The table/OpenAPI shipped earlier with values this PR finalises:

- **`action`**: `change | delete` → **`change | hide`** — "hide" unambiguously means "drop the heartbeat" (vs `delete`, which reads like "delete the rule").
- **`operation`**: `equals | contains | starts with | ends with` → **`equals | contains | starts_with | ends_with`** (underscore tokens). **`regex` deferred** — unbounded regex per heartbeat risks the Workers 10ms CPU budget; adding it later is additive.
- **`destination` / `destination_value`**: moved out of `required` — required for `change`, ignored for `hide`.
- Added `created_at` to `CustomRule` (used for the priority tie-break ordering).
- Removed `id` from `CustomRuleInput` (PUT is a full replace; ids are server-assigned).

## Response additions

- `PUT /users/current/custom_rules` → `400` (validation; existing set unchanged on failure).
- `DELETE /users/current/custom_rules/{rule_id}` → `404` (cross-user / unknown id, no existence leak).

## Design highlights (see `research.md`)

- **PUT is full-replace** via an atomic `db.batch([DELETE all, INSERT each])`; validate-then-write so a 400 never partially applies.
- **KV-cached rule set** keyed by `user_id`, invalidated on PUT/DELETE, so heartbeat ingestion avoids a per-request D1 read.
- **Sequential application** by `priority` (ties by `created_at`); a `change` feeds later rules; the first `hide` short-circuits.
- **hide-response shape** for dropped heartbeats will be verified against the documented WakaTime-compatible bulk contract in PR2 (not by reading upstream source). Flagged because it is wire-protocol consumed by editor plugins.
- **Validation cap** ≤ 50 rules; `hide` stores `""` for the NOT NULL destination columns.

## No schema migration

Uses the existing `custom_rules` table and existing heartbeat columns.

## Test plan

- [x] `npm run generate` reflects `change|hide`, underscore operations, conditional destination, and the 400/404 responses
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly
- [ ] PR2: validation module, pure matcher, CRUD handlers, ingestion hook, unit + integration tests
