### PR TITLE
feat: heartbeat retention policy + cron purge #108

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,19 +7,19 @@ Operator-facing runbook for running a CloudTime instance. See also
 ## Heartbeat retention (`HEARTBEAT_RETENTION_DAYS`)
 
 CloudTime stores every heartbeat as a raw row in the `heartbeats` table. The
-visible UI surfaces — `/summaries`, `/stats`, `/status_bar`, `/durations`,
-goals — read from the pre-aggregated `summaries` table, **not** from raw
+visible UI surfaces - `/summaries`, `/stats`, `/status_bar`, `/durations`,
+goals - read from the pre-aggregated `summaries` table, **not** from raw
 heartbeats. Raw heartbeats are only needed by:
 
-- `GET /heartbeats?date=…` (inspecting a specific day's raw events), and
-- the hourly cron aggregator's recent-window scan (last ~hour).
+- `GET /heartbeats?date=...` (inspecting a specific day's raw events), and
+- the hourly cron aggregator's catch-up cursor and recent-window scan.
 
 Because of this, raw heartbeats older than your inspection window can be
 discarded without affecting the aggregated rollup or any dashboard.
 
 ### Why set a retention window
 
-Daily ingest is typically thousands of heartbeats per active user — millions
+Daily ingest is typically thousands of heartbeats per active user - millions
 of rows per year. Cloudflare D1 has plan-level row/size caps, so a
 long-running instance will eventually need pruning.
 
@@ -37,31 +37,35 @@ HEARTBEAT_RETENTION_DAYS = "90"
 |---|---|
 | unset (default) | Retain raw heartbeats forever. No purge runs. |
 | positive number (e.g. `"90"`) | Purge raw heartbeats older than N days on each hourly cron. |
-| `"0"`, negative, or non-numeric | Treated as unset — retain forever. |
+| `"0"`, negative, or non-numeric | Treated as unset - retain forever. |
 
 Re-deploy (`wrangler deploy`) after changing the value.
 
 ### How it works
 
 - The purge runs inside the existing hourly cron (`crons = ["0 * * * *"]`),
-  alongside aggregation and session cleanup, and independently — a failure in
+  alongside aggregation and session cleanup, and independently - a failure in
   one does not block the others.
-- Each run deletes at most **1000** rows (`DELETE … WHERE id IN (SELECT id …
+- Each run deletes at most **1000** rows (`DELETE ... WHERE id IN (SELECT id ...
   WHERE time < cutoff LIMIT 1000)`), so a large backlog clears over several
   cron cycles rather than hammering D1 in a single run. At hourly cadence that
   is up to 24,000 rows/day of backlog clearance; once caught up, each run only
   removes the rows that aged past the window in the last hour.
-- The cutoff (`now − N days`) is always far older than the aggregator's
-  lookback window (minutes), so the purge never removes data the recent-window
-  aggregation still needs. Choose a retention window comfortably larger than a
-  day; values in the tens-to-hundreds of days are typical.
+- The purge is capped by the aggregation cursor (`last_aggregated_at`) minus the
+  aggregator's maximum lookback window, so it only deletes rows that are safely
+  behind completed cron aggregation. If aggregation has no cursor yet, or has
+  fallen behind, purge skips or waits for aggregation to catch up before
+  deleting that range.
+- Choose a retention window comfortably larger than a day; values in the
+  tens-to-hundreds of days are typical.
 
 ### Trade-offs
 
-- **Aggregated data is preserved.** `summaries` are computed before a heartbeat
-  could ever be purged, so historical `/summaries` and `/stats` are unaffected.
-- **Old raw days become unavailable.** `GET /heartbeats?date=…` for a day
-  beyond the retention window returns an empty list — the raw events are gone.
+- **Aggregated data is preserved.** The purge only removes rows safely behind
+  the aggregation cursor, so historical `/summaries` and `/stats` are
+  unaffected.
+- **Old raw days become unavailable.** `GET /heartbeats?date=...` for a day
+  beyond the retention window returns an empty list - the raw events are gone.
 - **`user_projects` first/last timestamps are unaffected.** They are maintained
   at insert time, not derived from a live heartbeat scan, so purging does not
   shift them.
@@ -70,8 +74,11 @@ Re-deploy (`wrangler deploy`) after changing the value.
 
 If you enable retention on an instance that has accumulated a large backlog,
 the first purges will each remove 1000 rows per hour until the backlog is
-cleared. This is intentional throttling. To clear faster, you can run a manual
-bounded delete via `wrangler d1 execute` during a maintenance window, e.g.:
+cleared. This is intentional throttling. If aggregation has fallen behind,
+purge will wait for the aggregation cursor to catch up before deleting that
+range. To clear faster, first confirm `last_aggregated_at` is newer than your
+retention cutoff, then run a manual bounded delete via `wrangler d1 execute`
+during a maintenance window, e.g.:
 
 ```bash
 wrangler d1 execute cloudtime-db --remote --command \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,82 @@
+# Operations Guide
+
+Operator-facing runbook for running a CloudTime instance. See also
+[deployment-guide.md](./deployment-guide.md) and
+[backup-restore.md](./backup-restore.md).
+
+## Heartbeat retention (`HEARTBEAT_RETENTION_DAYS`)
+
+CloudTime stores every heartbeat as a raw row in the `heartbeats` table. The
+visible UI surfaces — `/summaries`, `/stats`, `/status_bar`, `/durations`,
+goals — read from the pre-aggregated `summaries` table, **not** from raw
+heartbeats. Raw heartbeats are only needed by:
+
+- `GET /heartbeats?date=…` (inspecting a specific day's raw events), and
+- the hourly cron aggregator's recent-window scan (last ~hour).
+
+Because of this, raw heartbeats older than your inspection window can be
+discarded without affecting the aggregated rollup or any dashboard.
+
+### Why set a retention window
+
+Daily ingest is typically thousands of heartbeats per active user — millions
+of rows per year. Cloudflare D1 has plan-level row/size caps, so a
+long-running instance will eventually need pruning.
+
+### Configuration
+
+Set the `HEARTBEAT_RETENTION_DAYS` variable in `wrangler.toml` under `[vars]`
+(or via `wrangler secret put` if you prefer it not be committed):
+
+```toml
+[vars]
+HEARTBEAT_RETENTION_DAYS = "90"
+```
+
+| Value | Behaviour |
+|---|---|
+| unset (default) | Retain raw heartbeats forever. No purge runs. |
+| positive number (e.g. `"90"`) | Purge raw heartbeats older than N days on each hourly cron. |
+| `"0"`, negative, or non-numeric | Treated as unset — retain forever. |
+
+Re-deploy (`wrangler deploy`) after changing the value.
+
+### How it works
+
+- The purge runs inside the existing hourly cron (`crons = ["0 * * * *"]`),
+  alongside aggregation and session cleanup, and independently — a failure in
+  one does not block the others.
+- Each run deletes at most **1000** rows (`DELETE … WHERE id IN (SELECT id …
+  WHERE time < cutoff LIMIT 1000)`), so a large backlog clears over several
+  cron cycles rather than hammering D1 in a single run. At hourly cadence that
+  is up to 24,000 rows/day of backlog clearance; once caught up, each run only
+  removes the rows that aged past the window in the last hour.
+- The cutoff (`now − N days`) is always far older than the aggregator's
+  lookback window (minutes), so the purge never removes data the recent-window
+  aggregation still needs. Choose a retention window comfortably larger than a
+  day; values in the tens-to-hundreds of days are typical.
+
+### Trade-offs
+
+- **Aggregated data is preserved.** `summaries` are computed before a heartbeat
+  could ever be purged, so historical `/summaries` and `/stats` are unaffected.
+- **Old raw days become unavailable.** `GET /heartbeats?date=…` for a day
+  beyond the retention window returns an empty list — the raw events are gone.
+- **`user_projects` first/last timestamps are unaffected.** They are maintained
+  at insert time, not derived from a live heartbeat scan, so purging does not
+  shift them.
+
+### Backfill / catch-up
+
+If you enable retention on an instance that has accumulated a large backlog,
+the first purges will each remove 1000 rows per hour until the backlog is
+cleared. This is intentional throttling. To clear faster, you can run a manual
+bounded delete via `wrangler d1 execute` during a maintenance window, e.g.:
+
+```bash
+wrangler d1 execute cloudtime-db --remote --command \
+  "DELETE FROM heartbeats WHERE id IN (SELECT id FROM heartbeats WHERE time < unixepoch('now','-90 days') LIMIT 50000)"
+```
+
+Repeat until the row count stabilises. Always
+[back up](./backup-restore.md) before bulk deletes.

--- a/src/cron/aggregate.ts
+++ b/src/cron/aggregate.ts
@@ -26,7 +26,7 @@ type SummaryTuple = {
 };
 
 const DEFAULT_TIMEOUT = 15 * 60; // 15 minutes in seconds
-const MAX_USER_TIMEOUT = 60 * 60; // 60 minutes — max allowed by validation
+export const MAX_USER_TIMEOUT = 60 * 60; // 60 minutes - max allowed by validation
 const HEARTBEAT_LIMIT = 5000;
 
 async function getLastAggregatedAt(db: D1Database): Promise<number> {

--- a/src/cron/purge.ts
+++ b/src/cron/purge.ts
@@ -1,10 +1,12 @@
+import { MAX_USER_TIMEOUT } from "./aggregate";
+
 /**
  * Heartbeat retention purge (Issue #108).
  *
  * The UI surfaces (`/summaries`, `/stats`) read from the pre-aggregated
  * `summaries` table, not from raw heartbeats, so old raw heartbeats can be
  * discarded once the operator's retention window has passed without losing
- * the rollup. Only `GET /heartbeats?date=…` for old days is affected.
+ * the rollup. Only `GET /heartbeats?date=...` for old days is affected.
  *
  * Runs inside the hourly cron, throttled with a per-run row cap so a large
  * backlog clears over several cycles rather than hammering D1 in one shot.
@@ -16,7 +18,7 @@ const SECONDS_PER_DAY = 86400;
 /**
  * Parse the `HEARTBEAT_RETENTION_DAYS` env value. Returns the positive number
  * of days, or null when retention is disabled (unset / blank / non-positive /
- * non-numeric) — null means "retain forever".
+ * non-numeric) - null means "retain forever".
  */
 export function parseRetentionDays(raw: string | undefined): number | null {
   if (raw === undefined || raw.trim() === "") return null;
@@ -25,16 +27,24 @@ export function parseRetentionDays(raw: string | undefined): number | null {
   return n;
 }
 
+async function getLastAggregatedAt(db: D1Database): Promise<number | null> {
+  const row = await db
+    .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
+    .first<{ value: string }>();
+  const value = row ? Number(row.value) : null;
+  return value !== null && Number.isFinite(value) && value > 0 ? value : null;
+}
+
 /**
  * Delete up to `limit` heartbeats older than `retentionDays` days. Returns the
  * number of rows deleted so the caller can log progress / detect a backlog.
  *
- * `heartbeats.time` is epoch seconds. The cutoff (now − retentionDays days) is
- * always far older than the aggregator's lookback window (minutes), so this
- * never removes data the recent-window aggregation still needs.
+ * `heartbeats.time` is epoch seconds. The retention cutoff is additionally
+ * capped by the aggregation cursor minus the max lookback window so this never
+ * removes data that has not safely passed through cron aggregation.
  *
- * Uses a subquery-bounded DELETE (`id IN (SELECT … LIMIT ?)`) because SQLite /
- * D1 do not support `DELETE … LIMIT` directly. The `idx_heartbeats_time` index
+ * Uses a subquery-bounded DELETE (`id IN (SELECT ... LIMIT ?)`) because SQLite /
+ * D1 do not support `DELETE ... LIMIT` directly. The `idx_heartbeats_time` index
  * backs the time filter.
  */
 export async function purgeOldHeartbeats(
@@ -44,7 +54,14 @@ export async function purgeOldHeartbeats(
 ): Promise<number> {
   if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
 
-  const cutoff = Date.now() / 1000 - retentionDays * SECONDS_PER_DAY;
+  const lastAggregatedAt = await getLastAggregatedAt(db);
+  if (lastAggregatedAt === null) return 0;
+
+  const retentionCutoff = Date.now() / 1000 - retentionDays * SECONDS_PER_DAY;
+  const aggregationSafeCutoff = lastAggregatedAt - MAX_USER_TIMEOUT;
+  const cutoff = Math.min(retentionCutoff, aggregationSafeCutoff);
+  if (!Number.isFinite(cutoff) || cutoff <= 0) return 0;
+
   const res = await db
     .prepare(
       `DELETE FROM heartbeats

--- a/src/cron/purge.ts
+++ b/src/cron/purge.ts
@@ -1,0 +1,57 @@
+/**
+ * Heartbeat retention purge (Issue #108).
+ *
+ * The UI surfaces (`/summaries`, `/stats`) read from the pre-aggregated
+ * `summaries` table, not from raw heartbeats, so old raw heartbeats can be
+ * discarded once the operator's retention window has passed without losing
+ * the rollup. Only `GET /heartbeats?date=…` for old days is affected.
+ *
+ * Runs inside the hourly cron, throttled with a per-run row cap so a large
+ * backlog clears over several cycles rather than hammering D1 in one shot.
+ */
+
+export const DEFAULT_PURGE_LIMIT = 1000;
+const SECONDS_PER_DAY = 86400;
+
+/**
+ * Parse the `HEARTBEAT_RETENTION_DAYS` env value. Returns the positive number
+ * of days, or null when retention is disabled (unset / blank / non-positive /
+ * non-numeric) — null means "retain forever".
+ */
+export function parseRetentionDays(raw: string | undefined): number | null {
+  if (raw === undefined || raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * Delete up to `limit` heartbeats older than `retentionDays` days. Returns the
+ * number of rows deleted so the caller can log progress / detect a backlog.
+ *
+ * `heartbeats.time` is epoch seconds. The cutoff (now − retentionDays days) is
+ * always far older than the aggregator's lookback window (minutes), so this
+ * never removes data the recent-window aggregation still needs.
+ *
+ * Uses a subquery-bounded DELETE (`id IN (SELECT … LIMIT ?)`) because SQLite /
+ * D1 do not support `DELETE … LIMIT` directly. The `idx_heartbeats_time` index
+ * backs the time filter.
+ */
+export async function purgeOldHeartbeats(
+  db: D1Database,
+  retentionDays: number,
+  limit: number = DEFAULT_PURGE_LIMIT,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+
+  const cutoff = Date.now() / 1000 - retentionDays * SECONDS_PER_DAY;
+  const res = await db
+    .prepare(
+      `DELETE FROM heartbeats
+        WHERE id IN (SELECT id FROM heartbeats WHERE time < ? LIMIT ?)`,
+    )
+    .bind(cutoff, limit)
+    .run();
+
+  return res.meta.changes ?? 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import customRules from "./routes/custom-rules";
 import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
+import { parseRetentionDays, purgeOldHeartbeats } from "./cron/purge";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -141,9 +142,11 @@ export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(
       (async () => {
-        // Run aggregation and session cleanup independently so a failure
-        // in one does not prevent the other from completing.
-        const [, batchResults] = await Promise.allSettled([
+        // Run aggregation, session cleanup, and the optional heartbeat purge
+        // independently so a failure in one does not prevent the others from
+        // completing.
+        const retentionDays = parseRetentionDays(env.HEARTBEAT_RETENTION_DAYS);
+        const [, batchResults, purgeResult] = await Promise.allSettled([
           aggregateHeartbeats(env.DB),
           // Atomic DELETE + RETURNING avoids TOCTOU between SELECT and DELETE
           env.DB.batch([
@@ -152,6 +155,10 @@ export default {
             ),
             env.DB.prepare("DELETE FROM pending_links WHERE expires_at < datetime('now')"),
           ]),
+          // Purge raw heartbeats past the retention window (Issue #108).
+          // No-op when retention is unset; throttled per run so a backlog
+          // clears over several cron cycles.
+          retentionDays !== null ? purgeOldHeartbeats(env.DB, retentionDays) : Promise.resolve(0),
         ]);
 
         // Clean up KV cache for deleted sessions
@@ -160,6 +167,10 @@ export default {
           if (expired.length > 0) {
             await Promise.all(expired.map((r) => env.KV.delete(`session:${r.token_hash}`)));
           }
+        }
+
+        if (purgeResult?.status === "rejected") {
+          console.error("Heartbeat purge failed:", purgeResult.reason);
         }
       })(),
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,12 @@ export interface Env {
   // Instance mode: "single" (default) or "multi" (future)
   INSTANCE_MODE?: string;
 
+  // Optional raw-heartbeat retention window in days (Issue #108). Unset or
+  // non-positive = retain forever. When set, the hourly cron purges raw
+  // heartbeats older than this many days; pre-aggregated `summaries` are
+  // unaffected.
+  HEARTBEAT_RETENTION_DAYS?: string;
+
   // Runtime environment (set via wrangler.toml [vars] or secret)
   ENVIRONMENT?: string;
 

--- a/tests/integration/heartbeat-retention.test.ts
+++ b/tests/integration/heartbeat-retention.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the heartbeat retention purge (specs/.. Issue #108):
+ * parseRetentionDays (pure) + purgeOldHeartbeats against an in-memory D1.
+ */
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseRetentionDays, purgeOldHeartbeats, DEFAULT_PURGE_LIMIT } from "../../src/cron/purge";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice" });
+});
+
+afterEach(async () => {
+  await truncate("heartbeats", "summaries", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+const SECONDS_PER_DAY = 86400;
+const nowSec = () => Date.now() / 1000;
+
+async function seedHeartbeat(timeSec: number, suffix = ""): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO heartbeats (id, user_id, entity, type, time, is_write, created_at)
+     VALUES (?, ?, ?, 'file', ?, 0, datetime('now'))`,
+  )
+    .bind(crypto.randomUUID(), user.userId, `/e${suffix}.ts`, timeSec)
+    .run();
+}
+
+async function heartbeatCount(): Promise<number> {
+  const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM heartbeats").first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+describe("parseRetentionDays", () => {
+  it("returns null for unset / blank / non-positive / non-numeric values", () => {
+    expect(parseRetentionDays(undefined)).toBeNull();
+    expect(parseRetentionDays("")).toBeNull();
+    expect(parseRetentionDays("   ")).toBeNull();
+    expect(parseRetentionDays("0")).toBeNull();
+    expect(parseRetentionDays("-5")).toBeNull();
+    expect(parseRetentionDays("abc")).toBeNull();
+  });
+
+  it("returns the positive number of days", () => {
+    expect(parseRetentionDays("90")).toBe(90);
+    expect(parseRetentionDays("7")).toBe(7);
+    expect(parseRetentionDays("1.5")).toBe(1.5);
+  });
+});
+
+describe("purgeOldHeartbeats", () => {
+  it("deletes heartbeats older than the retention window and keeps recent ones", async () => {
+    await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old1"); // 100 days old
+    await seedHeartbeat(nowSec() - 91 * SECONDS_PER_DAY, "old2"); // 91 days old
+    await seedHeartbeat(nowSec() - 10 * SECONDS_PER_DAY, "recent1"); // 10 days old
+    await seedHeartbeat(nowSec(), "recent2"); // now
+
+    const deleted = await purgeOldHeartbeats(env.DB, 90);
+    expect(deleted).toBe(2);
+    expect(await heartbeatCount()).toBe(2); // the two recent ones remain
+  });
+
+  it("is a no-op when retentionDays is non-positive", async () => {
+    await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old");
+    expect(await purgeOldHeartbeats(env.DB, 0)).toBe(0);
+    expect(await purgeOldHeartbeats(env.DB, -1)).toBe(0);
+    expect(await heartbeatCount()).toBe(1);
+  });
+
+  it("throttles to the per-run limit, clearing a backlog over multiple runs", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, `b${i}`);
+    }
+    const first = await purgeOldHeartbeats(env.DB, 90, 2);
+    expect(first).toBe(2);
+    expect(await heartbeatCount()).toBe(3);
+
+    const second = await purgeOldHeartbeats(env.DB, 90, 2);
+    expect(second).toBe(2);
+    const third = await purgeOldHeartbeats(env.DB, 90, 2);
+    expect(third).toBe(1);
+    expect(await heartbeatCount()).toBe(0);
+  });
+
+  it("does not touch the summaries table", async () => {
+    await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old");
+    await env.DB.prepare(
+      `INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, '2026-01-01', 'p', 3600)`,
+    )
+      .bind(user.userId)
+      .run();
+
+    await purgeOldHeartbeats(env.DB, 90);
+
+    const summaries = await env.DB.prepare("SELECT COUNT(*) AS n FROM summaries").first<{ n: number }>();
+    expect(summaries?.n).toBe(1);
+  });
+
+  it("exposes a sane default per-run limit", () => {
+    expect(DEFAULT_PURGE_LIMIT).toBe(1000);
+  });
+});

--- a/tests/integration/heartbeat-retention.test.ts
+++ b/tests/integration/heartbeat-retention.test.ts
@@ -14,7 +14,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await truncate("heartbeats", "summaries", "users");
+  await truncate("heartbeats", "summaries", "meta", "users");
   await env.KV.delete(`apikey:${user.apiKeyHash}`);
 });
 
@@ -33,6 +33,14 @@ async function seedHeartbeat(timeSec: number, suffix = ""): Promise<void> {
 async function heartbeatCount(): Promise<number> {
   const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM heartbeats").first<{ n: number }>();
   return row?.n ?? 0;
+}
+
+async function setLastAggregatedAt(timeSec: number): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO meta (key, value) VALUES ('last_aggregated_at', ?) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+  )
+    .bind(String(timeSec))
+    .run();
 }
 
 describe("parseRetentionDays", () => {
@@ -54,6 +62,7 @@ describe("parseRetentionDays", () => {
 
 describe("purgeOldHeartbeats", () => {
   it("deletes heartbeats older than the retention window and keeps recent ones", async () => {
+    await setLastAggregatedAt(nowSec());
     await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old1"); // 100 days old
     await seedHeartbeat(nowSec() - 91 * SECONDS_PER_DAY, "old2"); // 91 days old
     await seedHeartbeat(nowSec() - 10 * SECONDS_PER_DAY, "recent1"); // 10 days old
@@ -65,6 +74,7 @@ describe("purgeOldHeartbeats", () => {
   });
 
   it("is a no-op when retentionDays is non-positive", async () => {
+    await setLastAggregatedAt(nowSec());
     await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old");
     expect(await purgeOldHeartbeats(env.DB, 0)).toBe(0);
     expect(await purgeOldHeartbeats(env.DB, -1)).toBe(0);
@@ -72,6 +82,7 @@ describe("purgeOldHeartbeats", () => {
   });
 
   it("throttles to the per-run limit, clearing a backlog over multiple runs", async () => {
+    await setLastAggregatedAt(nowSec());
     for (let i = 0; i < 5; i++) {
       await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, `b${i}`);
     }
@@ -87,6 +98,7 @@ describe("purgeOldHeartbeats", () => {
   });
 
   it("does not touch the summaries table", async () => {
+    await setLastAggregatedAt(nowSec());
     await seedHeartbeat(nowSec() - 100 * SECONDS_PER_DAY, "old");
     await env.DB.prepare(
       `INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, '2026-01-01', 'p', 3600)`,
@@ -98,6 +110,22 @@ describe("purgeOldHeartbeats", () => {
 
     const summaries = await env.DB.prepare("SELECT COUNT(*) AS n FROM summaries").first<{ n: number }>();
     expect(summaries?.n).toBe(1);
+  });
+
+  it("does not delete heartbeats that are not safely behind the aggregation cursor", async () => {
+    const old = nowSec() - 100 * SECONDS_PER_DAY;
+    await seedHeartbeat(old, "old");
+
+    expect(await purgeOldHeartbeats(env.DB, 90)).toBe(0);
+    expect(await heartbeatCount()).toBe(1);
+
+    await setLastAggregatedAt(old + 30 * 60);
+    expect(await purgeOldHeartbeats(env.DB, 90)).toBe(0);
+    expect(await heartbeatCount()).toBe(1);
+
+    await setLastAggregatedAt(nowSec());
+    expect(await purgeOldHeartbeats(env.DB, 90)).toBe(1);
+    expect(await heartbeatCount()).toBe(0);
   });
 
   it("exposes a sane default per-run limit", () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,6 +23,11 @@ __APP_VERSION__ = '"0.1.0"'
 
 [vars]
 INSTANCE_MODE = "single"
+# HEARTBEAT_RETENTION_DAYS - Optional. Number of days of raw heartbeats to keep.
+#                            Unset = retain forever. When set, the hourly cron
+#                            purges older raw heartbeats; aggregated `summaries`
+#                            are unaffected. See docs/operations.md.
+# HEARTBEAT_RETENTION_DAYS = "90"
 
 # OAuth & Session secrets (set via `wrangler secret put <NAME>`)
 # GITHUB_CLIENT_ID


### PR DESCRIPTION
## Summary

Adds an optional raw-heartbeat retention window (issue #108) so a long-running instance does not grow the `heartbeats` table unbounded against Cloudflare D1's plan caps. Single PR — cron + config only, **no OpenAPI/schema change**.

The UI surfaces (`/summaries`, `/stats`, goals, …) read from pre-aggregated `summaries`, so old raw heartbeats can be discarded without losing any rollup; only `GET /heartbeats?date=…` for old days is affected.

## What's in this PR

- **`src/cron/purge.ts`**
  - `parseRetentionDays(raw)` — unset / blank / `0` / negative / non-numeric → `null` (retain forever); positive → number of days.
  - `purgeOldHeartbeats(db, retentionDays, limit=1000)` — throttled `DELETE … WHERE id IN (SELECT id FROM heartbeats WHERE time < cutoff LIMIT 1000)` (SQLite/D1 lack `DELETE … LIMIT`). Backed by `idx_heartbeats_time`. Returns rows deleted.
- **`HEARTBEAT_RETENTION_DAYS`** env var added to `Env` and documented in `wrangler.toml [vars]`.
- **`src/index.ts`** — wired into the hourly cron alongside aggregation + session cleanup, run independently via `Promise.allSettled` (a purge failure is logged, doesn't block the rest).
- **`docs/operations.md`** — new operator runbook: choosing a window, how the throttle clears a backlog over cron cycles, trade-offs, and a manual catch-up snippet.
- **Tests** — `tests/integration/heartbeat-retention.test.ts`: `parseRetentionDays` units + purge integration (old deleted / recent kept, per-run limit clears a backlog over multiple runs, `summaries` untouched, no-op when disabled).

## Safety

- The cutoff (`now − N days`) is always far older than the aggregator's lookback window (minutes), so the recent-window aggregation is never starved. Retention is in days; the cron runs hourly.
- `user_projects.first/last_heartbeat_at` are maintained at insert time, not derived from a live scan, so purging does not shift them.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 216 passing (209 prior + 7 new)
- [ ] Set `HEARTBEAT_RETENTION_DAYS` on a staging instance and confirm old raw heartbeats are pruned over cron cycles while `/summaries` is unaffected