### PR TITLE
spec: Insights endpoint (PR1/2) #103

### DIFF
--- a/schemas/paths/insights/insights.yaml
+++ b/schemas/paths/insights/insights.yaml
@@ -3,6 +3,32 @@ get:
   tags:
     - insights
   summary: Coding activity insights
+  description: |
+    Derives an insight of the requested `insight_type` over `range` from the
+    pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
+    insight types ship in the first cut; an `hours`-of-day insight is
+    intentionally absent because `summaries` has day granularity only (it
+    would require an hourly aggregate — a future addition).
+
+    `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
+    `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
+    profile timezone (same vocabulary as `GET /stats/{range}`). An
+    unrecognised range returns 400.
+
+    Which `Insight` field is populated depends on `insight_type`:
+    - `days` → `days[]` (per-day totals across the range).
+    - `best_day` → `best_day` (the single highest-total day).
+    - `daily_average` → `daily_average` (mean seconds per active day).
+    - `weekday` → `items[]`, one per weekday (`name` = Monday…Sunday),
+      `total_seconds` = mean for that weekday, ordered most-active first.
+    - `projects` / `languages` / `editors` / `categories` / `machines` /
+      `operating_systems` → `items[]`, top values of that dimension by
+      `total_seconds` (with `percent` of the range total).
+
+    The `timeout` and `writes_only` query parameters are accepted for
+    forward-compatibility but are not applied in the first cut: insights read
+    from `summaries`, which already bake in each user's session timeout and do
+    not retain per-heartbeat write flags.
   parameters:
     - name: insight_type
       in: path

--- a/schemas/paths/insights/insights.yaml
+++ b/schemas/paths/insights/insights.yaml
@@ -8,27 +8,27 @@ get:
     pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
     insight types ship in the first cut; an `hours`-of-day insight is
     intentionally absent because `summaries` has day granularity only (it
-    would require an hourly aggregate — a future addition).
+    would require an hourly aggregate - a future addition).
 
     `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
     `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
     profile timezone (same vocabulary as `GET /stats/{range}`). An
-    unrecognised range returns 400.
+    invalid `insight_type` or unrecognised range returns 400.
 
     Which `Insight` field is populated depends on `insight_type`:
-    - `days` → `days[]` (per-day totals across the range).
-    - `best_day` → `best_day` (the single highest-total day).
-    - `daily_average` → `daily_average` (mean seconds per active day).
-    - `weekday` → `items[]`, one per weekday (`name` = Monday…Sunday),
+    - `days` -> `days[]` (per-day totals across the range).
+    - `best_day` -> `best_day` (the single highest-total day).
+    - `daily_average` -> `daily_average` (mean seconds per active day).
+    - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
       `total_seconds` = mean for that weekday, ordered most-active first.
     - `projects` / `languages` / `editors` / `categories` / `machines` /
-      `operating_systems` → `items[]`, top values of that dimension by
+      `operating_systems` -> `items[]`, top values of that dimension by
       `total_seconds` (with `percent` of the range total).
 
-    The `timeout` and `writes_only` query parameters are accepted for
-    forward-compatibility but are not applied in the first cut: insights read
-    from `summaries`, which already bake in each user's session timeout and do
-    not retain per-heartbeat write flags.
+    The `timeout`, `writes_only`, and `weekday` query parameters are accepted
+    for forward-compatibility but are not applied in the first cut: insights
+    read from `summaries`, which already bake in each user's session timeout
+    and do not retain per-heartbeat write flags or weekday filters.
   parameters:
     - name: insight_type
       in: path
@@ -64,7 +64,9 @@ get:
         type: boolean
     - name: weekday
       in: query
-      description: Filter for 'days' insight type (0-6 or monday-sunday)
+      description: >-
+        Reserved for future filtering of the days insight type (0-6 or
+        monday-sunday). Accepted but not applied in the first cut.
       schema:
         type: string
   responses:
@@ -79,5 +81,7 @@ get:
             properties:
               data:
                 $ref: ../../components/schemas/Insight.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/specs/103-insights/checklists/requirements.md
+++ b/specs/103-insights/checklists/requirements.md
@@ -5,13 +5,13 @@
 - [x] `spec.md` covers FR-001..FR-010 (dimension + temporal insights) with no `[NEEDS CLARIFICATION]` markers.
 - [x] `spec.md` explicitly lists the first-cut insight types and defers `hours`.
 - [x] `plan.md` Constitution Check has all five principles marked PASS.
-- [x] `research.md` documents the 7 design decisions (summaries-only, hours deferral, range reuse, active-day average, weekday-as-items, Unknown bucket, reserved params).
+- [x] `research.md` documents the 7 design decisions (summaries-only, hours deferral, range reuse, active-day average, weekday-as-items, Unknown bucket, reserved params including `weekday`).
 - [x] `data-model.md` confirms no schema change and documents the single grouped read + per-type shaping.
 - [x] `quickstart.md` enumerates scenarios A–I.
 - [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
-- [x] `contracts/openapi-diff.md` documents the description-only clarification + per-type field mapping.
-- [x] `insights.yaml` carries the per-type / range / reserved-param description.
-- [x] `npm run generate` produces only JSDoc changes (no type-shape change); `npm run typecheck` passes.
+- [x] `contracts/openapi-diff.md` documents the contract clarification, explicit 400 response, and per-type field mapping.
+- [x] `insights.yaml` carries the per-type / range / reserved-param description and explicit 400 response.
+- [x] `npm run generate` produces the documented JSDoc plus 400 response type; `npm run typecheck` passes.
 - [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
 - [x] PR1 references issue #103.
 

--- a/specs/103-insights/checklists/requirements.md
+++ b/specs/103-insights/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Acceptance Checklist: Insights Endpoint
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-010 (dimension + temporal insights) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` explicitly lists the first-cut insight types and defers `hours`.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 7 design decisions (summaries-only, hours deferral, range reuse, active-day average, weekday-as-items, Unknown bucket, reserved params).
+- [x] `data-model.md` confirms no schema change and documents the single grouped read + per-type shaping.
+- [x] `quickstart.md` enumerates scenarios A–I.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the description-only clarification + per-type field mapping.
+- [x] `insights.yaml` carries the per-type / range / reserved-param description.
+- [x] `npm run generate` produces only JSDoc changes (no type-shape change); `npm run typecheck` passes.
+- [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
+- [x] PR1 references issue #103.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/insights.ts` exports a pure `buildInsight(type, rows, range, tz)` plus helpers for dimension items, days/best_day/daily_average, and weekday; reuses the shared duration formatter for `digital`/`text`.
+- [ ] `src/routes/insights.ts` validates `insight_type` (enum) and resolves `range` via `resolveStatsRange` (400 on either invalid), issues one grouped `summaries` SELECT scoped by `user_id`, behind `authMiddleware`.
+- [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A/B: dimension insights group, order desc, percent of total, Unknown bucket for NULLs.
+- [ ] C: `days` active dates ascending.
+- [ ] D: `best_day` = max-total date (earliest on tie).
+- [ ] E: `daily_average` divides by active days.
+- [ ] F: `weekday` items per weekday, mean per active occurrence, ordered desc.
+- [ ] G: `all_time` / `YYYY` / `YYYY-MM` ranges scope correctly; all_time daily_average not diluted.
+- [ ] H: invalid `insight_type` and `range` → 400.
+- [ ] I: empty range → 200 empty/zeroed; unauthenticated → 401.
+
+### Tests
+
+- [ ] `tests/aggregation/insights.test.ts` — pure builder over a fixed fixture for every type (incl. tie-break, Unknown bucket, active-day average, weekday mean, zero-total percent).
+- [ ] `tests/integration/insights.test.ts` — endpoint per type against seeded `summaries`, validation 400s, cross-user isolation, 401.
+- [ ] `npm test` stays green with the new coverage.
+
+## Post-deployment gate
+
+- [ ] Spot-check `languages` / `best_day` / `daily_average` against a direct `summaries` query for a real user.
+- [ ] No 500s on the endpoint in the first 7 days.

--- a/specs/103-insights/contracts/openapi-diff.md
+++ b/specs/103-insights/contracts/openapi-diff.md
@@ -1,0 +1,52 @@
+# OpenAPI Diff
+
+The `getInsight` operation and the `Insight` / `SummaryItem` / `TimeRange`
+schemas already existed in `schemas/openapi.yaml`. This PR adds a clarifying
+operation description only — no type-shape change.
+
+## Files touched
+
+1. `schemas/paths/insights/insights.yaml` — add a `description` to
+   `getInsight` documenting the per-type response-field mapping, the `range`
+   vocabulary, the absence of an `hours` type, and the reserved
+   `timeout`/`writes_only` query params.
+
+No schema field changes, no new operation, no enum change.
+
+## Contract (unchanged shape)
+
+### `GET /users/current/insights/{insight_type}/{range}` → `getInsight`
+
+- `insight_type` (path) ∈ `weekday | days | best_day | daily_average |
+  projects | languages | editors | categories | machines |
+  operating_systems`. (No `hours` — day-granularity source.)
+- `range` (path): `last_7_days | last_30_days | last_6_months | last_year |
+  all_time | YYYY | YYYY-MM`.
+- `timeout`, `writes_only` (query): accepted, **reserved** (not applied in the
+  first cut).
+- `200` → `{ data: Insight }`; `401` unauthenticated. (Invalid `insight_type`
+  / `range` → `400` at the handler; the operation documents this.)
+
+### Which `Insight` field each type populates
+
+| `insight_type` | Field |
+|---|---|
+| `days` | `days[]` |
+| `best_day` | `best_day` |
+| `daily_average` | `daily_average` |
+| `weekday` | `items[]` (one per weekday) |
+| `projects` / `languages` / `editors` / `categories` / `machines` / `operating_systems` | `items[]` |
+
+`data.type` echoes the requested type; `data.range` is the resolved
+`TimeRange`.
+
+## Generated-types impact
+
+`npm run generate` adds only JSDoc to `operations["getInsight"]`. The
+TypeScript types for `Insight`, `SummaryItem`, `TimeRange`, and the operation
+parameters are unchanged.
+
+## SDD compliance note
+
+PR1 lands SpecKit + the description + regenerated types (JSDoc only). PR2 lands
+the route handler, the pure insight builder, and tests. No runtime code in PR1.

--- a/specs/103-insights/contracts/openapi-diff.md
+++ b/specs/103-insights/contracts/openapi-diff.md
@@ -1,31 +1,35 @@
 # OpenAPI Diff
 
 The `getInsight` operation and the `Insight` / `SummaryItem` / `TimeRange`
-schemas already existed in `schemas/openapi.yaml`. This PR adds a clarifying
-operation description only — no type-shape change.
+schemas already existed in `schemas/openapi.yaml`. This PR clarifies the
+operation contract without changing request parameters or the 200 response
+schema.
 
 ## Files touched
 
 1. `schemas/paths/insights/insights.yaml` — add a `description` to
    `getInsight` documenting the per-type response-field mapping, the `range`
    vocabulary, the absence of an `hours` type, and the reserved
-   `timeout`/`writes_only` query params.
+   `timeout`/`writes_only`/`weekday` query params.
+2. Add an explicit `400` response for invalid `insight_type` or `range`, using
+   the shared `BadRequest` response component.
 
-No schema field changes, no new operation, no enum change.
+No schema field changes, no new operation, no enum change, no 200 response
+shape change.
 
-## Contract (unchanged shape)
+## Contract
 
 ### `GET /users/current/insights/{insight_type}/{range}` → `getInsight`
 
-- `insight_type` (path) ∈ `weekday | days | best_day | daily_average |
+- `insight_type` (path) in `weekday | days | best_day | daily_average |
   projects | languages | editors | categories | machines |
-  operating_systems`. (No `hours` — day-granularity source.)
+  operating_systems`. (No `hours` - day-granularity source.)
 - `range` (path): `last_7_days | last_30_days | last_6_months | last_year |
   all_time | YYYY | YYYY-MM`.
-- `timeout`, `writes_only` (query): accepted, **reserved** (not applied in the
-  first cut).
-- `200` → `{ data: Insight }`; `401` unauthenticated. (Invalid `insight_type`
-  / `range` → `400` at the handler; the operation documents this.)
+- `timeout`, `writes_only`, `weekday` (query): accepted, **reserved** (not
+  applied in the first cut).
+- `200` -> `{ data: Insight }`; invalid `insight_type` / `range` -> `400`;
+  `401` unauthenticated.
 
 ### Which `Insight` field each type populates
 
@@ -42,9 +46,9 @@ No schema field changes, no new operation, no enum change.
 
 ## Generated-types impact
 
-`npm run generate` adds only JSDoc to `operations["getInsight"]`. The
-TypeScript types for `Insight`, `SummaryItem`, `TimeRange`, and the operation
-parameters are unchanged.
+`npm run generate` adds JSDoc to `operations["getInsight"]` and exposes the
+documented 400 response. The TypeScript types for `Insight`, `SummaryItem`,
+`TimeRange`, operation parameters, and the 200 response are unchanged.
 
 ## SDD compliance note
 

--- a/specs/103-insights/data-model.md
+++ b/specs/103-insights/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: Insights Endpoint
+
+No schema changes. `summaries` is the only data source.
+
+## `summaries` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,                 -- YYYY-MM-DD in the user's profile timezone
+  project TEXT,
+  language TEXT,
+  editor TEXT,
+  operating_system TEXT,
+  category TEXT,
+  branch TEXT,
+  machine TEXT,
+  entity TEXT,
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_summaries_unique
+  ON summaries(user_id, date, project, language, editor, operating_system, category, branch, machine);
+```
+
+`date` is already timezone-bucketed by the cron aggregator, so insights group on `date` directly and derive weekday from the local date — no TZ math at query time.
+
+## Range resolution
+
+`resolveStatsRange(range, tz)` → `{ start, end, text }` (inclusive `YYYY-MM-DD` bounds). Reused verbatim from `/stats`. Invalid range → handler returns 400.
+
+## Read query (one grouped SELECT per request)
+
+```sql
+SELECT date, project, language, editor, operating_system, category, machine,
+       SUM(total_seconds) AS total_seconds
+  FROM summaries
+ WHERE user_id = ? AND date BETWEEN ? AND ?
+ GROUP BY date, project, language, editor, operating_system, category, machine;
+```
+
+The handler shapes these rows in memory per `insight_type`. (A dimension insight could alternatively issue a narrower `GROUP BY <column>`; either way it is a single query.)
+
+## Per-type shaping
+
+| `insight_type` | Output field | Computation |
+|---|---|---|
+| `projects` / `languages` / `editors` / `categories` / `machines` / `operating_systems` | `items[]` | Sum `total_seconds` grouped by the column; NULL → `"Unknown"`; order desc; `percent` = share of range total; `digital`/`text`/`hours`/`minutes`/`seconds` via the shared formatter. |
+| `days` | `days[]` | Sum per `date`; active dates ascending; `{date, total_seconds, text}`. |
+| `best_day` | `best_day` | The date with max summed `total_seconds` (ties → earliest); zeroed if none. |
+| `daily_average` | `daily_average` | `{seconds = total ÷ active-day count, text}`; 0 when no active days. |
+| `weekday` | `items[]` | Group active days by weekday; `total_seconds` = mean of that weekday's active-day totals; `name` = English weekday; order desc. |
+
+`data.type` = requested `insight_type`; `data.range` = resolved `TimeRange` (`start`, `end`, `text`, `timezone = tz`).
+
+## Formatting reuse
+
+`digital` (H:MM), `text` (e.g. "2 hrs 30 mins"), and `hours`/`minutes`/`seconds` are produced by the same duration-formatting helper `/stats` uses to build `SummaryItem`s — not reimplemented.
+
+## No writes / cascade
+
+Read-only. No inserts, no schema change, no cleanup. `summaries` already cascades on user delete.

--- a/specs/103-insights/plan.md
+++ b/specs/103-insights/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Insights Endpoint
+
+**Branch**: `103-insights` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/103-insights/spec.md`
+
+## Summary
+
+Wire the declared `getInsight` operation to a read handler that derives each insight type from the `summaries` table over a resolved range. Reuse `resolveStatsRange` for the range vocabulary and the existing duration-formatting helpers for `digital`/`text`. No new table, no raw-heartbeat scan.
+
+PR1 (this PR): SpecKit artifacts + OpenAPI description (per-type field mapping, range vocab, reserved query params). The operation, `Insight`, `SummaryItem`, and `TimeRange` schemas already exist, so the OpenAPI change is description-only (JSDoc-only generated diff). PR2: the route + a small insight-builder helper + tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`summaries`, existing)
+**Testing**: Vitest + workers pool — unit tests for the pure shaping helpers, integration tests per insight type against a seeded `summaries` fixture
+**Performance Goals**: <10ms CPU — one indexed `GROUP BY` over the date window + in-memory shaping
+**Constraints**: summaries day-granularity only (no `hours`); Workers CPU budget
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Operation already declared; PR1 clarifies descriptions, PR2 implements. `npm run generate` is JSDoc-only. |
+| II. Cloudflare-Native | PASS | Pure D1 reads over `summaries`; reuses `resolveStatsRange`. No new bindings/tables. |
+| III. Type Safety | PASS | Handler uses `components["schemas"]["Insight"]` / `["SummaryItem"]` / `["TimeRange"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Derived from our own schema + aggregated data; no upstream source/assets. |
+| V. Simplicity First | PASS | One route + one pure builder reusing existing range + formatting helpers. `hours` deferred to avoid an hourly-aggregate detour. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/103-insights/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── insights.ts          # NEW: getInsight handler (validate type+range, dispatch)
+├── utils/
+│   └── insights.ts          # NEW: pure builders (dimension items, days, best_day, daily_average, weekday)
+└── index.ts                 # NEW route mount
+```
+
+**Structure Decision**: A thin route that validates `insight_type` + resolves `range`, then dispatches to a pure builder in `utils/insights.ts` that takes rows + range and returns the `Insight` shape. The builder is unit-testable without D1; the route owns the single SELECT.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Summaries-only**, no raw scan; **`hours` deferred** (needs hourly aggregate).
+2. **Range reuse** via `resolveStatsRange` (same vocabulary as `/stats`).
+3. **`daily_average` divides by active days**, not calendar days (avoids `all_time` dilution).
+4. **`weekday` returned as `items[]`** (no weekday-specific schema field), mean per active weekday occurrence.
+5. **NULL dimension → `"Unknown"`** bucket.
+6. **`timeout`/`writes_only` reserved** (summaries can't honour them).
+
+## Phase 1 — Design Outputs
+
+### Route sketch
+
+```ts
+const INSIGHT_TYPES = new Set(["weekday","days","best_day","daily_average",
+  "projects","languages","editors","categories","machines","operating_systems"]);
+const DIMENSION_COLUMN: Record<string,string> = {
+  projects:"project", languages:"language", editors:"editor",
+  categories:"category", machines:"machine", operating_systems:"operating_system" };
+
+insights.get("/insights/:insight_type/:range", async (c) => {
+  const type = c.req.param("insight_type");
+  if (!INSIGHT_TYPES.has(type)) return c.json({ error: "Invalid insight_type" }, 400);
+  const tz = await getUserTimezone(c);
+  const resolved = resolveStatsRange(c.req.param("range"), tz);
+  if (!resolved) return c.json({ error: "Invalid range" }, 400);
+  const rows = await c.env.DB.prepare(
+    `SELECT date, project, language, editor, operating_system, category, machine,
+            SUM(total_seconds) AS total_seconds
+       FROM summaries WHERE user_id = ? AND date BETWEEN ? AND ?
+      GROUP BY date, project, language, editor, operating_system, category, machine`,
+  ).bind(userId, resolved.start, resolved.end).all<SummaryRow>();
+  return c.json({ data: buildInsight(type, rows.results, resolved, tz) });
+});
+```
+
+(For dimension insights the builder can also be driven by a tighter per-column `GROUP BY`; the single grouped read above is enough for all types and stays one query.)
+
+### Builder sketch (pure, unit-testable)
+
+```ts
+// src/utils/insights.ts
+export function buildInsight(type, rows, range, tz): Insight { … }
+// helpers: groupByColumn → SummaryItem[] (percent + formatting via formatDuration),
+//          byDate → days[] / best_day / daily_average,
+//          byWeekday → items[] (English weekday names, mean per active occurrence)
+```
+
+Formatting (`digital`, `text`, `hours/minutes/seconds`) reuses the same helper `/stats` uses for `SummaryItem`.
+
+### OpenAPI surface
+
+Already declared. PR1 adds the per-type field-mapping description — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No type-shape change.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+Bounded: one grouped SELECT + pure in-memory shaping. The only subtle parts (active-day averaging, weekday derivation) live in the pure builder with direct unit tests.

--- a/specs/103-insights/plan.md
+++ b/specs/103-insights/plan.md
@@ -7,7 +7,7 @@
 
 Wire the declared `getInsight` operation to a read handler that derives each insight type from the `summaries` table over a resolved range. Reuse `resolveStatsRange` for the range vocabulary and the existing duration-formatting helpers for `digital`/`text`. No new table, no raw-heartbeat scan.
 
-PR1 (this PR): SpecKit artifacts + OpenAPI description (per-type field mapping, range vocab, reserved query params). The operation, `Insight`, `SummaryItem`, and `TimeRange` schemas already exist, so the OpenAPI change is description-only (JSDoc-only generated diff). PR2: the route + a small insight-builder helper + tests.
+PR1 (this PR): SpecKit artifacts + OpenAPI description (per-type field mapping, range vocab, reserved query params) plus the explicit 400 response for invalid inputs. The operation, `Insight`, `SummaryItem`, and `TimeRange` schemas already exist, so the 200 response shape is unchanged. PR2: the route + a small insight-builder helper + tests.
 
 ## Technical Context
 
@@ -67,7 +67,7 @@ See [research.md](./research.md). Key decisions:
 3. **`daily_average` divides by active days**, not calendar days (avoids `all_time` dilution).
 4. **`weekday` returned as `items[]`** (no weekday-specific schema field), mean per active weekday occurrence.
 5. **NULL dimension → `"Unknown"`** bucket.
-6. **`timeout`/`writes_only` reserved** (summaries can't honour them).
+6. **`timeout`/`writes_only`/`weekday` reserved** (summaries can't honour them).
 
 ## Phase 1 — Design Outputs
 
@@ -112,7 +112,7 @@ Formatting (`digital`, `text`, `hours/minutes/seconds`) reuses the same helper `
 
 ### OpenAPI surface
 
-Already declared. PR1 adds the per-type field-mapping description — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No type-shape change.
+Already declared. PR1 adds the per-type field-mapping description and explicit 400 response - see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No request parameter or 200 response shape change.
 
 ## Phase 2 — Implementation Tasks
 

--- a/specs/103-insights/quickstart.md
+++ b/specs/103-insights/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Insights Endpoint
+
+Manual verification once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+```
+
+Seed some `summaries` (until heartbeats accumulate naturally):
+
+```bash
+wrangler d1 execute cloudtime-db --remote --command "
+  INSERT INTO summaries (user_id, date, project, language, editor, total_seconds) VALUES
+   ('<uid>','2026-05-26','api','TypeScript','vscode',7200),
+   ('<uid>','2026-05-27','api','Go','vscode',3600),
+   ('<uid>','2026-05-28','web','TypeScript','vscode',1800);
+"
+```
+
+## Scenario A — Languages (dimension insight)
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/languages/last_7_days"
+```
+
+**Expected**: `data.type="languages"`, `data.range` set, `data.items` ordered by `total_seconds` desc (`TypeScript` then `Go`), each with `percent` of the range total and `text`/`digital`.
+
+## Scenario B — Editors / projects / categories / machines / operating_systems
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/projects/last_30_days"
+```
+
+**Expected**: same shape, grouped by the chosen dimension. Rows with a NULL dimension appear as an `"Unknown"` item.
+
+## Scenario C — Days
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/days/last_7_days"
+```
+
+**Expected**: `data.days` lists active dates ascending, each `{date, total_seconds, text}`.
+
+## Scenario D — Best day
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/best_day/last_30_days"
+```
+
+**Expected**: `data.best_day` is the highest-total date (`2026-05-26` for the seed above).
+
+## Scenario E — Daily average
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/daily_average/last_30_days"
+```
+
+**Expected**: `data.daily_average.seconds` = total ÷ number of **active** days (here `(7200+3600+1800)/3 = 4200`), with a human `text`.
+
+## Scenario F — Weekday
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/weekday/last_year"
+```
+
+**Expected**: `data.items` has one entry per occurring weekday (`name` = Monday…Sunday), `total_seconds` = mean for that weekday, ordered most-active-first.
+
+## Scenario G — all_time / YYYY / YYYY-MM ranges
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/languages/all_time"
+curl -sH "$H" "$BASE/users/current/insights/languages/2026"
+curl -sH "$H" "$BASE/users/current/insights/languages/2026-05"
+```
+
+**Expected**: 200 with the range scoped accordingly; `daily_average` over `all_time` divides by active days (not diluted to ~0).
+
+## Scenario H — Validation
+
+```bash
+curl -si "$H" "$BASE/users/current/insights/bogus/last_7_days"     # bad type
+curl -si "$H" "$BASE/users/current/insights/languages/since_forever" # bad range
+```
+
+**Expected**: 400 for both.
+
+## Scenario I — Empty range / auth
+
+```bash
+curl -sH "$H" "$BASE/users/current/insights/languages/2099"   # no data
+curl -si "$BASE/users/current/insights/languages/last_7_days" # no auth
+```
+
+**Expected**: empty range → 200 with `items: []` (or zeroed `best_day`/`daily_average`); no auth → 401.
+
+## Reverting / cleanup
+
+Read-only. Removing the route + helper disables the feature with no data impact.

--- a/specs/103-insights/research.md
+++ b/specs/103-insights/research.md
@@ -1,0 +1,81 @@
+# Research: Insights Endpoint
+
+## Decision 1: Derive from `summaries`, never raw heartbeats
+
+**Decision**: All first-cut insights are computed from the pre-aggregated `summaries` table via a single grouped `SELECT` over the range's date window.
+
+**Rationale**:
+- `summaries` is already bucketed per user / date / dimension by the cron aggregator; reading it is O(matches), heartbeats would be O(raw events) and blow the 10ms CPU budget.
+- Mirrors `/summaries`, `/stats`, and goals chart computation — consistent behaviour and one source of truth.
+
+**Alternative considered**: live heartbeat scan for accuracy. Rejected — cost, and the cron lag (≤1h) is irrelevant at day/range granularity.
+
+---
+
+## Decision 2: `hours` insight deferred
+
+**Decision**: No `hours`-of-day insight in the first cut. It is not in the declared `insight_type` enum and is out of scope.
+
+**Rationale**:
+- `summaries` has **day** granularity (`date`), not hour. An hours insight needs either an hourly aggregate (extend the cron to write per-hour rows) or a raw-heartbeat scan — both larger than this feature.
+- Adding it later is additive (new enum value + new aggregate), no break to the shipped types.
+
+**Alternative considered**: scan heartbeats at query time for the hours view only. Rejected for the first cut — inconsistent cost profile vs the other types; revisit with a dedicated hourly aggregate.
+
+---
+
+## Decision 3: Reuse the `/stats` range vocabulary
+
+**Decision**: `range` is resolved with the existing `resolveStatsRange(range, tz)` helper — `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `all_time`, `YYYY`, `YYYY-MM`. Invalid → 400.
+
+**Rationale**:
+- One range vocabulary across `/stats` and `/insights` means one mental model and one tested implementation. No reason to invent a parallel parser.
+
+**Alternative considered**: a bespoke insights range set. Rejected — needless divergence.
+
+---
+
+## Decision 4: `daily_average` divides by **active** days
+
+**Decision**: `daily_average.seconds = range_total ÷ (count of distinct dates with any summary row in range)`. Zero when there are no active days.
+
+**Rationale**:
+- Dividing by calendar days breaks `all_time` (start = 1970) — the average would round to ~0. Active-day averaging gives a meaningful "on days you coded, you averaged X".
+- Matches the intuitive "daily coding average" most tools show.
+
+**Alternative considered**: divide by calendar days in range. Rejected — meaningless for long/open ranges.
+
+---
+
+## Decision 5: `weekday` represented as `items[]`
+
+**Decision**: The `weekday` insight populates `items[]` with one `SummaryItem` per occurring weekday: `name` = English weekday (`Monday`…`Sunday`), `total_seconds` = mean of that weekday's active-day totals, ordered most-active-first.
+
+**Rationale**:
+- The `Insight` schema has no weekday-specific field; `items[]` is the existing generic list shape and fits ("which weekday do I code most").
+- Mean per **active** occurrence (consistent with Decision 4) avoids diluting by weekday occurrences that had no activity.
+
+**Alternative considered**: add a dedicated `weekdays` field to `Insight`. Rejected — avoids a schema change; `items[]` is sufficient and already typed.
+
+---
+
+## Decision 6: NULL dimension values bucket under `"Unknown"`
+
+**Decision**: When grouping a dimension (e.g. `language`) and the column is NULL, those rows are summed under a stable `"Unknown"` item rather than dropped.
+
+**Rationale**:
+- Dropping NULLs would make `percent` not sum to 100% and hide real time. A visible `"Unknown"` bucket is honest and matches how dashboards present unattributed time.
+
+**Alternative considered**: drop NULLs. Rejected — distorts totals/percentages.
+
+---
+
+## Decision 7: `timeout` / `writes_only` reserved, not applied
+
+**Decision**: The declared `timeout` and `writes_only` query params are accepted (no 400) but not applied in the first cut.
+
+**Rationale**:
+- `summaries` already bake in each user's session timeout during aggregation and do not retain per-heartbeat write flags, so these cannot be honoured without a raw-heartbeat scan (which Decision 1 rules out).
+- Keeping the params accepted avoids breaking the declared contract and leaves room to honour them if insights ever move to a raw-scan path.
+
+**Alternative considered**: remove the params, or 400 when supplied. Rejected — unnecessary contract churn; silently-accepted-but-documented is least disruptive.

--- a/specs/103-insights/research.md
+++ b/specs/103-insights/research.md
@@ -70,12 +70,13 @@
 
 ---
 
-## Decision 7: `timeout` / `writes_only` reserved, not applied
+## Decision 7: `timeout` / `writes_only` / `weekday` reserved, not applied
 
-**Decision**: The declared `timeout` and `writes_only` query params are accepted (no 400) but not applied in the first cut.
+**Decision**: The declared `timeout`, `writes_only`, and `weekday` query params are accepted (no 400) but not applied in the first cut.
 
 **Rationale**:
-- `summaries` already bake in each user's session timeout during aggregation and do not retain per-heartbeat write flags, so these cannot be honoured without a raw-heartbeat scan (which Decision 1 rules out).
+- `summaries` already bake in each user's session timeout during aggregation and do not retain per-heartbeat write flags, so those cannot be honoured without a raw-heartbeat scan (which Decision 1 rules out).
+- `weekday` is an existing query parameter on the declared operation, but the first cut defines `weekday` as an insight type, not as a filter on `days`; applying both meanings in PR2 would be ambiguous.
 - Keeping the params accepted avoids breaking the declared contract and leaves room to honour them if insights ever move to a raw-scan path.
 
 **Alternative considered**: remove the params, or 400 when supplied. Rejected — unnecessary contract churn; silently-accepted-but-documented is least disruptive.

--- a/specs/103-insights/spec.md
+++ b/specs/103-insights/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Insights Endpoint
+
+**Feature Branch**: `103-insights`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: The `getInsight` OpenAPI operation is declared (`/users/current/insights/{insight_type}/{range}`) but has no route or computation. Insights (best day, productive weekday, language trends) are a highly visible end-user feature and are currently absent.
+
+## Background
+
+Insights summarise a user's coding activity along a chosen dimension over a chosen time range. Everything in the first cut is derivable from the pre-aggregated `summaries` table (per user / date / project / language / editor / operating_system / category / machine), so no new table or raw-heartbeat scan is needed.
+
+The declared `insight_type` enum is: `weekday`, `days`, `best_day`, `daily_average`, `projects`, `languages`, `editors`, `categories`, `machines`, `operating_systems`. An `hours`-of-day insight is **not** declared and is out of scope (it needs hour granularity that `summaries` does not carry).
+
+`range` reuses the `GET /stats/{range}` vocabulary via the existing `resolveStatsRange` helper: `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `all_time`, `YYYY`, `YYYY-MM`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Dimension insights (Priority: P1)
+
+As an authenticated user, I want to see my top languages / editors / projects / categories / machines / operating systems over a range so I understand where my time goes.
+
+**Independent Test**: Seed `summaries` across a few dates with two languages. `GET /insights/languages/last_7_days` returns `{data:{type:"languages", range:{…}, items:[…]}}` where `items` are the languages ordered by `total_seconds` desc, each with `percent` of the range total.
+
+**Acceptance Scenarios**:
+1. **Given** summaries with several languages, **When** requesting `languages`, **Then** `items` lists each language once with summed `total_seconds`, `percent` of the range total, and human `text`/`digital`, ordered most-time-first.
+2. **Given** the same data, **When** requesting `editors` / `projects` / `categories` / `machines` / `operating_systems`, **Then** `items` groups by that column equivalently.
+3. **Given** rows whose dimension column is NULL, **When** grouping, **Then** they are bucketed under a stable `"Unknown"` name (not dropped).
+4. **Given** no summaries in range, **When** requesting any dimension insight, **Then** `items` is `[]` with HTTP 200.
+5. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 2 - Temporal insights (Priority: P1)
+
+As an authenticated user, I want day-level views — total per day, my best day, my daily average, and which weekday I code most — to understand my rhythm.
+
+**Independent Test**: Seed summaries on known dates. `GET /insights/best_day/last_30_days` returns the single highest-total day in `best_day`; `daily_average` returns mean seconds per active day; `days` returns per-day totals; `weekday` returns a per-weekday average.
+
+**Acceptance Scenarios**:
+1. **Given** summaries across several dates, **When** requesting `days`, **Then** `days[]` lists active dates ascending, each `{date, total_seconds, text}`.
+2. **Given** the same data, **When** requesting `best_day`, **Then** `best_day` is the date with the greatest summed `total_seconds`.
+3. **Given** the same data, **When** requesting `daily_average`, **Then** `daily_average.seconds` is the total divided by the number of **active** days in range (days with any summary row).
+4. **Given** the same data, **When** requesting `weekday`, **Then** `items[]` has one entry per weekday that occurred (`name` = Monday…Sunday), `total_seconds` = mean of that weekday's active-day totals, ordered most-active-first.
+5. **Given** no summaries in range, **When** requesting `best_day` / `daily_average`, **Then** the field is present with zeroed values (`total_seconds`/`seconds` = 0), and `days` / `weekday items` are empty.
+
+---
+
+### Edge Cases
+
+- **Invalid `insight_type`** (not in the enum): 400.
+- **Invalid `range`** (unparseable): 400 (mirrors `/stats`).
+- **`all_time` range**: `resolveStatsRange` maps it to `1970-01-01…today`. `daily_average` divides by **active** days (not calendar days) so the average is not diluted to near-zero.
+- **`YYYY` / `YYYY-MM` ranges**: scoped to that calendar year / month in the user's timezone.
+- **NULL dimension values**: bucketed under `"Unknown"`.
+- **Single active day**: `daily_average` equals that day's total; `weekday` has one item.
+- **Percent with zero total**: `percent` is 0 for every item (no divide-by-zero).
+- **Timezone**: `summaries.date` is already bucketed in the user's profile timezone by the cron aggregator; insights group by that `date` string directly. Weekday is derived from the local `date`.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `GET /api/v1/users/current/insights/{insight_type}/{range}` MUST validate `insight_type` against the declared enum and resolve `range` via `resolveStatsRange`; an invalid value of either returns 400.
+- **FR-002**: All computation MUST read only from `summaries` (rows `WHERE user_id = ? AND date BETWEEN start AND end`); no raw `heartbeats` scan, no new table.
+- **FR-003**: Dimension insights (`projects`, `languages`, `editors`, `categories`, `machines`, `operating_systems`) MUST return `items[]` grouped by that column, summed `total_seconds`, ordered descending, each with `percent` = share of the range total (0 when total is 0), plus `digital`/`text`/`hours`/`minutes`/`seconds` formatting. NULL values bucket under `"Unknown"`.
+- **FR-004**: `days` MUST return `days[]` of active dates ascending, each `{date, total_seconds, text}`.
+- **FR-005**: `best_day` MUST return the active date with the greatest summed `total_seconds` (ties → earliest date); zeroed when no activity.
+- **FR-006**: `daily_average` MUST return `{seconds, text}` where `seconds` = range total ÷ number of active days (0 when none).
+- **FR-007**: `weekday` MUST return `items[]` with one entry per occurring weekday (`name` = English weekday), `total_seconds` = mean of that weekday's active-day totals, ordered descending.
+- **FR-008**: The response MUST set `data.type` to the requested `insight_type` and `data.range` to the resolved `TimeRange` (`start`, `end`, `text`, `timezone`).
+- **FR-009**: Results MUST be strictly scoped by `user_id`; unauthenticated requests return 401.
+- **FR-010**: `timeout` and `writes_only` query parameters MUST be accepted without error but are not applied in the first cut (documented limitation).
+
+### Non-Functional Requirements
+
+- **NFR-001**: Each request MUST stay within the Workers 10ms CPU budget — one indexed `SELECT … GROUP BY` over the `summaries` date window, plus in-memory shaping. No per-item extra query.
+- **NFR-002**: No D1 schema migration; no new binding; no new dependency.
+- **NFR-003**: The handler MUST reuse the existing range resolver and the shared duration-formatting helpers used by `/stats` (`digital`/`text` formatting), not reimplement them.
+
+### Key Entities *(no schema change)*
+
+`summaries` is the only data source. The existing unique index on `(user_id, date, project, language, editor, operating_system, category, branch, machine)` supports grouped reads. The response uses the existing `Insight`, `SummaryItem`, and `TimeRange` schemas.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Every declared `insight_type` returns a populated, correctly-shaped response against a seeded `summaries` fixture.
+- **SC-002**: Dimension `percent` values sum to ~100% (within rounding) and items are ordered by time desc.
+- **SC-003**: `best_day` / `daily_average` / `weekday` match hand-computed expectations on a fixed fixture.
+- **SC-004**: Invalid `insight_type` and `range` both return 400; cross-user requests never leak another user's activity.
+- **SC-005**: A single `summaries` SELECT backs each request (verified by handler review / no N+1).
+
+## Out of Scope
+
+- **`hours`-of-day insight.** Needs hour granularity; would require an hourly aggregate (extend cron) or a raw-heartbeat scan. Deferred to a follow-up; explicitly not in the declared enum.
+- **Applying `timeout` / `writes_only`.** Summaries already bake in the session timeout and drop the write flag; honouring these would require raw heartbeats. Reserved.
+- **New aggregate tables** or schema changes.
+- **Caching.** May be layered later (like `/stats`); not required for correctness.
+- **Custom / arbitrary ranges** beyond the `resolveStatsRange` vocabulary.

--- a/specs/103-insights/spec.md
+++ b/specs/103-insights/spec.md
@@ -71,7 +71,7 @@ As an authenticated user, I want day-level views — total per day, my best day,
 - **FR-007**: `weekday` MUST return `items[]` with one entry per occurring weekday (`name` = English weekday), `total_seconds` = mean of that weekday's active-day totals, ordered descending.
 - **FR-008**: The response MUST set `data.type` to the requested `insight_type` and `data.range` to the resolved `TimeRange` (`start`, `end`, `text`, `timezone`).
 - **FR-009**: Results MUST be strictly scoped by `user_id`; unauthenticated requests return 401.
-- **FR-010**: `timeout` and `writes_only` query parameters MUST be accepted without error but are not applied in the first cut (documented limitation).
+- **FR-010**: `timeout`, `writes_only`, and `weekday` query parameters MUST be accepted without error but are not applied in the first cut (documented limitation).
 
 ### Non-Functional Requirements
 
@@ -94,7 +94,7 @@ As an authenticated user, I want day-level views — total per day, my best day,
 ## Out of Scope
 
 - **`hours`-of-day insight.** Needs hour granularity; would require an hourly aggregate (extend cron) or a raw-heartbeat scan. Deferred to a follow-up; explicitly not in the declared enum.
-- **Applying `timeout` / `writes_only`.** Summaries already bake in the session timeout and drop the write flag; honouring these would require raw heartbeats. Reserved.
+- **Applying `timeout` / `writes_only` / `weekday`.** Summaries already bake in the session timeout, drop the write flag, and cannot filter already-aggregated daily rows by weekday query semantics. Reserved.
 - **New aggregate tables** or schema changes.
 - **Caching.** May be layered later (like `/stats`); not required for correctness.
 - **Custom / arbitrary ranges** beyond the `resolveStatsRange` vocabulary.

--- a/specs/103-insights/tasks.md
+++ b/specs/103-insights/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: Insights Endpoint
+
+**Branch**: `103-insights`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (dimension + temporal stories, FR-001..FR-010, edge cases, first-cut type list, `hours` deferred).
+- [x] **T-002**: Author `plan.md` (Constitution Check, route + builder sketches).
+- [x] **T-003**: Author `research.md` (7 documented decisions).
+- [x] **T-004**: Author `data-model.md` (summaries-only; single grouped read; per-type shaping).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–I).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add the per-type / range / reserved-param description to `insights.yaml`. No type-shape change.
+- [x] **T-009**: Run `npm run generate` (JSDoc-only diff); run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Builder
+
+- [ ] **T-101**: `src/utils/insights.ts` — pure `buildInsight(type, rows, range, tz)` + helpers:
+  - dimension → `SummaryItem[]` (group by column, NULL→`"Unknown"`, percent of total, desc, shared formatter)
+  - `days[]`, `best_day`, `daily_average` (÷ active days)
+  - `weekday` → `items[]` (English weekday name, mean per active occurrence, desc)
+- [ ] **T-102**: Unit tests `tests/aggregation/insights.test.ts` over a fixed fixture for every type (tie-break, Unknown bucket, active-day average, weekday mean, zero-total percent).
+
+### Route
+
+- [ ] **T-103**: `src/routes/insights.ts` — validate `insight_type` against the enum; resolve `range` via `resolveStatsRange` (400 on either invalid); one grouped `summaries` SELECT scoped by `user_id`; dispatch to `buildInsight`; behind `authMiddleware`.
+- [ ] **T-104**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", insights)`.
+
+### Tests
+
+- [ ] **T-105**: `tests/integration/insights.test.ts` — endpoint per type against seeded `summaries`, validation 400s, cross-user isolation, 401, empty range.
+
+### Verification
+
+- [ ] **T-106**: `npm run typecheck` — zero errors.
+- [ ] **T-107**: `npm test` — full suite green incl. new unit + integration.
+- [ ] **T-108**: Manual run of `quickstart.md` A / D / E / H against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-109**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #103.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                 (PR1)
+T-010 → T-101 .. T-109                  (PR2 after PR1 merge)
+T-101 → T-102
+T-101 → T-103 → T-104
+T-102 / T-104 → T-105
+T-105 → T-106 → T-107 → T-108 → T-109
+```
+
+## Out of scope
+
+- `hours`-of-day insight (needs an hourly aggregate).
+- Applying `timeout` / `writes_only` (summaries can't honour them).
+- New aggregate tables / schema changes.
+- Response caching.

--- a/specs/103-insights/tasks.md
+++ b/specs/103-insights/tasks.md
@@ -13,8 +13,8 @@
 - [x] **T-005**: Author `quickstart.md` (scenarios A–I).
 - [x] **T-006**: Author `contracts/openapi-diff.md`.
 - [x] **T-007**: Author `checklists/requirements.md`.
-- [x] **T-008**: Add the per-type / range / reserved-param description to `insights.yaml`. No type-shape change.
-- [x] **T-009**: Run `npm run generate` (JSDoc-only diff); run `npm run typecheck`.
+- [x] **T-008**: Add the per-type / range / reserved-param description and 400 response to `insights.yaml`. No request parameter or 200 response shape change.
+- [x] **T-009**: Run `npm run generate` (JSDoc + 400 response diff); run `npm run typecheck`.
 - [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
 
 ## PR2 — Implementation (after PR1 merges)
@@ -60,6 +60,6 @@ T-105 → T-106 → T-107 → T-108 → T-109
 ## Out of scope
 
 - `hours`-of-day insight (needs an hourly aggregate).
-- Applying `timeout` / `writes_only` (summaries can't honour them).
+- Applying `timeout` / `writes_only` / `weekday` (summaries can't honour them).
 - New aggregate tables / schema changes.
 - Response caching.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -749,7 +749,34 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Coding activity insights */
+        /**
+         * Coding activity insights
+         * @description Derives an insight of the requested `insight_type` over `range` from the
+         *     pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
+         *     insight types ship in the first cut; an `hours`-of-day insight is
+         *     intentionally absent because `summaries` has day granularity only (it
+         *     would require an hourly aggregate — a future addition).
+         *
+         *     `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
+         *     `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
+         *     profile timezone (same vocabulary as `GET /stats/{range}`). An
+         *     unrecognised range returns 400.
+         *
+         *     Which `Insight` field is populated depends on `insight_type`:
+         *     - `days` → `days[]` (per-day totals across the range).
+         *     - `best_day` → `best_day` (the single highest-total day).
+         *     - `daily_average` → `daily_average` (mean seconds per active day).
+         *     - `weekday` → `items[]`, one per weekday (`name` = Monday…Sunday),
+         *       `total_seconds` = mean for that weekday, ordered most-active first.
+         *     - `projects` / `languages` / `editors` / `categories` / `machines` /
+         *       `operating_systems` → `items[]`, top values of that dimension by
+         *       `total_seconds` (with `percent` of the range total).
+         *
+         *     The `timeout` and `writes_only` query parameters are accepted for
+         *     forward-compatibility but are not applied in the first cut: insights read
+         *     from `summaries`, which already bake in each user's session timeout and do
+         *     not retain per-heartbeat write flags.
+         */
         get: operations["getInsight"];
         put?: never;
         post?: never;

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -755,27 +755,27 @@ export interface paths {
          *     pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
          *     insight types ship in the first cut; an `hours`-of-day insight is
          *     intentionally absent because `summaries` has day granularity only (it
-         *     would require an hourly aggregate — a future addition).
+         *     would require an hourly aggregate - a future addition).
          *
          *     `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
          *     `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
          *     profile timezone (same vocabulary as `GET /stats/{range}`). An
-         *     unrecognised range returns 400.
+         *     invalid `insight_type` or unrecognised range returns 400.
          *
          *     Which `Insight` field is populated depends on `insight_type`:
-         *     - `days` → `days[]` (per-day totals across the range).
-         *     - `best_day` → `best_day` (the single highest-total day).
-         *     - `daily_average` → `daily_average` (mean seconds per active day).
-         *     - `weekday` → `items[]`, one per weekday (`name` = Monday…Sunday),
+         *     - `days` -> `days[]` (per-day totals across the range).
+         *     - `best_day` -> `best_day` (the single highest-total day).
+         *     - `daily_average` -> `daily_average` (mean seconds per active day).
+         *     - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
          *       `total_seconds` = mean for that weekday, ordered most-active first.
          *     - `projects` / `languages` / `editors` / `categories` / `machines` /
-         *       `operating_systems` → `items[]`, top values of that dimension by
+         *       `operating_systems` -> `items[]`, top values of that dimension by
          *       `total_seconds` (with `percent` of the range total).
          *
-         *     The `timeout` and `writes_only` query parameters are accepted for
-         *     forward-compatibility but are not applied in the first cut: insights read
-         *     from `summaries`, which already bake in each user's session timeout and do
-         *     not retain per-heartbeat write flags.
+         *     The `timeout`, `writes_only`, and `weekday` query parameters are accepted
+         *     for forward-compatibility but are not applied in the first cut: insights
+         *     read from `summaries`, which already bake in each user's session timeout
+         *     and do not retain per-heartbeat write flags or weekday filters.
          */
         get: operations["getInsight"];
         put?: never;
@@ -3000,7 +3000,7 @@ export interface operations {
             query?: {
                 timeout?: number;
                 writes_only?: boolean;
-                /** @description Filter for 'days' insight type (0-6 or monday-sunday) */
+                /** @description Reserved for future filtering of the days insight type (0-6 or monday-sunday). Accepted but not applied in the first cut. */
                 weekday?: string;
             };
             header?: never;
@@ -3023,6 +3023,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Insights** (issue #103), following the SpecKit 2-PR workflow. The `getInsight` operation and `Insight`/`SummaryItem`/`TimeRange` schemas already existed; this PR adds the per-type design, clarifies operation behavior, documents reserved query params, and adds the explicit `400` response for invalid inputs. **No implementation code** — the route and builder land in PR2.

All first-cut insights derive from the pre-aggregated `summaries` table (no raw-heartbeat scan, no new table).

## First-cut insight types

All 10 declared types ship: `weekday`, `days`, `best_day`, `daily_average`, `projects`, `languages`, `editors`, `categories`, `machines`, `operating_systems`. **`hours` is explicitly deferred** — `summaries` has day granularity only; an hours-of-day view needs an hourly aggregate (future). The declared enum already omits `hours`.

## What's in this PR

- **OpenAPI** — `getInsight` now documents:
  - which `Insight` field each `insight_type` populates (`items[]` vs `days[]` vs `best_day` vs `daily_average`),
  - the `range` vocabulary (reused from `/stats` via `resolveStatsRange`: `last_7_days` ... `all_time` ... `YYYY` / `YYYY-MM`),
  - that `timeout`, `writes_only`, and `weekday` query params are accepted but **reserved** in the first cut,
  - invalid `insight_type` / `range` returns `400` via the shared `BadRequest` response.
- **Generated types** — JSDoc updates plus the documented `400` response type. Request params and the `200` response shape are unchanged.
- **SpecKit artifacts** under `specs/103-insights/`.

## Key design decisions (see `research.md`)

- **Summaries-only**, single grouped `SELECT` over the date window — stays in the 10ms CPU budget.
- **`daily_average` divides by active days**, not calendar days — avoids `all_time` diluting the average to ~0.
- **`weekday` represented as `items[]`** (no weekday-specific schema field), mean per active weekday occurrence, ordered most-active-first.
- **NULL dimension -> `"Unknown"`** bucket so `percent` still sums to ~100%.
- Existing `timeout` / `writes_only` / `weekday` query params are **reserved**, not applied, because `summaries` cannot honor those filters without a raw-heartbeat scan.

## No schema migration

Uses the existing `summaries` table and `Insight`/`SummaryItem`/`TimeRange` schemas.

## Test plan

- [x] `npm run generate`
- [x] `npm run lint:api`
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] PR2: `buildInsight` pure builder, `getInsight` route, unit + integration tests
