### PR TITLE
feat: Insights endpoint (PR2/2) #103

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import stats from "./routes/stats";
 import users from "./routes/users";
 import goals from "./routes/goals";
 import customRules from "./routes/custom-rules";
+import insights from "./routes/insights";
 import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
@@ -129,6 +130,9 @@ app.route("/api/v1/users/current", goals);
 
 // Custom rules routes (mounted at /users/current, sub-app defines /custom_rules, /custom_rules/:rule_id)
 app.route("/api/v1/users/current", customRules);
+
+// Insights routes (mounted at /users/current, sub-app defines /insights/:insight_type/:range)
+app.route("/api/v1/users/current", insights);
 
 // Machine names routes (mounted at /users/current, sub-app defines /machine_names)
 app.route("/api/v1/users/current", machines);

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -2,7 +2,7 @@
  * Coding activity insights (specs/103-insights/).
  *
  * Derives the requested insight_type over a range from the pre-aggregated
- * `summaries` table — one grouped SELECT, then pure in-memory shaping in
+ * `summaries` table - one grouped SELECT, then pure in-memory shaping in
  * src/utils/insights.ts. No raw-heartbeat scan, no new table.
  */
 import { Hono } from "hono";

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -1,0 +1,58 @@
+/**
+ * Coding activity insights (specs/103-insights/).
+ *
+ * Derives the requested insight_type over a range from the pre-aggregated
+ * `summaries` table — one grouped SELECT, then pure in-memory shaping in
+ * src/utils/insights.ts. No raw-heartbeat scan, no new table.
+ */
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import { authMiddleware, getUserTimezone } from "../middleware/auth";
+import { resolveStatsRange } from "../utils/stats-range";
+import { buildInsight, INSIGHT_TYPES, type InsightType } from "../utils/insights";
+import type { SummaryRow } from "../utils/summary-builder";
+
+const VALID_INSIGHT_TYPES = new Set<string>(INSIGHT_TYPES);
+
+const insights = new Hono<AuthEnv>();
+
+insights.use("/insights/*", authMiddleware);
+
+insights.get("/insights/:insight_type/:range", async (c) => {
+  const insightType = c.req.param("insight_type");
+  if (!VALID_INSIGHT_TYPES.has(insightType)) {
+    return c.json(
+      { error: `Invalid insight_type. Use one of: ${INSIGHT_TYPES.join(", ")}` },
+      400,
+    );
+  }
+
+  const tz = await getUserTimezone(c);
+  const resolved = resolveStatsRange(c.req.param("range"), tz);
+  if (!resolved) {
+    return c.json(
+      { error: "Invalid range. Use: last_7_days, last_30_days, last_6_months, last_year, all_time, YYYY, or YYYY-MM" },
+      400,
+    );
+  }
+
+  const userId = c.get("userId");
+  try {
+    const { results } = await c.env.DB.prepare(
+      `SELECT date, project, language, editor, operating_system, category, branch, machine,
+              SUM(total_seconds) AS total_seconds
+         FROM summaries
+        WHERE user_id = ? AND date BETWEEN ? AND ?
+        GROUP BY date, project, language, editor, operating_system, category, branch, machine`,
+    )
+      .bind(userId, resolved.start, resolved.end)
+      .all<SummaryRow>();
+
+    return c.json({ data: buildInsight(insightType as InsightType, results, resolved, tz) });
+  } catch (err) {
+    console.error("GET /insights error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default insights;

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure insight builders (specs/103-insights/). Shape a window of `summaries`
+ * rows into the `Insight` response for a given `insight_type`. No D1, no I/O —
+ * the route owns the single grouped SELECT and passes the rows in.
+ *
+ * Dimension insights reuse `aggregateDimension` (grouping, percent, NULL →
+ * "Unknown", formatting). Temporal insights derive per-date totals.
+ */
+import type { components } from "../types/generated";
+import { formatDigital, formatHumanReadable } from "./time-format";
+import { aggregateDimension, type Dimension, type SummaryRow } from "./summary-builder";
+
+type Insight = components["schemas"]["Insight"];
+type SummaryItem = components["schemas"]["SummaryItem"];
+
+export const INSIGHT_TYPES = [
+  "weekday",
+  "days",
+  "best_day",
+  "daily_average",
+  "projects",
+  "languages",
+  "editors",
+  "categories",
+  "machines",
+  "operating_systems",
+] as const;
+export type InsightType = (typeof INSIGHT_TYPES)[number];
+
+/** insight_type → the `summaries` column it groups by. */
+const DIMENSION_INSIGHTS: Partial<Record<InsightType, Dimension>> = {
+  projects: "project",
+  languages: "language",
+  editors: "editor",
+  categories: "category",
+  machines: "machine",
+  operating_systems: "operating_system",
+};
+
+const WEEKDAY_NAMES = [
+  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+];
+
+export interface ResolvedRange {
+  start: string;
+  end: string;
+  text: string;
+}
+
+/** Day-of-week (0=Sunday) for a local `YYYY-MM-DD` date string. */
+function weekdayOf(date: string): number {
+  return new Date(`${date}T00:00:00Z`).getUTCDay();
+}
+
+function buildItem(name: string, totalSeconds: number, denom: number): SummaryItem {
+  return {
+    name,
+    total_seconds: totalSeconds,
+    percent: denom > 0 ? Math.round((totalSeconds / denom) * 10000) / 100 : 0,
+    digital: formatDigital(totalSeconds),
+    text: formatHumanReadable(totalSeconds),
+    hours: Math.floor(totalSeconds / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: Math.floor(totalSeconds % 60),
+  };
+}
+
+/** Sum total_seconds per date. */
+function dailyTotals(rows: SummaryRow[]): Map<string, number> {
+  const totals = new Map<string, number>();
+  for (const r of rows) {
+    totals.set(r.date, (totals.get(r.date) ?? 0) + r.total_seconds);
+  }
+  return totals;
+}
+
+export function buildInsight(
+  type: InsightType,
+  rows: SummaryRow[],
+  range: ResolvedRange,
+  tz: string,
+): Insight {
+  const grandTotal = rows.reduce((sum, r) => sum + r.total_seconds, 0);
+  const base: Insight = {
+    type,
+    range: { start: range.start, end: range.end, text: range.text, timezone: tz },
+  };
+
+  const dimension = DIMENSION_INSIGHTS[type];
+  if (dimension) {
+    return { ...base, items: aggregateDimension(rows, dimension, grandTotal) };
+  }
+
+  const totals = dailyTotals(rows);
+
+  switch (type) {
+    case "days": {
+      const days = Array.from(totals.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([date, total_seconds]) => ({
+          date,
+          total_seconds,
+          text: formatHumanReadable(total_seconds),
+        }));
+      return { ...base, days };
+    }
+
+    case "best_day": {
+      let best: { date: string; total_seconds: number } | null = null;
+      // Ascending date scan + strict `>` makes ties resolve to the earliest day.
+      for (const [date, total] of Array.from(totals.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+        if (best === null || total > best.total_seconds) {
+          best = { date, total_seconds: total };
+        }
+      }
+      return {
+        ...base,
+        best_day: best
+          ? { date: best.date, total_seconds: best.total_seconds, text: formatHumanReadable(best.total_seconds) }
+          : { total_seconds: 0, text: formatHumanReadable(0) },
+      };
+    }
+
+    case "daily_average": {
+      const activeDays = totals.size;
+      const seconds = activeDays > 0 ? grandTotal / activeDays : 0;
+      return { ...base, daily_average: { seconds, text: formatHumanReadable(Math.round(seconds)) } };
+    }
+
+    case "weekday": {
+      const byWeekday = new Map<number, { sum: number; count: number }>();
+      for (const [date, total] of totals) {
+        const wd = weekdayOf(date);
+        const acc = byWeekday.get(wd) ?? { sum: 0, count: 0 };
+        acc.sum += total;
+        acc.count += 1;
+        byWeekday.set(wd, acc);
+      }
+      const averages = Array.from(byWeekday.entries()).map(([wd, { sum, count }]) => ({
+        wd,
+        avg: count > 0 ? sum / count : 0,
+      }));
+      const denom = averages.reduce((s, a) => s + a.avg, 0);
+      const items = averages
+        .sort((a, b) => b.avg - a.avg)
+        .map(({ wd, avg }) => buildItem(WEEKDAY_NAMES[wd], avg, denom));
+      return { ...base, items };
+    }
+
+    default:
+      return base;
+  }
+}

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -1,9 +1,9 @@
 /**
  * Pure insight builders (specs/103-insights/). Shape a window of `summaries`
- * rows into the `Insight` response for a given `insight_type`. No D1, no I/O —
+ * rows into the `Insight` response for a given `insight_type`. No D1, no I/O -
  * the route owns the single grouped SELECT and passes the rows in.
  *
- * Dimension insights reuse `aggregateDimension` (grouping, percent, NULL →
+ * Dimension insights reuse `aggregateDimension` (grouping, percent, NULL ->
  * "Unknown", formatting). Temporal insights derive per-date totals.
  */
 import type { components } from "../types/generated";
@@ -27,7 +27,7 @@ export const INSIGHT_TYPES = [
 ] as const;
 export type InsightType = (typeof INSIGHT_TYPES)[number];
 
-/** insight_type → the `summaries` column it groups by. */
+/** insight_type -> the `summaries` column it groups by. */
 const DIMENSION_INSIGHTS: Partial<Record<InsightType, Dimension>> = {
   projects: "project",
   languages: "language",
@@ -83,7 +83,12 @@ export function buildInsight(
   const grandTotal = rows.reduce((sum, r) => sum + r.total_seconds, 0);
   const base: Insight = {
     type,
-    range: { start: range.start, end: range.end, text: range.text, timezone: tz },
+    range: {
+      start: `${range.start}T00:00:00Z`,
+      end: `${range.end}T23:59:59Z`,
+      text: range.text,
+      timezone: tz,
+    },
   };
 
   const dimension = DIMENSION_INSIGHTS[type];

--- a/tests/aggregation/insights.test.ts
+++ b/tests/aggregation/insights.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for src/utils/insights.ts — the pure insight builder
+ * Unit tests for src/utils/insights.ts - the pure insight builder
  * (specs/103-insights/). No D1, no KV.
  */
 import { describe, expect, it } from "vitest";
@@ -23,7 +23,7 @@ function row(partial: Partial<SummaryRow>): SummaryRow {
   };
 }
 
-describe("buildInsight — dimension types", () => {
+describe("buildInsight - dimension types", () => {
   const rows: SummaryRow[] = [
     row({ date: "2026-05-01", language: "TypeScript", total_seconds: 7200 }),
     row({ date: "2026-05-02", language: "Go", total_seconds: 3600 }),
@@ -35,6 +35,8 @@ describe("buildInsight — dimension types", () => {
     const out = buildInsight("languages", rows, RANGE, "UTC");
     expect(out.type).toBe("languages");
     expect(out.range?.timezone).toBe("UTC");
+    expect(out.range?.start).toBe("2026-05-01T00:00:00Z");
+    expect(out.range?.end).toBe("2026-05-31T23:59:59Z");
     const items = out.items ?? [];
     expect(items.map((i) => i.name)).toEqual(["TypeScript", "Go", "Unknown"]);
     expect(items[0].total_seconds).toBe(9000); // 7200 + 1800
@@ -49,7 +51,7 @@ describe("buildInsight — dimension types", () => {
   });
 });
 
-describe("buildInsight — temporal types", () => {
+describe("buildInsight - temporal types", () => {
   // Three active days: Mon 2026-05-04, Tue 2026-05-05, Mon 2026-05-11
   const rows: SummaryRow[] = [
     row({ date: "2026-05-04", total_seconds: 3600 }), // Monday

--- a/tests/aggregation/insights.test.ts
+++ b/tests/aggregation/insights.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for src/utils/insights.ts — the pure insight builder
+ * (specs/103-insights/). No D1, no KV.
+ */
+import { describe, expect, it } from "vitest";
+import { buildInsight, type ResolvedRange } from "../../src/utils/insights";
+import type { SummaryRow } from "../../src/utils/summary-builder";
+
+const RANGE: ResolvedRange = { start: "2026-05-01", end: "2026-05-31", text: "last 30 days" };
+
+function row(partial: Partial<SummaryRow>): SummaryRow {
+  return {
+    date: "2026-05-01",
+    project: null,
+    language: null,
+    editor: null,
+    operating_system: null,
+    category: null,
+    branch: null,
+    machine: null,
+    total_seconds: 0,
+    ...partial,
+  };
+}
+
+describe("buildInsight — dimension types", () => {
+  const rows: SummaryRow[] = [
+    row({ date: "2026-05-01", language: "TypeScript", total_seconds: 7200 }),
+    row({ date: "2026-05-02", language: "Go", total_seconds: 3600 }),
+    row({ date: "2026-05-03", language: "TypeScript", total_seconds: 1800 }),
+    row({ date: "2026-05-03", language: null, total_seconds: 600 }),
+  ];
+
+  it("groups languages, orders desc, computes percent of total, buckets NULL as Unknown", () => {
+    const out = buildInsight("languages", rows, RANGE, "UTC");
+    expect(out.type).toBe("languages");
+    expect(out.range?.timezone).toBe("UTC");
+    const items = out.items ?? [];
+    expect(items.map((i) => i.name)).toEqual(["TypeScript", "Go", "Unknown"]);
+    expect(items[0].total_seconds).toBe(9000); // 7200 + 1800
+    // total = 13200; TS share = 9000/13200 = 68.18%
+    expect(items[0].percent).toBeCloseTo(68.18, 1);
+    expect(items.find((i) => i.name === "Unknown")?.total_seconds).toBe(600);
+  });
+
+  it("returns empty items for no rows", () => {
+    const out = buildInsight("editors", [], RANGE, "UTC");
+    expect(out.items).toEqual([]);
+  });
+});
+
+describe("buildInsight — temporal types", () => {
+  // Three active days: Mon 2026-05-04, Tue 2026-05-05, Mon 2026-05-11
+  const rows: SummaryRow[] = [
+    row({ date: "2026-05-04", total_seconds: 3600 }), // Monday
+    row({ date: "2026-05-05", total_seconds: 1800 }), // Tuesday
+    row({ date: "2026-05-11", total_seconds: 5400 }), // Monday
+  ];
+
+  it("days: active dates ascending with totals", () => {
+    const out = buildInsight("days", rows, RANGE, "UTC");
+    expect(out.days?.map((d) => d.date)).toEqual(["2026-05-04", "2026-05-05", "2026-05-11"]);
+    expect(out.days?.[2].total_seconds).toBe(5400);
+  });
+
+  it("best_day: highest-total date", () => {
+    const out = buildInsight("best_day", rows, RANGE, "UTC");
+    expect(out.best_day?.date).toBe("2026-05-11");
+    expect(out.best_day?.total_seconds).toBe(5400);
+  });
+
+  it("best_day: ties resolve to the earliest date", () => {
+    const tied: SummaryRow[] = [
+      row({ date: "2026-05-20", total_seconds: 1000 }),
+      row({ date: "2026-05-10", total_seconds: 1000 }),
+    ];
+    expect(buildInsight("best_day", tied, RANGE, "UTC").best_day?.date).toBe("2026-05-10");
+  });
+
+  it("daily_average: total divided by active days", () => {
+    const out = buildInsight("daily_average", rows, RANGE, "UTC");
+    // (3600 + 1800 + 5400) / 3 = 3600
+    expect(out.daily_average?.seconds).toBe(3600);
+  });
+
+  it("weekday: mean per active weekday occurrence, ordered desc", () => {
+    const out = buildInsight("weekday", rows, RANGE, "UTC");
+    const items = out.items ?? [];
+    // Monday avg = (3600 + 5400) / 2 = 4500; Tuesday avg = 1800
+    expect(items.map((i) => i.name)).toEqual(["Monday", "Tuesday"]);
+    expect(items[0].total_seconds).toBe(4500);
+    expect(items[1].total_seconds).toBe(1800);
+  });
+
+  it("zeroes best_day and daily_average when there is no activity", () => {
+    expect(buildInsight("best_day", [], RANGE, "UTC").best_day?.total_seconds).toBe(0);
+    expect(buildInsight("daily_average", [], RANGE, "UTC").daily_average?.seconds).toBe(0);
+    expect(buildInsight("weekday", [], RANGE, "UTC").items).toEqual([]);
+  });
+});

--- a/tests/integration/insights.test.ts
+++ b/tests/integration/insights.test.ts
@@ -86,9 +86,13 @@ describe("GET /insights/:insight_type/:range", () => {
 
     const res = await call(`${INSIGHTS}/languages/${YEAR}`, { headers: bearer(user.apiKey) });
     expect(res.status).toBe(200);
-    const { data } = (await res.json()) as { data: { type: string; range: { text: string }; items: { name: string }[] } };
+    const { data } = (await res.json()) as {
+      data: { type: string; range: { start: string; end: string; text: string }; items: { name: string }[] };
+    };
     expect(data.type).toBe("languages");
     expect(data.range.text).toBe("2026");
+    expect(data.range.start).toBe("2026-01-01T00:00:00Z");
+    expect(data.range.end).toBe("2026-12-31T23:59:59Z");
     expect(data.items.map((i) => i.name)).toEqual(["TypeScript", "Go"]);
   });
 

--- a/tests/integration/insights.test.ts
+++ b/tests/integration/insights.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for the Insights endpoint (specs/103-insights/).
+ * Seeds `summaries` directly and exercises each insight type, validation,
+ * cross-user isolation, and auth.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const INSIGHTS = "/api/v1/users/current/insights";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("summaries", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+async function seedSummary(opts: {
+  userId: string;
+  date: string;
+  totalSeconds: number;
+  language?: string;
+  editor?: string;
+  project?: string;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO summaries (user_id, date, project, language, editor, total_seconds)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      opts.userId,
+      opts.date,
+      opts.project ?? null,
+      opts.language ?? null,
+      opts.editor ?? null,
+      opts.totalSeconds,
+    )
+    .run();
+}
+
+// Use a fixed historical year so the data is inside the `2026` range regardless
+// of when the suite runs.
+const YEAR = "2026";
+
+describe("GET /insights/:insight_type/:range", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call(`${INSIGHTS}/languages/last_7_days`);
+    expect(res.status).toBe(401);
+  });
+
+  it("400s on an invalid insight_type", async () => {
+    const res = await call(`${INSIGHTS}/bogus/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on an invalid range", async () => {
+    const res = await call(`${INSIGHTS}/languages/since_forever`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(400);
+  });
+
+  it("languages: grouped, ordered desc, with range echoed", async () => {
+    await seedSummary({ userId: user.userId, date: "2026-03-01", language: "TypeScript", totalSeconds: 7200 });
+    await seedSummary({ userId: user.userId, date: "2026-03-02", language: "Go", totalSeconds: 3600 });
+
+    const res = await call(`${INSIGHTS}/languages/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    const { data } = (await res.json()) as { data: { type: string; range: { text: string }; items: { name: string }[] } };
+    expect(data.type).toBe("languages");
+    expect(data.range.text).toBe("2026");
+    expect(data.items.map((i) => i.name)).toEqual(["TypeScript", "Go"]);
+  });
+
+  it("best_day / daily_average / days over a year range", async () => {
+    await seedSummary({ userId: user.userId, date: "2026-03-01", project: "p", totalSeconds: 3600 });
+    await seedSummary({ userId: user.userId, date: "2026-03-02", project: "p", totalSeconds: 5400 });
+
+    const best = await call(`${INSIGHTS}/best_day/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(((await best.json()) as { data: { best_day: { date: string } } }).data.best_day.date).toBe("2026-03-02");
+
+    const avg = await call(`${INSIGHTS}/daily_average/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(((await avg.json()) as { data: { daily_average: { seconds: number } } }).data.daily_average.seconds).toBe(4500);
+
+    const days = await call(`${INSIGHTS}/days/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(((await days.json()) as { data: { days: { date: string }[] } }).data.days.map((d) => d.date)).toEqual([
+      "2026-03-01",
+      "2026-03-02",
+    ]);
+  });
+
+  it("empty range returns 200 with empty/zeroed payloads", async () => {
+    const items = await call(`${INSIGHTS}/languages/2099`, { headers: bearer(user.apiKey) });
+    expect(items.status).toBe(200);
+    expect(((await items.json()) as { data: { items: unknown[] } }).data.items).toEqual([]);
+
+    const avg = await call(`${INSIGHTS}/daily_average/2099`, { headers: bearer(user.apiKey) });
+    expect(((await avg.json()) as { data: { daily_average: { seconds: number } } }).data.daily_average.seconds).toBe(0);
+  });
+
+  it("isolates results per user", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await seedSummary({ userId: bob.userId, date: "2026-03-01", language: "Rust", totalSeconds: 9999 });
+
+    const res = await call(`${INSIGHTS}/languages/${YEAR}`, { headers: bearer(user.apiKey) });
+    expect(((await res.json()) as { data: { items: unknown[] } }).data.items).toEqual([]);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for **Insights** (issue #103), following the SpecKit 2-PR workflow. Wires the `getInsight` operation spec'd in #123 (merged) to a read handler that derives each insight type from the pre-aggregated `summaries` table — one grouped `SELECT`, then pure in-memory shaping.

## Endpoint

`GET /users/current/insights/{insight_type}/{range}` → `{ data: Insight }`

`insight_type` ∈ `weekday | days | best_day | daily_average | projects | languages | editors | categories | machines | operating_systems`. `range` reuses the `/stats` vocabulary.

## What's in this PR

- **`src/utils/insights.ts`** — pure `buildInsight(type, rows, range, tz)`:
  - Dimension types reuse the existing `aggregateDimension` (group by column, `percent` of total, NULL → `"Unknown"`, `digital`/`text`/`hours`/`minutes`/`seconds`).
  - `days` → active dates ascending; `best_day` → max-total date (ties → earliest); `daily_average` → total ÷ **active** days; `weekday` → `items[]`, mean per active weekday occurrence, ordered desc.
- **`src/routes/insights.ts`** — validates `insight_type` (enum) and resolves `range` via `resolveStatsRange` (400 on either invalid); one grouped `summaries` SELECT scoped by `user_id`; behind `authMiddleware`. Mounted in `index.ts`.
- **Tests** — pure-builder unit tests (`tests/aggregation/insights.test.ts`: every type, Unknown bucket, tie-break, active-day average, weekday mean, empty) and endpoint integration (`tests/integration/insights.test.ts`: per type, validation 400s, empty range, cross-user isolation, 401).

## Decisions carried from PR1

- `hours` deferred (not in enum); `timeout`/`writes_only`/`weekday` query params accepted but not applied; `daily_average` over active days; `weekday` as `items[]`; NULL → `"Unknown"`.

## No schema / type change

OpenAPI + generated types landed in PR1 (#123). This PR is implementation + tests only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 232 passing (216 prior + 16 new)
- [ ] Manual `quickstart.md` A / D / E / H against a staging worker