### PR TITLE
spec: Machine Names endpoint (PR1/2) #104

### DIFF
--- a/schemas/components/schemas/Machine.yaml
+++ b/schemas/components/schemas/Machine.yaml
@@ -7,12 +7,17 @@ properties:
     type: string
   value:
     type: string
-    description: Machine hostname
+    description: Machine hostname (the heartbeat `machine` / `X-Machine-Name` value)
   ip:
     type: string
+    description: |
+      Last source IP seen for this machine. Owner-private — returned only to
+      the user who owns the row. May be absent when no IP was captured.
   last_seen_at:
     type: string
     format: date-time
+    description: Timestamp of the most recent heartbeat from this machine.
   created_at:
     type: string
     format: date-time
+    description: Timestamp the machine was first seen.

--- a/schemas/paths/tracking/machine-names.yaml
+++ b/schemas/paths/tracking/machine-names.yaml
@@ -3,6 +3,15 @@ get:
   tags:
     - machine_names
   summary: List user's machines
+  description: |
+    Returns the authenticated user's machines (devices), ordered by
+    `last_seen_at` descending. Machines are recorded server-side from the
+    `machine` body field / `X-Machine-Name` header on incoming heartbeats;
+    this endpoint surfaces that per-device registry.
+
+    The `ip` field is the last source IP seen for the device and is
+    owner-private — it is only ever returned for the requesting user's own
+    machines (always the case here, since the list is user-scoped).
   responses:
     '200':
       description: List of machines

--- a/specs/104-machine-names/checklists/requirements.md
+++ b/specs/104-machine-names/checklists/requirements.md
@@ -11,7 +11,7 @@
 - [x] `contracts/openapi-diff.md` documents the description-only clarifications.
 - [x] `machine-names.yaml` and `Machine.yaml` carry the clarifying descriptions.
 - [x] `npm run generate` produces only JSDoc changes (no type-shape change); `npm run typecheck` passes.
-- [x] PR1 contains no changes under `src/`.
+- [x] PR1 contains no runtime code changes under `src/` (only regenerated `src/types/generated.ts`).
 - [x] PR1 references issue #104.
 
 ## PR2 (Implementation) gate — must be ✅ before merging

--- a/specs/104-machine-names/checklists/requirements.md
+++ b/specs/104-machine-names/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Acceptance Checklist: Machine Names Endpoint
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-008 (ingestion population + list) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 5 design decisions (side registry vs FK, IP source, registration-follows-persistence, batched dedupe, ordering).
+- [x] `data-model.md` confirms no schema change and documents the upsert + read query.
+- [x] `quickstart.md` enumerates scenarios A–G.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the description-only clarifications.
+- [x] `machine-names.yaml` and `Machine.yaml` carry the clarifying descriptions.
+- [x] `npm run generate` produces only JSDoc changes (no type-shape change); `npm run typecheck` passes.
+- [x] PR1 contains no changes under `src/`.
+- [x] PR1 references issue #104.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/machine.ts` exports `machineUpsertStmt(db, userId, value, ip)` building the `INSERT … ON CONFLICT` statement.
+- [ ] `src/routes/heartbeats.ts` upserts distinct machines into the existing batch on `POST /heartbeats` and `/heartbeats.bulk`, only for persisted (valid, non-hidden) heartbeats, with `ip = CF-Connecting-IP ?? null`.
+- [ ] `src/routes/machines.ts` exports a Hono sub-app with `GET /machine_names` (ordered by `last_seen_at` DESC) behind `authMiddleware`, mirroring `user-agents.ts`.
+- [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: two devices register and list newest-first.
+- [ ] B: repeat device advances `last_seen_at`, no duplicate.
+- [ ] C: `X-Machine-Name` header is honoured when body omits `machine`.
+- [ ] D: a heartbeat without a machine registers nothing.
+- [ ] E: a hidden heartbeat (custom rule) registers no machine.
+- [ ] F: bulk dedupes one device into a single upsert.
+- [ ] G: unauthenticated 401; cross-user isolation.
+
+### Tests
+
+- [ ] `tests/integration/machine-names.test.ts`: ingestion population (single + bulk dedupe), repeat-upsert no-duplicate, no-machine no-row, hidden-heartbeat no-row, list ordering, cross-user isolation, 401.
+- [ ] `npm test` stays green with the new coverage.
+
+## Post-deployment gate
+
+- [ ] Send heartbeats from two real devices and confirm both appear, newest-active first.
+- [ ] Confirm `ip` shows only the requesting user's own device addresses.
+- [ ] No 500s on the endpoint or the heartbeat hot path in the first 7 days.

--- a/specs/104-machine-names/contracts/openapi-diff.md
+++ b/specs/104-machine-names/contracts/openapi-diff.md
@@ -23,7 +23,7 @@ Returns `{"data": Machine[]}` ordered by `last_seen_at` descending.
 `Machine` (unchanged required set: `id`, `value`):
 
 - `id`, `value` (hostname) — required
-- `ip` — optional, owner-private (the caller's own; null when not captured)
+- `ip` — optional, owner-private (the caller's own; omitted when not captured)
 - `last_seen_at`, `created_at` — optional date-time
 
 Responses: `200` (list), `401` (unauthenticated).

--- a/specs/104-machine-names/contracts/openapi-diff.md
+++ b/specs/104-machine-names/contracts/openapi-diff.md
@@ -1,0 +1,48 @@
+# OpenAPI Diff
+
+The `getMachineNames` operation and the `Machine` schema already existed in
+`schemas/openapi.yaml`. This PR only clarifies descriptions — there is no
+type-shape change.
+
+## Files touched
+
+1. `schemas/paths/tracking/machine-names.yaml` — add a `description` to
+   `getMachineNames` (ordering by `last_seen_at` DESC; `ip` is owner-private).
+2. `schemas/components/schemas/Machine.yaml` — add field descriptions
+   (`value` source, `ip` owner-private/nullable, `last_seen_at` / `created_at`
+   meaning).
+
+No new path items, no new operations, no `required`-list change.
+
+## Contract shape (unchanged)
+
+### `GET /users/current/machine_names` → `getMachineNames`
+
+Returns `{"data": Machine[]}` ordered by `last_seen_at` descending.
+
+`Machine` (unchanged required set: `id`, `value`):
+
+- `id`, `value` (hostname) — required
+- `ip` — optional, owner-private (the caller's own; null when not captured)
+- `last_seen_at`, `created_at` — optional date-time
+
+Responses: `200` (list), `401` (unauthenticated).
+
+## Generated-types impact
+
+`npm run generate` adds only JSDoc comments to `operations["getMachineNames"]`
+and `components["schemas"]["Machine"]`. The TypeScript types are unchanged
+(no field added/removed/required), so no handler is affected by the
+regeneration.
+
+## Heartbeat ingestion — no contract change in PR1
+
+The ingestion-time `machine_names` upsert is behavioural and lands in PR2. It
+does not alter the heartbeat request/response contract: `machine` remains a
+free-text field on `HeartbeatInput` and on the stored row.
+
+## SDD compliance note
+
+PR1 lands SpecKit + the description clarifications + regenerated types
+(JSDoc only). PR2 lands the upsert helper, the ingestion hook, the read
+route, and tests. No runtime code in PR1.

--- a/specs/104-machine-names/data-model.md
+++ b/specs/104-machine-names/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Machine Names Endpoint
+
+No schema changes. Uses the existing `machine_names` table; `heartbeats` is unchanged.
+
+## `machine_names` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS machine_names (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  value TEXT NOT NULL,
+  ip TEXT,
+  last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, value)
+);
+```
+
+`UNIQUE(user_id, value)` is the conflict target for the ingestion upsert. `ON DELETE CASCADE` removes a user's machines when the user is deleted.
+
+## Ingestion upsert
+
+```sql
+INSERT INTO machine_names (id, user_id, value, ip, last_seen_at, created_at)
+VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+ON CONFLICT (user_id, value) DO UPDATE SET
+  last_seen_at = datetime('now'),
+  ip = excluded.ip;
+```
+
+- Bound params: `crypto.randomUUID()`, `userId`, `machine` value, `ip` (`CF-Connecting-IP` or null).
+- Added to the existing heartbeat `db.batch()`; one statement per **distinct** persisted machine value per request.
+- Only runs for persisted heartbeats (valid + not hidden by a custom rule).
+
+## Read query
+
+```sql
+SELECT id, value, ip, last_seen_at, created_at
+  FROM machine_names
+ WHERE user_id = ?
+ ORDER BY last_seen_at DESC;
+```
+
+Strictly `user_id`-scoped, so a caller never sees another user's machines or IPs.
+
+## Field treatment in the read handler
+
+| Column | Handler treatment |
+|---|---|
+| `id`, `value` | Pass through |
+| `ip` | Pass through (null → omitted from the response object) |
+| `last_seen_at`, `created_at` | `normalizeDateTime` → ISO 8601 (mirrors `user_agents`) |
+
+## `heartbeats` (unchanged)
+
+`heartbeats.machine` continues to store the raw machine string. No foreign key, no new column. The registry is derived alongside, not from a join.
+
+## Cleanup / cascade
+
+`machine_names` cascades on user delete. No per-machine delete endpoint (out of scope); the registry is ingestion-driven.

--- a/specs/104-machine-names/plan.md
+++ b/specs/104-machine-names/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Machine Names Endpoint
+
+**Branch**: `104-machine-names` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/104-machine-names/spec.md`
+
+## Summary
+
+Populate the `machine_names` registry at heartbeat ingestion and expose it with a single read endpoint, mirroring the `user_agents` feature (#105). Unlike user agents, `machine` is not foreign-keyed onto `heartbeats` — `machine_names` is an independent per-device registry upserted in the existing heartbeat `db.batch()`.
+
+PR1 (this PR): SpecKit artifacts + OpenAPI description clarifications (the `getMachineNames` operation and `Machine` schema already exist). No runtime code. PR2: the upsert helper, the ingestion hook in `heartbeats.ts`, the read route, and tests.
+
+No D1 migration, no new binding.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`machine_names`, existing)
+**Testing**: Vitest + workers pool — integration tests for ingestion population + the list endpoint
+**Performance Goals**: <10ms CPU; one extra batched upsert per distinct machine
+**Constraints**: fold the upsert into the existing heartbeat batch; no extra round-trip
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI operation already declared; PR1 clarifies descriptions, PR2 implements. `npm run generate` adds only JSDoc (no type-shape change). |
+| II. Cloudflare-Native | PASS | One `INSERT … ON CONFLICT` added to the heartbeat `db.batch()`. IP from `CF-Connecting-IP`. No new bindings. |
+| III. Type Safety | PASS | Read handler uses `components["schemas"]["Machine"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Registry derived from our own schema; no upstream source/assets. |
+| V. Simplicity First | PASS | Mirrors `user_agents`: one upsert helper + one list route. No mutation endpoints. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/104-machine-names/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── machines.ts          # NEW: getMachineNames read handler (mirrors user-agents.ts)
+├── utils/
+│   └── machine.ts           # NEW: machineUpsertStmt(db, userId, value, ip) → D1PreparedStatement
+├── routes/heartbeats.ts     # EXTEND: upsert distinct machines into the batch (single + bulk)
+└── index.ts                 # NEW route mount
+```
+
+**Structure Decision**: Read route in `machines.ts` mirrors `user-agents.ts` almost verbatim. The upsert is exposed as a statement builder so it slots into the existing heartbeat batch (like `UPSERT_PROJECT_SQL`) rather than a separate write.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. `machine_names` is a **side registry**, not an FK on `heartbeats` — the raw `machine` string stays on the row.
+2. **IP from `CF-Connecting-IP`**, stored verbatim, owner-private.
+3. **Registration follows persistence** — invalid/hidden heartbeats register no machine.
+4. **Upsert folded into the heartbeat batch**, deduped per distinct machine.
+5. **List ordered by `last_seen_at` DESC**, mirroring `user_agents`.
+
+## Phase 1 — Design Outputs
+
+### Upsert statement builder
+
+```ts
+// src/utils/machine.ts
+const MACHINE_UPSERT_SQL = `INSERT INTO machine_names (id, user_id, value, ip, last_seen_at, created_at)
+VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+ON CONFLICT (user_id, value) DO UPDATE SET
+  last_seen_at = datetime('now'),
+  ip = excluded.ip`;
+
+export function machineUpsertStmt(db: D1Database, userId: string, value: string, ip: string | null): D1PreparedStatement {
+  return db.prepare(MACHINE_UPSERT_SQL).bind(crypto.randomUUID(), userId, value, ip);
+}
+```
+
+### Ingestion hook (heartbeats.ts)
+
+- Single POST: after rules (so a hidden heartbeat registers nothing), if `machine` present, push `machineUpsertStmt` into the insert batch with `ip = c.req.header("CF-Connecting-IP") ?? null`.
+- Bulk POST: collect the **distinct** machine values across persisted (valid, non-hidden) items into a `Set`, push one upsert per distinct value (same request IP).
+
+### Read route (mirrors user-agents.ts)
+
+```ts
+machines.get("/machine_names", async (c) => {
+  const userId = c.get("userId");
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, value, ip, last_seen_at, created_at FROM machine_names
+      WHERE user_id = ? ORDER BY last_seen_at DESC`,
+  ).bind(userId).all<MachineRow>();
+  return c.json({ data: results.map(rowToMachine) });
+});
+```
+
+### OpenAPI surface
+
+Already declared. PR1 adds clarifying descriptions (ordering, ip privacy) — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No type-shape change.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+The only shared-path touch is the heartbeat ingestion batch, gated on a present `machine` value and deduped. No new failure modes beyond the existing batch.

--- a/specs/104-machine-names/quickstart.md
+++ b/specs/104-machine-names/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Machine Names Endpoint
+
+Manual verification once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+export HJ="$H
+Content-Type: application/json"
+```
+
+## Scenario A — Devices register at ingestion
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/a.ts","type":"file","time":'"$(date +%s)"',"machine":"laptop"}'
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/b.ts","type":"file","time":'"$(date +%s)"',"machine":"desktop"}'
+curl -sH "$H" "$BASE/users/current/machine_names"
+```
+
+**Expected**: `data` lists two machines (`desktop`, `laptop`) ordered by `last_seen_at` descending, each with `id`, `value`, `last_seen_at`, `created_at`, and `ip` (your address, or absent if not captured).
+
+## Scenario B — Repeat device updates last_seen_at, no duplicate
+
+```bash
+sleep 1
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/c.ts","type":"file","time":'"$(date +%s)"',"machine":"laptop"}'
+curl -sH "$H" "$BASE/users/current/machine_names"
+```
+
+**Expected**: still two machines; `laptop` now sorts first (its `last_seen_at` advanced); no duplicate `laptop` row.
+
+## Scenario C — X-Machine-Name header
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -H "X-Machine-Name: ci-runner" \
+  -d '{"entity":"/d.ts","type":"file","time":'"$(date +%s)"'}'
+curl -sH "$H" "$BASE/users/current/machine_names"
+```
+
+**Expected**: a `ci-runner` machine appears (the header is honoured when the body omits `machine`).
+
+## Scenario D — No machine value registers nothing
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/e.ts","type":"file","time":'"$(date +%s)"'}'
+```
+
+**Expected**: no new machine row (the list is unchanged from before this call).
+
+## Scenario E — Hidden heartbeat registers no machine
+
+With a custom `hide` rule (#101) matching `project=secret`:
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats" -H "$H" -H "Content-Type: application/json" \
+  -d '{"entity":"/f.ts","type":"file","time":'"$(date +%s)"',"project":"secret","machine":"ghost"}'
+curl -sH "$H" "$BASE/users/current/machine_names"
+```
+
+**Expected**: no `ghost` machine — a hidden heartbeat leaves no device trace.
+
+## Scenario F — Bulk dedupes one device
+
+```bash
+curl -sX POST "$BASE/users/current/heartbeats.bulk" -H "$H" -H "Content-Type: application/json" -d '[
+  {"entity":"/g.ts","type":"file","time":'"$(date +%s)"',"machine":"laptop"},
+  {"entity":"/h.ts","type":"file","time":'"$(date +%s)"',"machine":"laptop"}
+]'
+```
+
+**Expected**: `laptop` upserted once; still a single `laptop` row with an advanced `last_seen_at`.
+
+## Scenario G — Cross-user isolation / auth
+
+```bash
+curl -si "$BASE/users/current/machine_names"   # no auth → 401
+```
+
+**Expected**: 401 unauthenticated. As another user, the list never includes your machines.
+
+## Reverting / cleanup
+
+Removing the ingestion upsert and the route disables the feature without data loss — existing `machine_names` rows remain, and `heartbeats.machine` is untouched.

--- a/specs/104-machine-names/research.md
+++ b/specs/104-machine-names/research.md
@@ -1,0 +1,59 @@
+# Research: Machine Names Endpoint
+
+## Decision 1: `machine_names` is a side registry, not an FK on `heartbeats`
+
+**Decision**: `heartbeats.machine` keeps storing the raw string. `machine_names` is upserted independently at ingestion; no `machine_id` foreign key is added to `heartbeats`.
+
+**Rationale**:
+- The issue (#104) states the heartbeat already stores `machine` as a string and asks only to *also* populate the registry. Adding an FK would be a schema migration and a behavioural change to ingestion for no read-side benefit (no endpoint joins on machine yet).
+- This diverges intentionally from `user_agents` (#99), which *does* FK onto heartbeats. User agents are parsed/normalised and reused; machine names are a flat per-device list, so a registry is enough.
+
+**Alternative considered**: foreign-key `heartbeats.machine` → `machine_names.id`. Rejected — migration + ingestion churn, out of scope.
+
+---
+
+## Decision 2: IP from `CF-Connecting-IP`, stored verbatim, owner-private
+
+**Decision**: The upsert sets `ip` to `CF-Connecting-IP` (the real client IP behind Cloudflare), or null when absent. It is returned only in the user-scoped list, never resolved or enriched.
+
+**Rationale**:
+- `CF-Connecting-IP` is the canonical client IP on Workers. The `machine_names.ip` column exists to show "last seen from this address."
+- The list endpoint is strictly `WHERE user_id = ?`, so a user only ever sees their own machines' IPs — the field is owner-private by construction.
+
+**Alternative considered**: store no IP (drop the column from the response). Rejected — the column exists and the per-device "last IP" is useful to a self-hoster; keeping it user-scoped removes the privacy concern.
+
+---
+
+## Decision 3: Registration follows persistence
+
+**Decision**: A machine is registered only for heartbeats that are actually persisted. Invalid heartbeats (failed validation) and heartbeats dropped by a `hide` custom rule (#101) register no machine.
+
+**Rationale**:
+- A hidden heartbeat is meant to leave no trace (#101 FR-009); registering its device would leak that activity occurred. Sequencing the upsert after rule application and validation preserves that guarantee.
+- Avoids polluting the registry with devices from rejected payloads.
+
+**Alternative considered**: register on any received `machine` value regardless of persistence. Rejected — contradicts the hide-rule non-disclosure guarantee.
+
+---
+
+## Decision 4: Upsert folded into the heartbeat batch, deduped per distinct machine
+
+**Decision**: The machine upsert is an `INSERT … ON CONFLICT` statement added to the existing heartbeat `db.batch()`. For bulk requests, distinct machine values are collected into a set and upserted once each.
+
+**Rationale**:
+- Folding into the existing batch avoids an extra D1 round-trip on the hot path (mirrors `UPSERT_PROJECT_SQL`).
+- A 25-item bulk POST from one device should issue one machine upsert, not 25 — dedupe by value (the request IP is constant).
+- No `RETURNING` is needed because we do not store an FK; the upsert is fire-and-forget.
+
+**Alternative considered**: a standalone upsert per heartbeat. Rejected — redundant writes and round-trips.
+
+---
+
+## Decision 5: List ordered by `last_seen_at` DESC
+
+**Decision**: `GET /machine_names` returns machines ordered by `last_seen_at` descending, mirroring `GET /user_agents`.
+
+**Rationale**:
+- "Most recently active device first" is the natural default for a device list and matches the sibling endpoint, keeping the two registries consistent for clients.
+
+**Alternative considered**: order by `created_at` or `value`. Rejected — recency is the useful axis; consistency with `user_agents` reduces client surprise.

--- a/specs/104-machine-names/spec.md
+++ b/specs/104-machine-names/spec.md
@@ -59,7 +59,7 @@ As an authenticated user, I want to list my devices most-recently-active first s
 - **FR-003**: A bulk request MUST upsert each distinct `machine` value at most once per request.
 - **FR-004**: A heartbeat that is not persisted (invalid, or dropped by a `hide` custom rule) MUST NOT register a machine.
 - **FR-005**: `GET /api/v1/users/current/machine_names` MUST return the user's machines as `{"data": Machine[]}` ordered by `last_seen_at` descending.
-- **FR-006**: Each entry MUST include `id`, `value`, `last_seen_at`, `created_at`, and `ip` (the caller's own; the list is user-scoped so `ip` is never another user's).
+- **FR-006**: Each entry MUST include `id`, `value`, `last_seen_at`, and `created_at`. When an IP was captured, `ip` MUST be the caller's own machine IP; when no IP was captured, `ip` MAY be omitted. The list is user-scoped so `ip` is never another user's.
 - **FR-007**: The endpoint MUST require API-key or session authentication; unauthenticated requests return 401.
 - **FR-008**: Results MUST be strictly scoped by `user_id`; no other user's machines appear.
 

--- a/specs/104-machine-names/spec.md
+++ b/specs/104-machine-names/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Machine Names Endpoint
+
+**Feature Branch**: `104-machine-names`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: The `machine_names` D1 table and the `getMachineNames` OpenAPI operation are declared, but no route is mounted and the table is never populated. `POST /heartbeats` already extracts a `machine` value (body field / `X-Machine-Name` header) and stores it on the `heartbeats` row, but no per-device registry is maintained.
+
+## Background
+
+A self-hosted user with multiple devices (work laptop + home desktop) sends heartbeats tagged with a `machine` name, but cannot see a per-device breakdown — the `machine_names` table that would back such a view is empty. This feature populates that registry at ingestion time and exposes it read-only.
+
+It mirrors the `user_agents` feature (#105): a small side-registry kept current by heartbeat ingestion, surfaced by a single list endpoint. **Difference**: `machine` stays a raw string on the `heartbeats` row (no foreign key); `machine_names` is an independent per-device registry, not a normalisation target.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Devices are registered at ingestion (Priority: P1)
+
+As an authenticated user, I want each device I send heartbeats from to be recorded automatically, so the list reflects my real devices without manual setup.
+
+**Independent Test**: POST a heartbeat with `machine="laptop"`, then POST another with `machine="desktop"`; confirm `machine_names` holds two rows for the user, each with a `last_seen_at`. POST a third `machine="laptop"` heartbeat and confirm the `laptop` row's `last_seen_at` advances (no duplicate row).
+
+**Acceptance Scenarios**:
+1. **Given** a heartbeat with a `machine` value, **When** ingested, **Then** a `machine_names` row for `(user_id, value)` exists.
+2. **Given** a repeat `machine` value, **When** ingested again, **Then** the existing row's `last_seen_at` (and `ip`) updates; no duplicate row (UNIQUE `(user_id, value)`).
+3. **Given** a heartbeat with no `machine` value, **When** ingested, **Then** no `machine_names` row is created.
+4. **Given** a bulk POST with several heartbeats sharing one `machine`, **When** ingested, **Then** that device is upserted once (not once per heartbeat).
+
+---
+
+### User Story 2 - List my machines (Priority: P1)
+
+As an authenticated user, I want to list my devices most-recently-active first so I can see where my coding time comes from.
+
+**Independent Test**: With two devices registered, `GET /machine_names` returns both as `{"data": Machine[]}` ordered by `last_seen_at` descending, each with `id`, `value`, `last_seen_at`, `created_at`, and the owner-private `ip`.
+
+**Acceptance Scenarios**:
+1. **Given** registered machines, **When** listing, **Then** they return ordered by `last_seen_at` descending.
+2. **Given** no machines, **When** listing, **Then** the response is `{"data": []}` with 200.
+3. **Given** another user's machines, **When** listing, **Then** none appear (strict per-user isolation).
+4. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### Edge Cases
+
+- **`machine` present but `ip` unavailable** (no `CF-Connecting-IP`): the row is still upserted with `ip` null.
+- **Hidden heartbeats** (custom-rule `hide`, #101): a heartbeat dropped by a hide rule MUST NOT register a machine — device registration follows persistence.
+- **Very long / unusual machine strings**: stored as-is (the column is free-text); no parsing as with user agents.
+- **Concurrent upserts of the same device**: UNIQUE `(user_id, value)` + `ON CONFLICT` make the upsert idempotent.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On `POST /heartbeats` and `POST /heartbeats.bulk`, for every persisted heartbeat carrying a non-empty `machine` value, the server MUST upsert a `machine_names` row keyed by `(user_id, value)`, setting `last_seen_at` to now and `ip` to the request's source IP (`CF-Connecting-IP`, else null).
+- **FR-002**: A repeat `(user_id, value)` MUST update `last_seen_at`/`ip` in place via `ON CONFLICT`, never insert a duplicate.
+- **FR-003**: A bulk request MUST upsert each distinct `machine` value at most once per request.
+- **FR-004**: A heartbeat that is not persisted (invalid, or dropped by a `hide` custom rule) MUST NOT register a machine.
+- **FR-005**: `GET /api/v1/users/current/machine_names` MUST return the user's machines as `{"data": Machine[]}` ordered by `last_seen_at` descending.
+- **FR-006**: Each entry MUST include `id`, `value`, `last_seen_at`, `created_at`, and `ip` (the caller's own; the list is user-scoped so `ip` is never another user's).
+- **FR-007**: The endpoint MUST require API-key or session authentication; unauthenticated requests return 401.
+- **FR-008**: Results MUST be strictly scoped by `user_id`; no other user's machines appear.
+
+### Non-Functional Requirements
+
+- **NFR-001**: The ingestion upsert MUST stay within the Workers CPU budget — one extra batched statement per distinct machine, folded into the existing heartbeat `db.batch()` (no separate round-trip).
+- **NFR-002**: No D1 schema migration; the `machine_names` table already exists with `UNIQUE(user_id, value)`.
+- **NFR-003**: The list endpoint MUST issue a single `SELECT`.
+
+### Key Entities *(no schema change)*
+
+The existing `machine_names` table (`id`, `user_id`, `value`, `ip`, `last_seen_at`, `created_at`, `UNIQUE(user_id, value)`, `ON DELETE CASCADE`) covers everything. `heartbeats.machine` continues to store the raw string; no foreign key is added.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: After heartbeats from two devices, the user sees exactly two machines, newest-active first.
+- **SC-002**: Re-sending from a known device advances its `last_seen_at` without creating a duplicate.
+- **SC-003**: A hidden heartbeat does not create a machine row.
+- **SC-004**: Cross-user listing never leaks another user's machines or IPs.
+
+## Out of Scope
+
+- **Per-machine activity stats / filtering** of summaries by machine. This is a registry list only.
+- **Renaming, merging, or deleting machines.** No mutation endpoints; the registry is ingestion-driven.
+- **Foreign-keying `heartbeats.machine`** to `machine_names`. The raw string stays on the heartbeat row.
+- **Geo/IP enrichment.** `ip` is stored verbatim, not resolved.

--- a/specs/104-machine-names/tasks.md
+++ b/specs/104-machine-names/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: Machine Names Endpoint
+
+**Branch**: `104-machine-names`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (2 user stories, FR-001..FR-008, NFRs, edge cases).
+- [x] **T-002**: Author `plan.md` (Constitution Check, upsert + route sketches).
+- [x] **T-003**: Author `research.md` (5 documented decisions).
+- [x] **T-004**: Author `data-model.md` (existing table; upsert + read query).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–G).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add clarifying descriptions to `machine-names.yaml` (`getMachineNames`) and `Machine.yaml` (fields). No type-shape change.
+- [x] **T-009**: Run `npm run generate` (JSDoc-only diff); run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Upsert helper
+
+- [ ] **T-101**: `src/utils/machine.ts` — `machineUpsertStmt(db, userId, value, ip)` returning the `INSERT … ON CONFLICT (user_id, value) DO UPDATE` statement.
+
+### Heartbeat integration
+
+- [ ] **T-102**: In `src/routes/heartbeats.ts`, resolve `ip = c.req.header("CF-Connecting-IP") ?? null`; for the single POST, push one machine upsert when a persisted heartbeat has a `machine`; for bulk, collect distinct machine values from persisted (valid, non-hidden) items and push one upsert each. Fold into the existing `db.batch()`.
+
+### Read route
+
+- [ ] **T-103**: `src/routes/machines.ts` — Hono sub-app, `GET /machine_names` ordered by `last_seen_at` DESC, `rowToMachine` mirroring `rowToUserAgent`, behind `authMiddleware`.
+- [ ] **T-104**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", machines)`.
+
+### Tests
+
+- [ ] **T-105**: `tests/integration/machine-names.test.ts` — scenarios A–G (population single + bulk dedupe, repeat upsert, no-machine, hidden-heartbeat, ordering, cross-user, 401).
+
+### Verification
+
+- [ ] **T-106**: `npm run typecheck` — zero errors.
+- [ ] **T-107**: `npm test` — full suite green incl. new integration.
+- [ ] **T-108**: Manual run of `quickstart.md` A / B / E against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-109**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #104.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                  (PR1)
+T-010 → T-101 .. T-109                   (PR2 after PR1 merge)
+T-101 → T-102                            (helper before ingestion hook)
+T-103 → T-104                            (route before mount)
+T-102 / T-104 → T-105                    (integration needs ingestion + list)
+T-105 → T-106 → T-107 → T-108 → T-109
+```
+
+## Out of scope
+
+- Per-machine activity stats or summary filtering by machine.
+- Machine rename / merge / delete (no mutation endpoints).
+- Foreign-keying `heartbeats.machine`.
+- IP geo-resolution / enrichment.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -823,7 +823,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List user's machines */
+        /**
+         * List user's machines
+         * @description Returns the authenticated user's machines (devices), ordered by
+         *     `last_seen_at` descending. Machines are recorded server-side from the
+         *     `machine` body field / `X-Machine-Name` header on incoming heartbeats;
+         *     this endpoint surfaces that per-device registry.
+         *
+         *     The `ip` field is the last source IP seen for the device and is
+         *     owner-private — it is only ever returned for the requesting user's own
+         *     machines (always the case here, since the list is user-scoped).
+         */
         get: operations["getMachineNames"];
         put?: never;
         post?: never;
@@ -1607,12 +1617,22 @@ export interface components {
         };
         Machine: {
             id: string;
-            /** @description Machine hostname */
+            /** @description Machine hostname (the heartbeat `machine` / `X-Machine-Name` value) */
             value: string;
+            /**
+             * @description Last source IP seen for this machine. Owner-private — returned only to
+             *     the user who owns the row. May be absent when no IP was captured.
+             */
             ip?: string;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description Timestamp of the most recent heartbeat from this machine.
+             */
             last_seen_at?: string;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description Timestamp the machine was first seen.
+             */
             created_at?: string;
         };
         UserAgent: {


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Machine Names** (issue #104), following the SpecKit 2-PR workflow. The `getMachineNames` operation and `Machine` schema already existed; this PR adds clarifying descriptions and the SpecKit design for populating the `machine_names` registry at ingestion and listing it. **No implementation code** — the ingestion hook and read route land in PR2.

Mirrors the `user_agents` feature (#105), with one deliberate difference (below).

## What's in this PR

- **OpenAPI (description-only, no type-shape change)**
  - `getMachineNames`: documents ordering by `last_seen_at` DESC and that `ip` is owner-private.
  - `Machine`: field descriptions (`value` source, `ip` optional/owner-private, `last_seen_at`/`created_at` meaning).
- **Generated types** regenerated — JSDoc-only diff (no field added/removed/required).
- **SpecKit artifacts** under `specs/104-machine-names/`.

## Key design decisions (see `research.md`)

- **Side registry, not an FK.** `heartbeats.machine` stays a raw string; `machine_names` is an independent per-device table upserted at ingestion. (Unlike `user_agents`, which FKs onto heartbeats — machine names need no normalisation.)
- **IP from `CF-Connecting-IP`**, stored verbatim, returned only in the user-scoped list (owner-private by construction).
- **Registration follows persistence** — a heartbeat dropped by a `hide` custom rule (#101) or failing validation registers no machine, preserving the hide non-disclosure guarantee.
- **Upsert folded into the existing heartbeat `db.batch()`**, deduped per distinct machine (a 25-item bulk from one device → one upsert).
- **List ordered by `last_seen_at` DESC**, consistent with `user_agents`.

## No schema migration

Uses the existing `machine_names` table (`UNIQUE(user_id, value)`, `ON DELETE CASCADE`).

## Test plan

- [x] `npm run generate` produces a JSDoc-only diff
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly
- [ ] PR2: `machineUpsertStmt` helper, ingestion hook (single + bulk dedupe), `GET /machine_names` route, integration tests
