### PR TITLE
feat: Custom Rules CRUD + heartbeat remap (PR2/2) #101

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import summaries from "./routes/summaries";
 import stats from "./routes/stats";
 import users from "./routes/users";
 import goals from "./routes/goals";
+import customRules from "./routes/custom-rules";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
 
@@ -123,6 +124,9 @@ app.route("/api/v1/users/current", users);
 
 // Goals routes (mounted at /users/current, sub-app defines /goals, /goals/:goal_id)
 app.route("/api/v1/users/current", goals);
+
+// Custom rules routes (mounted at /users/current, sub-app defines /custom_rules, /custom_rules/:rule_id)
+app.route("/api/v1/users/current", customRules);
 
 // User agents routes (mounted at /users/current, sub-app defines /user_agents)
 app.route("/api/v1/users/current", userAgents);

--- a/src/routes/custom-rules.ts
+++ b/src/routes/custom-rules.ts
@@ -1,0 +1,138 @@
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { normalizeDateTime } from "../utils/user";
+import { validateCustomRules } from "../utils/custom-rule-input";
+import { invalidateRules } from "../utils/custom-rules";
+
+type CustomRule = components["schemas"]["CustomRule"];
+
+interface CustomRuleRow {
+  id: string;
+  action: string;
+  source: string;
+  operation: string;
+  source_value: string;
+  destination: string;
+  destination_value: string;
+  priority: number;
+  created_at: string;
+}
+
+const SELECT_COLUMNS =
+  "id, action, source, operation, source_value, destination, destination_value, priority, created_at";
+
+function rowToCustomRule(row: CustomRuleRow): CustomRule {
+  return {
+    id: row.id,
+    action: row.action as CustomRule["action"],
+    source: row.source as CustomRule["source"],
+    operation: row.operation as CustomRule["operation"],
+    source_value: row.source_value,
+    destination: row.destination as CustomRule["destination"],
+    destination_value: row.destination_value,
+    priority: row.priority,
+    created_at: normalizeDateTime(row.created_at),
+  };
+}
+
+async function listRules(db: D1Database, userId: string): Promise<CustomRule[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM custom_rules
+        WHERE user_id = ? ORDER BY priority ASC, created_at ASC`,
+    )
+    .bind(userId)
+    .all<CustomRuleRow>();
+  return results.map(rowToCustomRule);
+}
+
+const customRules = new Hono<AuthEnv>();
+
+customRules.use("/custom_rules", authMiddleware);
+customRules.use("/custom_rules/*", authMiddleware);
+
+customRules.get("/custom_rules", async (c) => {
+  const userId = c.get("userId");
+  try {
+    return c.json({ data: await listRules(c.env.DB, userId) });
+  } catch (err) {
+    console.error("GET /custom_rules error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+customRules.put("/custom_rules", async (c) => {
+  const userId = c.get("userId");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const parsed = validateCustomRules(body);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+
+  try {
+    // Atomic full-replace: clear the user's rules, then insert the new set.
+    const stmts: D1PreparedStatement[] = [
+      c.env.DB.prepare("DELETE FROM custom_rules WHERE user_id = ?").bind(userId),
+    ];
+    for (const r of parsed.value) {
+      stmts.push(
+        c.env.DB.prepare(
+          `INSERT INTO custom_rules
+             (id, user_id, action, source, operation, source_value,
+              destination, destination_value, priority, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+        ).bind(
+          crypto.randomUUID(),
+          userId,
+          r.action,
+          r.source,
+          r.operation,
+          r.source_value,
+          r.destination,
+          r.destination_value,
+          r.priority,
+        ),
+      );
+    }
+    await c.env.DB.batch(stmts);
+    await invalidateRules(c.env, userId);
+
+    return c.json({ data: await listRules(c.env.DB, userId) });
+  } catch (err) {
+    console.error("PUT /custom_rules error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+customRules.delete("/custom_rules/:rule_id", async (c) => {
+  const userId = c.get("userId");
+  const ruleId = c.req.param("rule_id");
+
+  try {
+    const res = await c.env.DB.prepare(
+      "DELETE FROM custom_rules WHERE id = ? AND user_id = ?",
+    )
+      .bind(ruleId, userId)
+      .run();
+
+    if (res.meta.changes === 0) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    await invalidateRules(c.env, userId);
+    return c.body(null, 204);
+  } catch (err) {
+    console.error("DELETE /custom_rules/:rule_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default customRules;

--- a/src/routes/custom-rules.ts
+++ b/src/routes/custom-rules.ts
@@ -24,13 +24,14 @@ const SELECT_COLUMNS =
   "id, action, source, operation, source_value, destination, destination_value, priority, created_at";
 
 function rowToCustomRule(row: CustomRuleRow): CustomRule {
+  const destination = row.destination || row.source;
   return {
     id: row.id,
     action: row.action as CustomRule["action"],
     source: row.source as CustomRule["source"],
     operation: row.operation as CustomRule["operation"],
     source_value: row.source_value,
-    destination: row.destination as CustomRule["destination"],
+    destination: destination as CustomRule["destination"],
     destination_value: row.destination_value,
     priority: row.priority,
     created_at: normalizeDateTime(row.created_at),

--- a/src/routes/heartbeats.ts
+++ b/src/routes/heartbeats.ts
@@ -4,6 +4,7 @@ import type { components } from "../types/generated";
 import { authMiddleware, getUserTimeout, getUserTimezone } from "../middleware/auth";
 import { getEpochBoundsForDate } from "../utils/time-format";
 import { resolveUserAgentId } from "../utils/user-agent";
+import { applyRules, loadRules } from "../utils/custom-rules";
 
 type HeartbeatInput = components["schemas"]["HeartbeatInput"];
 type Heartbeat = components["schemas"]["Heartbeat"];
@@ -139,6 +140,14 @@ heartbeats.post("/heartbeats", async (c) => {
   const userAgent = input.user_agent ?? c.req.header("User-Agent") ?? undefined;
 
   try {
+    // Apply the user's custom rules before persisting (Issue #101). A `change`
+    // rewrites a dimension in place; a `hide` drops the heartbeat. Hidden
+    // heartbeats still get a success-shaped response so the caller cannot tell
+    // which were dropped.
+    const rules = await loadRules(c.env, userId);
+    if (applyRules(input, rules) === null) {
+      return c.json({ data: buildHeartbeatResponse(crypto.randomUUID(), userId, input, machine, null) }, 201);
+    }
     const heartbeat = await insertHeartbeat(c.env.DB, userId, input, machine, userAgent);
     return c.json({ data: heartbeat }, 201);
   } catch (err) {
@@ -173,25 +182,37 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
   // Per-item validation
   const validationErrors: (string | null)[] = inputs.map((input) => validateHeartbeatInput(input));
   const ids = inputs.map(() => crypto.randomUUID());
-  const validCount = validationErrors.filter((e) => e === null).length;
+
+  // Apply the user's custom rules before anything is persisted (Issue #101).
+  // `change` rewrites dimensions on inputs[i] in place; `hide` flags the item
+  // so it is excluded from the batch. Rules are loaded once per request.
+  const rules = await loadRules(c.env, userId);
+  const hidden: boolean[] = new Array(inputs.length).fill(false);
+  for (let i = 0; i < inputs.length; i++) {
+    if (validationErrors[i]) continue;
+    if (applyRules(inputs[i], rules) === null) {
+      hidden[i] = true;
+    }
+  }
 
   // Resolve every distinct User-Agent value once before the heartbeat batch,
   // so a 25-item bulk POST issues at most a handful of upserts instead of one
-  // per heartbeat (Issue #99).
+  // per heartbeat (Issue #99). Hidden heartbeats are skipped so they leave no
+  // user_agents trace.
   const userAgentCache = new Map<string, string>();
   const userAgentIds: (string | null)[] = new Array(inputs.length).fill(null);
   for (let i = 0; i < inputs.length; i++) {
-    if (validationErrors[i]) continue;
+    if (validationErrors[i] || hidden[i]) continue;
     const ua = inputs[i].user_agent ?? headerUserAgent;
     userAgentIds[i] = await resolveUserAgentId(c.env.DB, userId, ua ?? null, userAgentCache);
   }
 
-  // Build insert statements only for valid heartbeats
+  // Build insert statements only for valid, non-hidden heartbeats
   const stmts: D1PreparedStatement[] = [];
   const projectTimes = new Map<string, { min: number; max: number }>();
 
   for (let i = 0; i < inputs.length; i++) {
-    if (validationErrors[i]) continue; // skip invalid
+    if (validationErrors[i] || hidden[i]) continue;
     const input = inputs[i];
     const machine = input.machine ?? headerMachine;
     stmts.push(
@@ -221,11 +242,17 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
     }
   }
 
-  // Map batch results back to per-input indices (valid items only)
+  // Map batch results back to per-input indices. Hidden items report success
+  // with the same shape as a stored heartbeat so the caller cannot tell which
+  // were dropped; invalid items report their error; the rest consume a batch
+  // result in order.
   let batchIdx = 0;
   const responses: [HeartbeatBulkItem, number][] = inputs.map((_, i) => {
     if (validationErrors[i]) {
       return [{ data: null, error: validationErrors[i] }, 400];
+    }
+    if (hidden[i]) {
+      return [{ data: { id: ids[i] }, error: null }, 201];
     }
     const success = batchResults[batchIdx]?.success ?? false;
     batchIdx++;
@@ -397,6 +424,22 @@ async function insertHeartbeat(
   }
   await db.batch(stmts);
 
+  return buildHeartbeatResponse(id, userId, input, machine, userAgentId, now);
+}
+
+/**
+ * Build the API response object for a heartbeat. Shared by the persisted path
+ * and the `hide` path so a dropped heartbeat is indistinguishable from a
+ * stored one in the response (Issue #101).
+ */
+function buildHeartbeatResponse(
+  id: string,
+  userId: string,
+  input: HeartbeatInput,
+  machine: string | undefined,
+  userAgentId: string | null,
+  now: string = new Date().toISOString(),
+): Heartbeat {
   return {
     id,
     user_id: userId,

--- a/src/utils/custom-rule-input.ts
+++ b/src/utils/custom-rule-input.ts
@@ -1,0 +1,109 @@
+/**
+ * Validation for the `PUT /custom_rules` payload (specs/101-custom-rules-crud/).
+ *
+ * Pure: turns an untrusted parsed JSON value into a normalised list of rows
+ * ready to persist, or a 400-worthy error. `change` rules require a
+ * destination; `hide` rules ignore it (stored as empty strings).
+ */
+import {
+  RULE_ACTIONS,
+  RULE_FIELDS,
+  RULE_OPERATIONS,
+  type RuleAction,
+  type RuleField,
+  type RuleOperation,
+} from "./custom-rules";
+
+export const MAX_RULES = 50;
+
+export interface ValidatedRule {
+  action: RuleAction;
+  source: RuleField;
+  operation: RuleOperation;
+  source_value: string;
+  destination: RuleField | "";
+  destination_value: string;
+  priority: number;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+const ACTIONS = new Set<string>(RULE_ACTIONS);
+const FIELDS = new Set<string>(RULE_FIELDS);
+const OPERATIONS = new Set<string>(RULE_OPERATIONS);
+
+function fail(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+/**
+ * Validate a full-replace rule array. Returns the normalised rows (priority
+ * defaulted to array index when omitted) or a 400 error message.
+ */
+export function validateCustomRules(body: unknown): ValidationResult<ValidatedRule[]> {
+  if (!Array.isArray(body)) {
+    return fail("Request body must be an array of rules");
+  }
+  if (body.length > MAX_RULES) {
+    return fail(`At most ${MAX_RULES} rules are allowed`);
+  }
+
+  const out: ValidatedRule[] = [];
+  for (let i = 0; i < body.length; i++) {
+    const raw = body[i];
+    const at = `rule[${i}]`;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      return fail(`${at} must be an object`);
+    }
+    const r = raw as Record<string, unknown>;
+
+    if (!ACTIONS.has(r.action as string)) {
+      return fail(`${at}.action must be one of ${RULE_ACTIONS.join(", ")}`);
+    }
+    if (!FIELDS.has(r.source as string)) {
+      return fail(`${at}.source must be one of ${RULE_FIELDS.join(", ")}`);
+    }
+    if (!OPERATIONS.has(r.operation as string)) {
+      return fail(`${at}.operation must be one of ${RULE_OPERATIONS.join(", ")}`);
+    }
+    if (typeof r.source_value !== "string" || r.source_value.length === 0) {
+      return fail(`${at}.source_value must be a non-empty string`);
+    }
+
+    const action = r.action as RuleAction;
+    let destination: RuleField | "" = "";
+    let destinationValue = "";
+    if (action === "change") {
+      if (!FIELDS.has(r.destination as string)) {
+        return fail(`${at}.destination must be one of ${RULE_FIELDS.join(", ")} for a change rule`);
+      }
+      if (typeof r.destination_value !== "string" || r.destination_value.length === 0) {
+        return fail(`${at}.destination_value must be a non-empty string for a change rule`);
+      }
+      destination = r.destination as RuleField;
+      destinationValue = r.destination_value;
+    }
+
+    let priority = i;
+    if (r.priority !== undefined) {
+      if (typeof r.priority !== "number" || !Number.isInteger(r.priority)) {
+        return fail(`${at}.priority must be an integer`);
+      }
+      priority = r.priority;
+    }
+
+    out.push({
+      action,
+      source: r.source as RuleField,
+      operation: r.operation as RuleOperation,
+      source_value: r.source_value,
+      destination,
+      destination_value: destinationValue,
+      priority,
+    });
+  }
+
+  return { ok: true, value: out };
+}

--- a/src/utils/custom-rules.ts
+++ b/src/utils/custom-rules.ts
@@ -1,0 +1,118 @@
+/**
+ * Custom-rule matcher + KV-cached rule loading (specs/101-custom-rules-crud/).
+ *
+ * `applyRules` is pure: it rewrites or drops a heartbeat-like object in
+ * memory according to the user's rules. `loadRules` / `invalidateRules`
+ * wrap the per-user KV cache that keeps the heartbeat hot path off D1.
+ */
+import type { Env } from "../types";
+
+export const RULE_FIELDS = [
+  "project",
+  "language",
+  "editor",
+  "operating_system",
+  "category",
+  "entity",
+] as const;
+export type RuleField = (typeof RULE_FIELDS)[number];
+
+export const RULE_OPERATIONS = ["equals", "contains", "starts_with", "ends_with"] as const;
+export type RuleOperation = (typeof RULE_OPERATIONS)[number];
+
+export const RULE_ACTIONS = ["change", "hide"] as const;
+export type RuleAction = (typeof RULE_ACTIONS)[number];
+
+export interface CompiledRule {
+  action: RuleAction;
+  source: RuleField;
+  operation: RuleOperation;
+  source_value: string;
+  destination: RuleField | "";
+  destination_value: string;
+}
+
+const CACHE_TTL = 3600; // seconds; correctness comes from explicit invalidation
+const cacheKey = (userId: string): string => `customrules:${userId}`;
+
+interface RuleRow {
+  action: string;
+  source: string;
+  operation: string;
+  source_value: string;
+  destination: string;
+  destination_value: string;
+  priority: number;
+  created_at: string;
+}
+
+function matches(value: string, op: RuleOperation, target: string): boolean {
+  switch (op) {
+    case "equals":
+      return value === target;
+    case "contains":
+      return value.includes(target);
+    case "starts_with":
+      return value.startsWith(target);
+    case "ends_with":
+      return value.endsWith(target);
+  }
+}
+
+/**
+ * Apply rules in order to a heartbeat-like object. Each `change` rule whose
+ * `source` field matches rewrites the `destination` field in place, so later
+ * rules see the new value. The first matching `hide` rule drops the heartbeat
+ * (returns null). Returns the (possibly mutated) object, or null if hidden.
+ */
+export function applyRules<T extends Partial<Record<RuleField, unknown>>>(
+  hb: T,
+  rules: CompiledRule[],
+): T | null {
+  for (const rule of rules) {
+    const field = hb[rule.source];
+    if (typeof field !== "string" || !matches(field, rule.operation, rule.source_value)) {
+      continue;
+    }
+    if (rule.action === "hide") {
+      return null;
+    }
+    if (rule.destination !== "") {
+      (hb as Record<RuleField, unknown>)[rule.destination] = rule.destination_value;
+    }
+  }
+  return hb;
+}
+
+/**
+ * Load the user's rules, KV-cached and pre-sorted by application order.
+ * An empty set is cached too, so users without rules still skip the D1 read
+ * on the heartbeat hot path.
+ */
+export async function loadRules(env: Env, userId: string): Promise<CompiledRule[]> {
+  const cached = (await env.KV.get(cacheKey(userId), "json")) as CompiledRule[] | null;
+  if (cached !== null) {
+    return cached;
+  }
+  const { results } = await env.DB.prepare(
+    `SELECT action, source, operation, source_value, destination, destination_value, priority, created_at
+       FROM custom_rules WHERE user_id = ? ORDER BY priority ASC, created_at ASC`,
+  )
+    .bind(userId)
+    .all<RuleRow>();
+  const rules: CompiledRule[] = results.map((r) => ({
+    action: r.action as RuleAction,
+    source: r.source as RuleField,
+    operation: r.operation as RuleOperation,
+    source_value: r.source_value,
+    destination: (r.destination || "") as RuleField | "",
+    destination_value: r.destination_value,
+  }));
+  await env.KV.put(cacheKey(userId), JSON.stringify(rules), { expirationTtl: CACHE_TTL });
+  return rules;
+}
+
+/** Drop the cached rule set so the next ingestion reloads from D1. */
+export async function invalidateRules(env: Env, userId: string): Promise<void> {
+  await env.KV.delete(cacheKey(userId));
+}

--- a/tests/aggregation/custom-rules.test.ts
+++ b/tests/aggregation/custom-rules.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for src/utils/custom-rules.ts (pure matcher) and
+ * src/utils/custom-rule-input.ts (PUT validation). No D1, no KV.
+ */
+import { describe, expect, it } from "vitest";
+import { applyRules, type CompiledRule } from "../../src/utils/custom-rules";
+import { validateCustomRules, MAX_RULES } from "../../src/utils/custom-rule-input";
+
+function rule(partial: Partial<CompiledRule>): CompiledRule {
+  return {
+    action: "change",
+    source: "project",
+    operation: "equals",
+    source_value: "old",
+    destination: "project",
+    destination_value: "new",
+    ...partial,
+  };
+}
+
+describe("applyRules (matcher)", () => {
+  it("rewrites the destination field on a matching change rule", () => {
+    const hb = { project: "old", language: "Go" };
+    const out = applyRules(hb, [rule({})]);
+    expect(out).not.toBeNull();
+    expect(out?.project).toBe("new");
+    expect(out?.language).toBe("Go");
+  });
+
+  it("leaves non-matching heartbeats untouched", () => {
+    const hb = { project: "keep" };
+    expect(applyRules(hb, [rule({})])?.project).toBe("keep");
+  });
+
+  it("supports contains / starts_with / ends_with", () => {
+    expect(applyRules({ project: "abcdef" }, [rule({ operation: "contains", source_value: "cd" })])?.project).toBe("new");
+    expect(applyRules({ project: "work/x" }, [rule({ operation: "starts_with", source_value: "work/" })])?.project).toBe("new");
+    expect(applyRules({ project: "x.tmp" }, [rule({ operation: "ends_with", source_value: ".tmp" })])?.project).toBe("new");
+    expect(applyRules({ project: "nomatch" }, [rule({ operation: "contains", source_value: "zz" })])?.project).toBe("nomatch");
+  });
+
+  it("can rewrite across dimensions (entity → project)", () => {
+    const hb = { entity: "/repo/secret.ts", project: "fallback" };
+    const out = applyRules(hb, [
+      rule({ source: "entity", operation: "contains", source_value: "secret", destination: "project", destination_value: "Secret" }),
+    ]);
+    expect(out?.project).toBe("Secret");
+  });
+
+  it("returns null (drops) on a matching hide rule", () => {
+    const hb = { project: "work/secret" };
+    const out = applyRules(hb, [rule({ action: "hide", operation: "starts_with", source_value: "work/", destination: "", destination_value: "" })]);
+    expect(out).toBeNull();
+  });
+
+  it("applies rules sequentially: a change can set up a later rule's match", () => {
+    const hb = { project: "a" };
+    const out = applyRules(hb, [
+      rule({ source_value: "a", destination_value: "b" }),
+      rule({ source_value: "b", destination_value: "c" }),
+    ]);
+    expect(out?.project).toBe("c");
+  });
+
+  it("short-circuits on the first matching hide", () => {
+    const hb = { project: "x" };
+    const out = applyRules(hb, [
+      rule({ action: "hide", source_value: "x", destination: "", destination_value: "" }),
+      rule({ source_value: "x", destination_value: "should-not-apply" }),
+    ]);
+    expect(out).toBeNull();
+  });
+
+  it("skips rules whose source field is missing or non-string", () => {
+    const hb = { language: "Go" }; // no project
+    expect(applyRules(hb, [rule({})])).toEqual({ language: "Go" });
+  });
+
+  it("is a no-op for an empty rule set", () => {
+    const hb = { project: "old" };
+    expect(applyRules(hb, [])).toEqual({ project: "old" });
+  });
+});
+
+describe("validateCustomRules", () => {
+  const change = {
+    action: "change",
+    source: "project",
+    operation: "equals",
+    source_value: "old",
+    destination: "project",
+    destination_value: "new",
+  };
+
+  it("accepts a valid array and defaults priority to the array index", () => {
+    const r = validateCustomRules([change, { action: "hide", source: "project", operation: "starts_with", source_value: "work/" }]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toHaveLength(2);
+    expect(r.value[0].priority).toBe(0);
+    expect(r.value[1].priority).toBe(1);
+    // hide rule normalises destination fields to empty strings
+    expect(r.value[1].destination).toBe("");
+    expect(r.value[1].destination_value).toBe("");
+  });
+
+  it("accepts an empty array (clear all)", () => {
+    const r = validateCustomRules([]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual([]);
+  });
+
+  it("honours an explicit priority", () => {
+    const r = validateCustomRules([{ ...change, priority: 7 }]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value[0].priority).toBe(7);
+  });
+
+  it("rejects a non-array body", () => {
+    expect(validateCustomRules({}).ok).toBe(false);
+    expect(validateCustomRules(null).ok).toBe(false);
+  });
+
+  it("rejects unknown enum values", () => {
+    expect(validateCustomRules([{ ...change, action: "drop" }]).ok).toBe(false);
+    expect(validateCustomRules([{ ...change, source: "nope" }]).ok).toBe(false);
+    expect(validateCustomRules([{ ...change, operation: "regex" }]).ok).toBe(false);
+  });
+
+  it("requires a non-empty source_value", () => {
+    expect(validateCustomRules([{ ...change, source_value: "" }]).ok).toBe(false);
+  });
+
+  it("requires destination + destination_value for change rules", () => {
+    const noDest = validateCustomRules([{ action: "change", source: "project", operation: "equals", source_value: "x" }]);
+    expect(noDest.ok).toBe(false);
+    const emptyDestVal = validateCustomRules([{ ...change, destination_value: "" }]);
+    expect(emptyDestVal.ok).toBe(false);
+  });
+
+  it("does not require destination for hide rules", () => {
+    const r = validateCustomRules([{ action: "hide", source: "project", operation: "equals", source_value: "x" }]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a non-integer priority", () => {
+    expect(validateCustomRules([{ ...change, priority: 1.5 }]).ok).toBe(false);
+  });
+
+  it("enforces the rule-count cap", () => {
+    const many = Array.from({ length: MAX_RULES + 1 }, () => ({ ...change }));
+    expect(validateCustomRules(many).ok).toBe(false);
+  });
+});

--- a/tests/integration/custom-rules.test.ts
+++ b/tests/integration/custom-rules.test.ts
@@ -92,6 +92,8 @@ describe("custom_rules CRUD", () => {
     expect(data[0].priority).toBe(0);
     expect(data[1].priority).toBe(1);
     expect(data[1].action).toBe("hide");
+    expect(data[1].destination).toBe("project");
+    expect(data[1].destination_value).toBe("");
     expect(data[0].created_at).toBeTruthy();
 
     const list = await call(RULES, { headers: bearer(user.apiKey) });

--- a/tests/integration/custom-rules.test.ts
+++ b/tests/integration/custom-rules.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests for Custom Rules (specs/101-custom-rules-crud/):
+ * CRUD endpoints plus the heartbeat-ingestion remap (change / hide).
+ * Runs against the in-memory D1 + KV provided by vitest-pool-workers.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const RULES = "/api/v1/users/current/custom_rules";
+const HEARTBEATS = "/api/v1/users/current/heartbeats";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("heartbeats", "user_projects", "custom_rules", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+  await env.KV.delete(`customrules:${user.userId}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authJson(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+interface RuleShape {
+  id: string;
+  action: string;
+  source: string;
+  operation: string;
+  source_value: string;
+  destination: string;
+  destination_value: string;
+  priority: number;
+  created_at: string;
+}
+
+function putRules(apiKey: string, rules: unknown[]): Promise<Response> {
+  return call(RULES, { method: "PUT", headers: authJson(apiKey), body: JSON.stringify(rules) });
+}
+
+const changeOldToNew = {
+  action: "change",
+  source: "project",
+  operation: "equals",
+  source_value: "cloudtime-old",
+  destination: "project",
+  destination_value: "cloudtime",
+};
+const hideWork = {
+  action: "hide",
+  source: "project",
+  operation: "starts_with",
+  source_value: "work/",
+};
+
+// --- CRUD --------------------------------------------------------------------
+
+describe("custom_rules CRUD", () => {
+  it("GET returns {data:[]} for a user with no rules", async () => {
+    const res = await call(RULES, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it("PUT replaces the set and echoes server-assigned id/created_at/priority", async () => {
+    const res = await putRules(user.apiKey, [changeOldToNew, hideWork]);
+    expect(res.status).toBe(200);
+    const { data } = (await res.json()) as { data: RuleShape[] };
+    expect(data).toHaveLength(2);
+    expect(data[0].id).toMatch(/[0-9a-f-]{36}/);
+    expect(data[0].priority).toBe(0);
+    expect(data[1].priority).toBe(1);
+    expect(data[1].action).toBe("hide");
+    expect(data[0].created_at).toBeTruthy();
+
+    const list = await call(RULES, { headers: bearer(user.apiKey) });
+    const listed = (await list.json()) as { data: RuleShape[] };
+    expect(listed.data.map((r) => r.source_value)).toEqual(["cloudtime-old", "work/"]);
+  });
+
+  it("orders rules by priority ascending", async () => {
+    await putRules(user.apiKey, [
+      { ...changeOldToNew, source_value: "p2", priority: 2 },
+      { ...changeOldToNew, source_value: "p0", priority: 0 },
+      { ...changeOldToNew, source_value: "p1", priority: 1 },
+    ]);
+    const list = await call(RULES, { headers: bearer(user.apiKey) });
+    const { data } = (await list.json()) as { data: RuleShape[] };
+    expect(data.map((r) => r.source_value)).toEqual(["p0", "p1", "p2"]);
+  });
+
+  it("rejects an invalid rule with 400 and leaves the existing set unchanged", async () => {
+    await putRules(user.apiKey, [changeOldToNew]);
+    // change rule missing destination_value
+    const bad = await putRules(user.apiKey, [
+      { action: "change", source: "project", operation: "equals", source_value: "x", destination: "project" },
+    ]);
+    expect(bad.status).toBe(400);
+    const list = await call(RULES, { headers: bearer(user.apiKey) });
+    const { data } = (await list.json()) as { data: RuleShape[] };
+    expect(data).toHaveLength(1);
+    expect(data[0].source_value).toBe("cloudtime-old");
+  });
+
+  it("PUT [] clears all rules", async () => {
+    await putRules(user.apiKey, [changeOldToNew]);
+    const cleared = await putRules(user.apiKey, []);
+    expect(cleared.status).toBe(200);
+    const list = await call(RULES, { headers: bearer(user.apiKey) });
+    expect(await list.json()).toEqual({ data: [] });
+  });
+
+  it("DELETE removes an owned rule (204) and 404s on unknown id", async () => {
+    await putRules(user.apiKey, [changeOldToNew, hideWork]);
+    const list = await call(RULES, { headers: bearer(user.apiKey) });
+    const { data } = (await list.json()) as { data: RuleShape[] };
+    const id = data[0].id;
+
+    const del = await call(`${RULES}/${id}`, { method: "DELETE", headers: bearer(user.apiKey) });
+    expect(del.status).toBe(204);
+
+    const after = await call(RULES, { headers: bearer(user.apiKey) });
+    const { data: remaining } = (await after.json()) as { data: RuleShape[] };
+    expect(remaining.find((r) => r.id === id)).toBeUndefined();
+    expect(remaining).toHaveLength(1);
+
+    const unknown = await call(`${RULES}/missing`, { method: "DELETE", headers: bearer(user.apiKey) });
+    expect(unknown.status).toBe(404);
+  });
+
+  it("isolates rules across users and 404s cross-user DELETE", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await putRules(bob.apiKey, [changeOldToNew]);
+    const bobList = await call(RULES, { headers: bearer(bob.apiKey) });
+    const bobRuleId = ((await bobList.json()) as { data: RuleShape[] }).data[0].id;
+
+    // alice has no rules and cannot see/delete bob's
+    expect(await (await call(RULES, { headers: bearer(user.apiKey) })).json()).toEqual({ data: [] });
+    const del = await call(`${RULES}/${bobRuleId}`, { method: "DELETE", headers: bearer(user.apiKey) });
+    expect(del.status).toBe(404);
+
+    const stillThere = await call(RULES, { headers: bearer(bob.apiKey) });
+    expect(((await stillThere.json()) as { data: RuleShape[] }).data).toHaveLength(1);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+    await env.KV.delete(`customrules:${bob.userId}`);
+  });
+
+  it("requires authentication", async () => {
+    expect((await call(RULES)).status).toBe(401);
+    // application/json bypasses the form-style CSRF guard, reaching authMiddleware.
+    expect(
+      (await call(RULES, { method: "PUT", headers: { "Content-Type": "application/json" }, body: "[]" })).status,
+    ).toBe(401);
+    expect(
+      (await call(`${RULES}/x`, { method: "DELETE", headers: { "Content-Type": "application/json" } })).status,
+    ).toBe(401);
+  });
+});
+
+// --- Heartbeat ingestion remap ----------------------------------------------
+
+describe("custom_rules heartbeat remap", () => {
+  const nowEpoch = () => Math.floor(Date.now() / 1000);
+  const today = () => new Date().toISOString().slice(0, 10);
+
+  async function listHeartbeats(apiKey: string): Promise<Array<{ id: string; project?: string }>> {
+    const res = await call(`${HEARTBEATS}?date=${today()}`, { headers: bearer(apiKey) });
+    return ((await res.json()) as { data: Array<{ id: string; project?: string }> }).data;
+  }
+
+  it("change rule rewrites the dimension on an ingested heartbeat", async () => {
+    await putRules(user.apiKey, [changeOldToNew]);
+    const res = await call(HEARTBEATS, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ entity: "/x.ts", type: "file", time: nowEpoch(), project: "cloudtime-old" }),
+    });
+    expect(res.status).toBe(201);
+
+    const stored = await listHeartbeats(user.apiKey);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].project).toBe("cloudtime");
+  });
+
+  it("hide rule drops the heartbeat while the request still succeeds", async () => {
+    await putRules(user.apiKey, [hideWork]);
+    const res = await call(HEARTBEATS, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ entity: "/y.ts", type: "file", time: nowEpoch(), project: "work/secret" }),
+    });
+    expect(res.status).toBe(201); // success, no leak that it was dropped
+    const body = (await res.json()) as { data: { id: string } };
+    expect(body.data.id).toBeTruthy();
+
+    const stored = await listHeartbeats(user.apiKey);
+    expect(stored).toHaveLength(0); // not persisted
+  });
+
+  it("bulk: changes, hides, and keeps in order", async () => {
+    await putRules(user.apiKey, [changeOldToNew, hideWork]);
+    const res = await call(`${HEARTBEATS}.bulk`, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([
+        { entity: "/a.ts", type: "file", time: nowEpoch(), project: "cloudtime-old" },
+        { entity: "/b.ts", type: "file", time: nowEpoch(), project: "work/secret" },
+        { entity: "/c.ts", type: "file", time: nowEpoch(), project: "keep" },
+      ]),
+    });
+    expect(res.status).toBe(202);
+    const { responses } = (await res.json()) as { responses: [{ data: { id: string } | null; error: string | null }, number][] };
+    expect(responses).toHaveLength(3);
+    // All three report success (the hidden one is indistinguishable).
+    expect(responses.every(([item, status]) => status === 201 && item.error === null)).toBe(true);
+
+    const stored = await listHeartbeats(user.apiKey);
+    const projects = stored.map((h) => h.project).sort();
+    expect(projects).toEqual(["cloudtime", "keep"]); // work/secret hidden
+  });
+
+  it("no rules: heartbeats are stored unchanged", async () => {
+    const res = await call(HEARTBEATS, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ entity: "/z.ts", type: "file", time: nowEpoch(), project: "cloudtime-old" }),
+    });
+    expect(res.status).toBe(201);
+    const stored = await listHeartbeats(user.apiKey);
+    expect(stored[0].project).toBe("cloudtime-old");
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for **Custom Rules** (issue #101), following the SpecKit 2-PR workflow. Wires the CRUD surface and the ingestion-time remap spec'd in #118 (merged). Mutation endpoints + a heartbeat hook that rewrites or drops heartbeats per the user's rules.

Follow-up to the spec PR (#118).

## Endpoints

| Method | Path | Result |
|---|---|---|
| `GET` | `/users/current/custom_rules` | 200 `{data: CustomRule[]}` (priority order) |
| `PUT` | `/users/current/custom_rules` | 200 `{data: CustomRule[]}` (full replace) |
| `DELETE` | `/users/current/custom_rules/{rule_id}` | 204 / 404 |

## What's in this PR

- **`src/utils/custom-rules.ts`** — pure `applyRules(hb, rules)` (rewrite in place on `change`, return `null` on `hide`, sequential by priority, first `hide` short-circuits) + KV-cached `loadRules` / `invalidateRules` keyed `customrules:${userId}`.
- **`src/utils/custom-rule-input.ts`** — `validateCustomRules` for the PUT array: enum checks, `change` requires `destination` + non-empty `destination_value`, `source_value` non-empty, ≤ 50 rules, `priority` defaults to array index.
- **`src/routes/custom-rules.ts`** — `GET` (ordered), `PUT` (validate → atomic `db.batch([DELETE all, INSERT each])` → cache invalidate → return persisted), `DELETE` (`WHERE id=? AND user_id=?`; 204/404; cache invalidate). Mounted in `index.ts`.
- **`src/routes/heartbeats.ts`** — apply rules before INSERT on `POST /heartbeats` and `/heartbeats.bulk`; hidden heartbeats are excluded from the batch (and skip user-agent resolution, leaving no trace) but still return a **success-shaped** response so callers cannot tell which were dropped. Shared `buildHeartbeatResponse` keeps the hidden and stored shapes identical.
- **Tests** — pure matcher + validation unit tests (`tests/aggregation/custom-rules.test.ts`) and integration tests (`tests/integration/custom-rules.test.ts`) for CRUD (ordering, validation-leaves-set-unchanged, clear, cross-user 404, auth) and ingestion (change rewrite, hide drop, bulk mix order, no-rules passthrough).

## Hide-response decision (spec follow-up)

Per #118, the hidden-heartbeat response shape was finalised here: a dropped heartbeat returns the **same success shape as a stored one** (`{data:{id},error:null}` / 201). This is the least-distinguishable option — returning `data:null` would let a caller enumerate which items were hidden. Verified against the compatible bulk-response contract by shape, without reading upstream source.

## No schema / type change

OpenAPI + generated types landed in PR1 (#118). This PR is implementation + tests only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 199 passing (168 prior + 31 new)
- [ ] Manual `quickstart.md` E / F / G against a staging worker