### PR TITLE
feat: Machine Names endpoint + ingestion (PR2/2) #104

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import stats from "./routes/stats";
 import users from "./routes/users";
 import goals from "./routes/goals";
 import customRules from "./routes/custom-rules";
+import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
 
@@ -127,6 +128,9 @@ app.route("/api/v1/users/current", goals);
 
 // Custom rules routes (mounted at /users/current, sub-app defines /custom_rules, /custom_rules/:rule_id)
 app.route("/api/v1/users/current", customRules);
+
+// Machine names routes (mounted at /users/current, sub-app defines /machine_names)
+app.route("/api/v1/users/current", machines);
 
 // User agents routes (mounted at /users/current, sub-app defines /user_agents)
 app.route("/api/v1/users/current", userAgents);

--- a/src/routes/heartbeats.ts
+++ b/src/routes/heartbeats.ts
@@ -5,6 +5,7 @@ import { authMiddleware, getUserTimeout, getUserTimezone } from "../middleware/a
 import { getEpochBoundsForDate } from "../utils/time-format";
 import { resolveUserAgentId } from "../utils/user-agent";
 import { applyRules, loadRules } from "../utils/custom-rules";
+import { machineUpsertStmt } from "../utils/machine";
 
 type HeartbeatInput = components["schemas"]["HeartbeatInput"];
 type Heartbeat = components["schemas"]["Heartbeat"];
@@ -138,6 +139,7 @@ heartbeats.post("/heartbeats", async (c) => {
 
   const machine = input.machine ?? c.req.header("X-Machine-Name") ?? undefined;
   const userAgent = input.user_agent ?? c.req.header("User-Agent") ?? undefined;
+  const ip = c.req.header("CF-Connecting-IP") ?? null;
 
   try {
     // Apply the user's custom rules before persisting (Issue #101). A `change`
@@ -148,7 +150,7 @@ heartbeats.post("/heartbeats", async (c) => {
     if (applyRules(input, rules) === null) {
       return c.json({ data: buildHeartbeatResponse(crypto.randomUUID(), userId, input, machine, null) }, 201);
     }
-    const heartbeat = await insertHeartbeat(c.env.DB, userId, input, machine, userAgent);
+    const heartbeat = await insertHeartbeat(c.env.DB, userId, input, machine, userAgent, ip);
     return c.json({ data: heartbeat }, 201);
   } catch (err) {
     console.error("POST /heartbeats error:", err);
@@ -177,6 +179,7 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
   // Resolve machine/user_agent: body field > header > undefined
   const headerMachine = c.req.header("X-Machine-Name") ?? undefined;
   const headerUserAgent = c.req.header("User-Agent") ?? undefined;
+  const ip = c.req.header("CF-Connecting-IP") ?? null;
   const now = new Date().toISOString();
 
   // Per-item validation
@@ -210,6 +213,7 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
   // Build insert statements only for valid, non-hidden heartbeats
   const stmts: D1PreparedStatement[] = [];
   const projectTimes = new Map<string, { min: number; max: number }>();
+  const machineValues = new Set<string>();
 
   for (let i = 0; i < inputs.length; i++) {
     if (validationErrors[i] || hidden[i]) continue;
@@ -227,9 +231,17 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
         projectTimes.set(input.project, { min: input.time, max: input.time });
       }
     }
+    if (machine) {
+      machineValues.add(machine);
+    }
   }
   for (const [project, times] of projectTimes) {
     stmts.push(c.env.DB.prepare(UPSERT_PROJECT_SQL).bind(userId, project, times.min, times.max));
+  }
+  // Register each distinct device once (Issue #104). Appended after the
+  // heartbeat inserts so the per-item batch-result mapping below is unaffected.
+  for (const value of machineValues) {
+    stmts.push(machineUpsertStmt(c.env.DB, userId, value, ip));
   }
 
   let batchResults: D1Result[] = [];
@@ -408,6 +420,7 @@ async function insertHeartbeat(
   input: HeartbeatInput,
   machine: string | undefined,
   userAgent: string | undefined,
+  ip: string | null = null,
 ): Promise<Heartbeat> {
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
@@ -421,6 +434,10 @@ async function insertHeartbeat(
   const stmts = [bindHeartbeatParams(db.prepare(INSERT_HEARTBEAT_SQL), id, userId, input, machine, userAgentId, now)];
   if (input.project) {
     stmts.push(db.prepare(UPSERT_PROJECT_SQL).bind(userId, input.project, input.time, input.time));
+  }
+  // Register the device in the machine_names registry (Issue #104).
+  if (machine) {
+    stmts.push(machineUpsertStmt(db, userId, machine, ip));
   }
   await db.batch(stmts);
 

--- a/src/routes/machines.ts
+++ b/src/routes/machines.ts
@@ -1,0 +1,57 @@
+/**
+ * Read-only endpoint exposing the machine_names registry populated by
+ * heartbeat ingestion (Issue #104).
+ *
+ * Each device a user sends heartbeats from is upserted into `machine_names`
+ * (see src/utils/machine.ts). This route surfaces those rows so clients can
+ * show a per-device breakdown. Mirrors src/routes/user-agents.ts.
+ */
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { normalizeDateTime } from "../utils/user";
+
+type Machine = components["schemas"]["Machine"];
+
+interface MachineRow {
+  id: string;
+  value: string;
+  ip: string | null;
+  last_seen_at: string;
+  created_at: string;
+}
+
+function rowToMachine(row: MachineRow): Machine {
+  return {
+    id: row.id,
+    value: row.value,
+    ip: row.ip ?? undefined,
+    last_seen_at: normalizeDateTime(row.last_seen_at),
+    created_at: normalizeDateTime(row.created_at),
+  };
+}
+
+const machines = new Hono<AuthEnv>();
+
+machines.use("/machine_names", authMiddleware);
+
+machines.get("/machine_names", async (c) => {
+  const userId = c.get("userId");
+  try {
+    const { results } = await c.env.DB.prepare(
+      `SELECT id, value, ip, last_seen_at, created_at
+         FROM machine_names
+        WHERE user_id = ?
+        ORDER BY last_seen_at DESC`,
+    )
+      .bind(userId)
+      .all<MachineRow>();
+    return c.json({ data: results.map(rowToMachine) });
+  } catch (err) {
+    console.error("GET /machine_names error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default machines;

--- a/src/utils/machine.ts
+++ b/src/utils/machine.ts
@@ -1,0 +1,26 @@
+/**
+ * Helper for maintaining the `machine_names` per-device registry from
+ * heartbeat ingestion (Issue #104).
+ *
+ * Unlike user agents, `machine` is not foreign-keyed onto `heartbeats` — the
+ * raw string stays on the heartbeat row. This registry is upserted alongside,
+ * keyed by UNIQUE(user_id, value), so the same device returns to the same row
+ * across heartbeats. No RETURNING is needed; the statement is folded into the
+ * existing heartbeat `db.batch()`.
+ */
+
+const MACHINE_UPSERT_SQL = `INSERT INTO machine_names (id, user_id, value, ip, last_seen_at, created_at)
+VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+ON CONFLICT (user_id, value) DO UPDATE SET
+  last_seen_at = datetime('now'),
+  ip = excluded.ip`;
+
+/** Build the upsert statement registering one device for a user. */
+export function machineUpsertStmt(
+  db: D1Database,
+  userId: string,
+  value: string,
+  ip: string | null,
+): D1PreparedStatement {
+  return db.prepare(MACHINE_UPSERT_SQL).bind(crypto.randomUUID(), userId, value, ip);
+}

--- a/tests/integration/machine-names.test.ts
+++ b/tests/integration/machine-names.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests for the Machine Names feature (specs/104-machine-names/):
+ * heartbeat-ingestion population of the machine_names registry plus the
+ * read-only list endpoint. Runs against the in-memory D1 + KV.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const MACHINES = "/api/v1/users/current/machine_names";
+const HEARTBEATS = "/api/v1/users/current/heartbeats";
+const RULES = "/api/v1/users/current/custom_rules";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("heartbeats", "user_projects", "machine_names", "custom_rules", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+  await env.KV.delete(`customrules:${user.userId}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authJson(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+interface MachineShape {
+  id: string;
+  value: string;
+  ip?: string;
+  last_seen_at: string;
+  created_at: string;
+}
+
+const nowEpoch = () => Math.floor(Date.now() / 1000);
+
+function postHeartbeat(apiKey: string, body: Record<string, unknown>, headers: Record<string, string> = {}): Promise<Response> {
+  return call(HEARTBEATS, { method: "POST", headers: { ...authJson(apiKey), ...headers }, body: JSON.stringify(body) });
+}
+
+async function listMachines(apiKey: string): Promise<MachineShape[]> {
+  const res = await call(MACHINES, { headers: bearer(apiKey) });
+  return ((await res.json()) as { data: MachineShape[] }).data;
+}
+
+describe("machine_names ingestion population", () => {
+  it("registers a device per distinct machine value", async () => {
+    await postHeartbeat(user.apiKey, { entity: "/a.ts", type: "file", time: nowEpoch(), machine: "laptop" });
+    await postHeartbeat(user.apiKey, { entity: "/b.ts", type: "file", time: nowEpoch(), machine: "desktop" });
+
+    const machines = await listMachines(user.apiKey);
+    expect(machines.map((m) => m.value).sort()).toEqual(["desktop", "laptop"]);
+    expect(machines.every((m) => m.id && m.last_seen_at && m.created_at)).toBe(true);
+  });
+
+  it("upserts a repeat device without creating a duplicate", async () => {
+    await postHeartbeat(user.apiKey, { entity: "/a.ts", type: "file", time: nowEpoch(), machine: "laptop" });
+    await postHeartbeat(user.apiKey, { entity: "/c.ts", type: "file", time: nowEpoch(), machine: "laptop" });
+
+    const machines = await listMachines(user.apiKey);
+    expect(machines).toHaveLength(1);
+    expect(machines[0].value).toBe("laptop");
+  });
+
+  it("honours the X-Machine-Name header when the body omits machine", async () => {
+    await postHeartbeat(user.apiKey, { entity: "/d.ts", type: "file", time: nowEpoch() }, { "X-Machine-Name": "ci-runner" });
+    const machines = await listMachines(user.apiKey);
+    expect(machines.map((m) => m.value)).toEqual(["ci-runner"]);
+  });
+
+  it("registers nothing when no machine value is present", async () => {
+    await postHeartbeat(user.apiKey, { entity: "/e.ts", type: "file", time: nowEpoch() });
+    expect(await listMachines(user.apiKey)).toEqual([]);
+  });
+
+  it("does not register a machine for a hidden heartbeat", async () => {
+    await call(RULES, {
+      method: "PUT",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([{ action: "hide", source: "project", operation: "equals", source_value: "secret" }]),
+    });
+    const res = await postHeartbeat(user.apiKey, {
+      entity: "/f.ts",
+      type: "file",
+      time: nowEpoch(),
+      project: "secret",
+      machine: "ghost",
+    });
+    expect(res.status).toBe(201); // success-shaped, but dropped
+    expect(await listMachines(user.apiKey)).toEqual([]);
+  });
+
+  it("bulk: upserts each distinct device once", async () => {
+    const res = await call(`${HEARTBEATS}.bulk`, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([
+        { entity: "/g.ts", type: "file", time: nowEpoch(), machine: "laptop" },
+        { entity: "/h.ts", type: "file", time: nowEpoch(), machine: "laptop" },
+        { entity: "/i.ts", type: "file", time: nowEpoch(), machine: "desktop" },
+      ]),
+    });
+    expect(res.status).toBe(202);
+    const machines = await listMachines(user.apiKey);
+    expect(machines.map((m) => m.value).sort()).toEqual(["desktop", "laptop"]);
+  });
+});
+
+describe("GET /machine_names", () => {
+  it("returns {data:[]} for a user with no machines", async () => {
+    const res = await call(MACHINES, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it("orders machines by last_seen_at descending", async () => {
+    // Seed two machines with explicit, distinct last_seen_at values.
+    await env.DB.prepare(
+      `INSERT INTO machine_names (id, user_id, value, last_seen_at, created_at)
+       VALUES (?, ?, 'old', '2026-05-01 10:00:00', '2026-05-01 10:00:00'),
+              (?, ?, 'new', '2026-05-10 10:00:00', '2026-05-10 10:00:00')`,
+    )
+      .bind(crypto.randomUUID(), user.userId, crypto.randomUUID(), user.userId)
+      .run();
+
+    const machines = await listMachines(user.apiKey);
+    expect(machines.map((m) => m.value)).toEqual(["new", "old"]);
+  });
+
+  it("isolates machines per user", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await postHeartbeat(bob.apiKey, { entity: "/x.ts", type: "file", time: nowEpoch(), machine: "bob-box" });
+
+    expect(await listMachines(user.apiKey)).toEqual([]);
+    const bobMachines = await listMachines(bob.apiKey);
+    expect(bobMachines.map((m) => m.value)).toEqual(["bob-box"]);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    expect((await call(MACHINES)).status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for **Machine Names** (issue #104), following the SpecKit 2-PR workflow. Populates the `machine_names` registry at heartbeat ingestion and exposes it read-only, per the spec in #120 (merged).

## Endpoint

| Method | Path | Result |
|---|---|---|
| `GET` | `/users/current/machine_names` | 200 `{data: Machine[]}` (last_seen_at DESC) |

## What's in this PR

- **`src/utils/machine.ts`** — `machineUpsertStmt` building `INSERT … ON CONFLICT (user_id, value) DO UPDATE` (updates `last_seen_at` + `ip`). Folded into the existing heartbeat `db.batch()`; no `RETURNING` since `machine` stays a raw string on `heartbeats` (not an FK).
- **`src/routes/heartbeats.ts`** — registers the device for **persisted** heartbeats on `POST /heartbeats` and `/heartbeats.bulk`, `ip` from `CF-Connecting-IP`. Hidden (custom-rule `hide`, #101) and invalid heartbeats register nothing. Bulk dedupes distinct machine values; the upserts are appended **after** the heartbeat inserts so the per-item batch-result mapping is unaffected.
- **`src/routes/machines.ts`** — `GET /machine_names` ordered by `last_seen_at` DESC, user-scoped, behind `authMiddleware`. Mirrors `user-agents.ts`. Mounted in `index.ts`.
- **Tests** — `tests/integration/machine-names.test.ts`: population (single + bulk dedupe), repeat-upsert no-duplicate, `X-Machine-Name` header fallback, no-machine-no-row, hidden-heartbeat-no-row, ordering, cross-user isolation, 401.

## Notes

- **`machine` is not foreign-keyed** onto `heartbeats` — the registry is an independent side table (deliberate divergence from `user_agents`, documented in `research.md`).
- **Registration follows persistence**: a heartbeat dropped by a `hide` rule leaves no machine trace, preserving the #101 non-disclosure guarantee (covered by a test).

## No schema / type change

OpenAPI + generated types landed in PR1 (#120). This PR is implementation + tests only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 209 passing (199 prior + 10 new)
- [ ] Manual `quickstart.md` A / B / E against a staging worker