### PR TITLE
spec: External Durations (PR1/2) #106

### DIFF
--- a/schemas/paths/external-durations/external-durations-bulk.yaml
+++ b/schemas/paths/external-durations/external-durations-bulk.yaml
@@ -3,6 +3,13 @@ post:
   tags:
     - external_durations
   summary: Create up to 100 external durations
+  description: |
+    Batch-creates external durations (all-or-nothing): every element is
+    validated first, and any invalid element returns 400 with nothing
+    written. Each element is idempotent on `(user_id, external_id)` — a
+    re-sent `external_id` updates the existing row. Returns the persisted
+    rows. The cap is 100 per request (larger than the heartbeat bulk cap, to
+    suit calendar imports).
   requestBody:
     required: true
     content:
@@ -26,6 +33,8 @@ post:
                 type: array
                 items:
                   $ref: ../../components/schemas/ExternalDuration.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
 delete:
@@ -33,6 +42,11 @@ delete:
   tags:
     - external_durations
   summary: Delete external durations
+  description: |
+    Deletes the listed external durations (by `id`) whose `start_time` falls
+    on `date`, scoped to the authenticated user. Returns 204. A malformed
+    body (missing `date`/`ids`, or invalid `date`) returns 400. Unknown ids
+    are ignored.
   requestBody:
     required: true
     content:
@@ -53,5 +67,7 @@ delete:
   responses:
     '204':
       description: External durations deleted
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/external-durations/external-durations.yaml
+++ b/schemas/paths/external-durations/external-durations.yaml
@@ -3,6 +3,16 @@ get:
   tags:
     - external_durations
   summary: List external durations for a day
+  description: |
+    Returns the authenticated user's external durations whose `start_time`
+    falls on `date`, ordered by `start_time` ascending. `date` is interpreted
+    in the `timezone` query param when supplied, otherwise the user's profile
+    timezone (same convention as `GET /heartbeats`). Optional `project` and
+    `branches` (comma-separated) further filter the results.
+
+    External durations are a parallel, non-coding time series — they are
+    **not** aggregated into `summaries`, so they do not affect `/stats`,
+    `/summaries`, goals, or insights.
   parameters:
     - name: date
       in: query
@@ -36,6 +46,8 @@ get:
                 type: array
                 items:
                   $ref: ../../components/schemas/ExternalDuration.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
 post:
@@ -43,6 +55,12 @@ post:
   tags:
     - external_durations
   summary: Create a single external duration
+  description: |
+    Creates one external duration and returns it. Idempotent on
+    `(user_id, external_id)`: re-sending the same `external_id` updates the
+    existing row in place (so calendar/meeting syncs can be replayed safely).
+    Validation failures (missing required fields, unknown `type`, or
+    `end_time` < `start_time`) return 400.
   requestBody:
     required: true
     content:
@@ -61,5 +79,7 @@ post:
             properties:
               data:
                 $ref: ../../components/schemas/ExternalDuration.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/external-durations/external-durations.yaml
+++ b/schemas/paths/external-durations/external-durations.yaml
@@ -8,7 +8,8 @@ get:
     falls on `date`, ordered by `start_time` ascending. `date` is interpreted
     in the `timezone` query param when supplied, otherwise the user's profile
     timezone (same convention as `GET /heartbeats`). Optional `project` and
-    `branches` (comma-separated) further filter the results.
+    `branches` (comma-separated) further filter the results. Missing or
+    malformed `date`, or an invalid IANA `timezone`, returns 400.
 
     External durations are a parallel, non-coding time series — they are
     **not** aggregated into `summaries`, so they do not affect `/stats`,
@@ -30,6 +31,10 @@ get:
         type: string
     - name: timezone
       in: query
+      description: >-
+        IANA timezone (e.g. Asia/Tokyo). Determines the local-day bounds for
+        `date`. Defaults to the authenticated user's profile timezone when
+        omitted.
       schema:
         type: string
   responses:

--- a/specs/106-external-durations/checklists/requirements.md
+++ b/specs/106-external-durations/checklists/requirements.md
@@ -23,7 +23,7 @@
 - [ ] `src/routes/external-durations.ts` implements all four handlers behind `authMiddleware`:
   - `POST /external_durations` — validate, upsert on `(user_id, external_id)`, return `201 {data}`.
   - `POST /external_durations.bulk` — validate all (≤100), `db.batch` upsert, return `201 {data[]}`; any invalid → 400, nothing written.
-  - `GET /external_durations?date=` — day-scoped by `start_time` (tz), `project`/`branches` filters, `400` on missing/bad date.
+  - `GET /external_durations?date=` — day-scoped by `start_time` (tz), `project`/`branches` filters, `400` on missing/bad date or invalid timezone.
   - `DELETE /external_durations.bulk` — `{date, ids}`, scoped by `user_id`, `204`, `400` on bad body.
 - [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
 - [ ] The cron aggregator and `summaries` are **not** modified.
@@ -32,7 +32,7 @@
 ### Behaviour (per `quickstart.md`)
 
 - [ ] A: single create 201; B: re-sync idempotent (no duplicate); C: validation 400s.
-- [ ] D: bulk all-or-nothing; E: list day-scoped + project filter, missing date 400; F: bulk delete 204 + unknown ids ignored.
+- [ ] D: bulk all-or-nothing; E: list day-scoped + project filter, missing date / invalid timezone 400; F: bulk delete 204 + unknown ids ignored.
 - [ ] G: `/stats` unaffected; H: unauthenticated 401, cross-user isolation.
 
 ### Tests

--- a/specs/106-external-durations/checklists/requirements.md
+++ b/specs/106-external-durations/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Acceptance Checklist: External Durations
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-007 (create / bulk / list / delete) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` records the spec-level decisions (upsert idempotency, parallel series, bulk cap 100, all-or-nothing).
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 5 design decisions.
+- [x] `data-model.md` confirms no schema change and documents the upsert / list / delete statements.
+- [x] `quickstart.md` enumerates scenarios A–H.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the `400` additions and descriptions.
+- [x] Both path files carry the new `400` responses + descriptions.
+- [x] `npm run generate` adds the 400 responses + JSDoc (no body type-shape change); `npm run typecheck` passes.
+- [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
+- [x] PR1 references issue #106.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/utils/external-duration-input.ts` validates a body → normalised row | error (required fields, `type` enum, `end_time` ≥ `start_time`).
+- [ ] `src/routes/external-durations.ts` implements all four handlers behind `authMiddleware`:
+  - `POST /external_durations` — validate, upsert on `(user_id, external_id)`, return `201 {data}`.
+  - `POST /external_durations.bulk` — validate all (≤100), `db.batch` upsert, return `201 {data[]}`; any invalid → 400, nothing written.
+  - `GET /external_durations?date=` — day-scoped by `start_time` (tz), `project`/`branches` filters, `400` on missing/bad date.
+  - `DELETE /external_durations.bulk` — `{date, ids}`, scoped by `user_id`, `204`, `400` on bad body.
+- [ ] `src/index.ts` mounts the router at `/api/v1/users/current`.
+- [ ] The cron aggregator and `summaries` are **not** modified.
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: single create 201; B: re-sync idempotent (no duplicate); C: validation 400s.
+- [ ] D: bulk all-or-nothing; E: list day-scoped + project filter, missing date 400; F: bulk delete 204 + unknown ids ignored.
+- [ ] G: `/stats` unaffected; H: unauthenticated 401, cross-user isolation.
+
+### Tests
+
+- [ ] `tests/security/external-duration-input.test.ts` (or `tests/aggregation/`): validation rules.
+- [ ] `tests/integration/external-durations.test.ts`: create/upsert, bulk all-or-nothing, list-by-day + filters, bulk delete, cross-user, 401.
+- [ ] `npm test` stays green with the new coverage.
+
+## Post-deployment gate
+
+- [ ] Push a calendar event, re-push it, confirm a single updated row.
+- [ ] Confirm `/stats` totals do not change when external durations are added.
+- [ ] No 500s on the endpoints in the first 7 days.

--- a/specs/106-external-durations/contracts/openapi-diff.md
+++ b/specs/106-external-durations/contracts/openapi-diff.md
@@ -1,0 +1,42 @@
+# OpenAPI Diff
+
+The four `external_durations` operations and the `ExternalDuration` /
+`ExternalDurationInput` schemas already existed. This PR adds the missing
+error responses and documents the behaviour. No schema field changes.
+
+## Files touched
+
+1. `schemas/paths/external-durations/external-durations.yaml`
+   - `getExternalDurations`: add `400`; document day-scoping (timezone),
+     `project`/`branches` filters, and the parallel-series note.
+   - `createExternalDuration`: add `400`; document upsert idempotency on
+     `(user_id, external_id)`.
+2. `schemas/paths/external-durations/external-durations-bulk.yaml`
+   - `createExternalDurationsBulk`: add `400`; document all-or-nothing
+     validation, idempotency, and the 100-item cap.
+   - `deleteExternalDurationsBulk`: add `400`; document day+id scoping and
+     that unknown ids are ignored.
+
+No new operations, no path changes, no schema field changes. `maxItems: 100`
+on the bulk body is **kept** (OpenAPI SSoT) over the issue prose's "max 25".
+
+## Contract (shape unchanged)
+
+- `GET /users/current/external_durations?date=…` → `200 {data: ExternalDuration[]}`, `400`, `401`.
+- `POST /users/current/external_durations` → `201 {data: ExternalDuration}`, `400`, `401`.
+- `POST /users/current/external_durations.bulk` (≤100) → `201 {data: ExternalDuration[]}`, `400`, `401`.
+- `DELETE /users/current/external_durations.bulk` (`{date, ids}`) → `204`, `400`, `401`.
+
+`ExternalDuration` = `ExternalDurationInput` + `id` / `user_id` / `created_at`.
+
+## Generated-types impact
+
+`npm run generate` adds the `400` (BadRequest) responses to all four
+operations and the JSDoc descriptions. No request/response **body** type
+changes — `ExternalDuration` / `ExternalDurationInput` are untouched.
+
+## SDD compliance note
+
+PR1 lands SpecKit + the response/description additions + regenerated types.
+PR2 lands the route handlers and the validation helper, plus tests. No runtime
+code in PR1.

--- a/specs/106-external-durations/contracts/openapi-diff.md
+++ b/specs/106-external-durations/contracts/openapi-diff.md
@@ -8,7 +8,8 @@ error responses and documents the behaviour. No schema field changes.
 
 1. `schemas/paths/external-durations/external-durations.yaml`
    - `getExternalDurations`: add `400`; document day-scoping (timezone),
-     `project`/`branches` filters, and the parallel-series note.
+     invalid timezone handling, `project`/`branches` filters, and the
+     parallel-series note.
    - `createExternalDuration`: add `400`; document upsert idempotency on
      `(user_id, external_id)`.
 2. `schemas/paths/external-durations/external-durations-bulk.yaml`
@@ -22,7 +23,7 @@ on the bulk body is **kept** (OpenAPI SSoT) over the issue prose's "max 25".
 
 ## Contract (shape unchanged)
 
-- `GET /users/current/external_durations?date=…` → `200 {data: ExternalDuration[]}`, `400`, `401`.
+- `GET /users/current/external_durations?date=...` -> `200 {data: ExternalDuration[]}`, `400`, `401`.
 - `POST /users/current/external_durations` → `201 {data: ExternalDuration}`, `400`, `401`.
 - `POST /users/current/external_durations.bulk` (≤100) → `201 {data: ExternalDuration[]}`, `400`, `401`.
 - `DELETE /users/current/external_durations.bulk` (`{date, ids}`) → `204`, `400`, `401`.

--- a/specs/106-external-durations/data-model.md
+++ b/specs/106-external-durations/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: External Durations
+
+No schema changes. Uses the existing `external_durations` table.
+
+## `external_durations` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS external_durations (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  entity TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'app',     -- file | app | domain
+  category TEXT,
+  start_time REAL NOT NULL,             -- epoch seconds
+  end_time REAL NOT NULL,               -- epoch seconds
+  project TEXT,
+  branch TEXT,
+  language TEXT,
+  meta TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ext_durations_user_time ON external_durations(user_id, start_time);
+```
+
+`UNIQUE(user_id, external_id)` is the upsert conflict target. `idx_ext_durations_user_time` backs the day-scoped GET and DELETE.
+
+## Write-path field treatment
+
+| Field | Treatment |
+|---|---|
+| `id` | Server `crypto.randomUUID()` on insert; preserved on conflict-update |
+| `user_id` | From the session; bound in every statement / WHERE |
+| `external_id` | Required; conflict key |
+| `entity` | Required, non-empty |
+| `type` | Required, ∈ `file|app|domain` |
+| `start_time` / `end_time` | Required, finite numbers (epoch seconds); `end_time` ≥ `start_time` |
+| `category` / `project` / `branch` / `language` / `meta` | Optional strings, stored as-is or NULL |
+| `created_at` | `datetime('now')` on insert; unchanged on update |
+
+## Statements
+
+### Create / bulk create (upsert)
+```sql
+INSERT INTO external_durations
+  (id, user_id, external_id, entity, type, category, start_time, end_time, project, branch, language, meta)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT (user_id, external_id) DO UPDATE SET
+  entity = excluded.entity, type = excluded.type, category = excluded.category,
+  start_time = excluded.start_time, end_time = excluded.end_time,
+  project = excluded.project, branch = excluded.branch,
+  language = excluded.language, meta = excluded.meta;
+```
+Single create reads the row back (RETURNING or a follow-up SELECT) to return it. Bulk runs one `db.batch()` of upserts after validating all elements, then returns the persisted rows.
+
+### List (day-scoped)
+```sql
+SELECT id, user_id, external_id, entity, type, category, start_time, end_time,
+       project, branch, language, meta, created_at
+  FROM external_durations
+ WHERE user_id = ? AND start_time >= ? AND start_time < ?
+   /* optional: AND project = ?  AND branch IN (?, …) */
+ ORDER BY start_time ASC;
+```
+`?`/`?` are the local-day epoch bounds from `getEpochBoundsForDate(date, tz)`.
+
+### Bulk delete
+```sql
+DELETE FROM external_durations
+ WHERE user_id = ? AND start_time >= ? AND start_time < ? AND id IN (?, …);
+```
+Unknown / unowned ids simply do not match.
+
+## Aggregation
+
+None. External durations are a parallel series; the cron aggregator and `summaries` are untouched (see research Decision 2).
+
+## Cleanup / cascade
+
+`external_durations` cascades on user delete. No additional cleanup.

--- a/specs/106-external-durations/plan.md
+++ b/specs/106-external-durations/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: External Durations
+
+**Branch**: `106-external-durations` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/106-external-durations/spec.md`
+
+## Summary
+
+Wire the four declared `external_durations` operations to handlers backed by the existing table. Mirrors the heartbeat handlers (single + bulk create, GET by day, bulk delete) but with two differences: create is an **upsert** on `(user_id, external_id)`, and the data is a **parallel series** — the cron aggregator is untouched.
+
+PR1 (this PR): SpecKit artifacts + OpenAPI reconciliation (add `400` responses, document upsert idempotency / parallel-series / day-scoped GET). PR2: the route + a validation helper + tests.
+
+No D1 migration, no new binding.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`external_durations`, existing)
+**Testing**: Vitest + workers pool — validation unit tests + endpoint integration tests
+**Performance Goals**: <10ms CPU — single-row upsert / bulk `db.batch()` / one indexed SELECT
+**Constraints**: bulk ≤ 100; GET uses `idx_ext_durations_user_time`
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Operations already declared; PR1 adds `400` responses + descriptions, PR2 implements. `npm run generate` adds the 400 response types + JSDoc. |
+| II. Cloudflare-Native | PASS | D1 upsert + `db.batch()` + indexed SELECT. Reuses the heartbeat date→epoch helper. No new bindings. |
+| III. Type Safety | PASS | Handlers use `components["schemas"]["ExternalDuration"]` / `["ExternalDurationInput"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Original contract from our own schema; no upstream source/assets. |
+| V. Simplicity First | PASS | One route + one validation helper, mirroring heartbeats. Cron untouched (parallel series). |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/106-external-durations/
+├── plan.md, spec.md, research.md, data-model.md, quickstart.md, tasks.md
+├── contracts/openapi-diff.md
+└── checklists/requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── external-durations.ts   # NEW: 4 handlers (get / create / bulk create / bulk delete)
+├── utils/
+│   └── external-duration-input.ts  # NEW: validateExternalDuration(body) → row | error
+└── index.ts                    # NEW route mount
+```
+
+**Structure Decision**: One router for the resource (mounted at `/users/current`, defining `/external_durations` and `/external_durations.bulk`), mirroring `heartbeats.ts`. Validation is a pure helper so the rules are unit-testable without D1.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Upsert on `(user_id, external_id)`** — idempotent replayable syncs.
+2. **Parallel series** — not aggregated into `summaries`; cron untouched.
+3. **Bulk cap 100** (OpenAPI SSoT over the issue's prose 25), **all-or-nothing** validation.
+4. **GET day-scoped** by `start_time` in the user's (or query) timezone; `project`/`branches` filters.
+5. **Delete** by `id` within day, scoped by `user_id`; unknown ids ignored.
+
+## Phase 1 — Design Outputs
+
+### Validation helper sketch
+
+```ts
+// src/utils/external-duration-input.ts
+const TYPES = new Set(["file", "app", "domain"]);
+export function validateExternalDuration(body: unknown): { ok: true; value: ValidatedExt } | { ok: false; error: string } {
+  // external_id, entity non-empty strings; type ∈ TYPES; start_time/end_time finite; end_time >= start_time;
+  // optional category/project/branch/language/meta strings.
+}
+```
+
+### Upsert SQL (single + per bulk element)
+
+```sql
+INSERT INTO external_durations
+  (id, user_id, external_id, entity, type, category, start_time, end_time, project, branch, language, meta)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT (user_id, external_id) DO UPDATE SET
+  entity = excluded.entity, type = excluded.type, category = excluded.category,
+  start_time = excluded.start_time, end_time = excluded.end_time,
+  project = excluded.project, branch = excluded.branch, language = excluded.language, meta = excluded.meta
+RETURNING id, user_id, external_id, entity, type, category, start_time, end_time, project, branch, language, meta, created_at;
+```
+
+Single create uses `.first()` on the RETURNING; bulk uses `db.batch()` of the upserts (no RETURNING needed across batch — re-SELECT by the request's `external_id`s, or return the validated rows with their resolved ids).
+
+### GET / DELETE
+
+- GET: `getEpochBoundsForDate(date, tz)` → `WHERE user_id = ? AND start_time >= ? AND start_time < ?` (+ optional `project = ?`, `branch IN (…)`), `ORDER BY start_time ASC`.
+- DELETE: `DELETE FROM external_durations WHERE user_id = ? AND start_time >= ? AND start_time < ? AND id IN (…)`.
+
+### OpenAPI surface
+
+Already declared; PR1 adds `400` responses + descriptions — see [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+Bounded: mirrors heartbeats, minus the cron coupling (parallel series). The only new wrinkle is the upsert + all-or-nothing bulk, both straightforward.

--- a/specs/106-external-durations/quickstart.md
+++ b/specs/106-external-durations/quickstart.md
@@ -63,9 +63,10 @@ curl -sX POST "$EXT.bulk" "${HJ[@]}" -d '[
 ```bash
 curl -s "$EXT?date=2026-05-29" -H "$H"
 curl -s "$EXT?date=2026-05-29&project=Personal" -H "$H"
+curl -si "$EXT?date=2026-05-29&timezone=Not/AZone" -H "$H"
 ```
 
-**Expected**: entries whose `start_time` is on that local day, ascending; `project` filter narrows them. Missing `date` → 400.
+**Expected**: entries whose `start_time` is on that local day, ascending; `project` filter narrows them. Missing `date` or invalid `timezone` returns 400.
 
 ## Scenario F — Bulk delete
 

--- a/specs/106-external-durations/quickstart.md
+++ b/specs/106-external-durations/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: External Durations
+
+Manual verification once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+export HJ=(-H "$H" -H "Content-Type: application/json")
+export EXT="$BASE/users/current/external_durations"
+```
+
+## Scenario A — Create one
+
+```bash
+curl -sX POST "$EXT" "${HJ[@]}" -d '{
+  "external_id":"cal-evt-1","entity":"Standup","type":"app",
+  "category":"meeting","start_time":'"$(date +%s)"',"end_time":'"$(($(date +%s)+900))"'}'
+```
+
+**Expected**: 201, `data` with a server `id`, `user_id`, `created_at`, echoing the input.
+
+## Scenario B — Idempotent re-sync
+
+```bash
+# same external_id, new end_time
+curl -sX POST "$EXT" "${HJ[@]}" -d '{
+  "external_id":"cal-evt-1","entity":"Standup","type":"app",
+  "start_time":'"$(date +%s)"',"end_time":'"$(($(date +%s)+1800))"'}'
+curl -s "$EXT?date=$(date +%F)" -H "$H"
+```
+
+**Expected**: still a single `cal-evt-1` entry, now with the updated `end_time` (no duplicate).
+
+## Scenario C — Validation (400)
+
+```bash
+# missing entity
+-d '{"external_id":"x","type":"app","start_time":1,"end_time":2}'
+# bad type
+-d '{"external_id":"x","entity":"e","type":"meeting","start_time":1,"end_time":2}'
+# end before start
+-d '{"external_id":"x","entity":"e","type":"app","start_time":5,"end_time":1}'
+```
+
+**Expected**: each returns 400; nothing stored.
+
+## Scenario D — Bulk create (all-or-nothing)
+
+```bash
+curl -sX POST "$EXT.bulk" "${HJ[@]}" -d '[
+  {"external_id":"e1","entity":"A","type":"app","start_time":1717000000,"end_time":1717003600},
+  {"external_id":"e2","entity":"B","type":"app","start_time":1717100000,"end_time":1717103600}
+]'
+```
+
+**Expected**: 201 with `data` of length 2. Re-running with one invalid element returns 400 and writes nothing.
+
+## Scenario E — List by day
+
+```bash
+curl -s "$EXT?date=2026-05-29" -H "$H"
+curl -s "$EXT?date=2026-05-29&project=Personal" -H "$H"
+```
+
+**Expected**: entries whose `start_time` is on that local day, ascending; `project` filter narrows them. Missing `date` → 400.
+
+## Scenario F — Bulk delete
+
+```bash
+ID=$(curl -s "$EXT?date=$(date +%F)" -H "$H" | jq -r '.data[0].id')
+curl -siX DELETE "$EXT.bulk" "${HJ[@]}" -d '{"date":"'"$(date +%F)"'","ids":["'"$ID"'"]}'
+```
+
+**Expected**: 204; the entry is gone. Unknown ids in the list are ignored (still 204).
+
+## Scenario G — Coding metrics unaffected
+
+```bash
+curl -s "$BASE/users/current/stats/last_7_days" -H "$H"
+```
+
+**Expected**: `/stats` totals are unchanged by the external durations created above — they are a parallel, non-coding series.
+
+## Scenario H — Auth / isolation
+
+```bash
+curl -si "$EXT?date=2026-05-29"   # no auth → 401
+```
+
+**Expected**: 401. Another user never sees these durations.
+
+## Reverting / cleanup
+
+Removing the route + mount disables the feature without data loss. Existing rows remain; nothing else reads them.

--- a/specs/106-external-durations/research.md
+++ b/specs/106-external-durations/research.md
@@ -38,10 +38,11 @@
 
 ## Decision 4: GET is day-scoped by `start_time`
 
-**Decision**: `GET /external_durations?date=…` returns durations whose `start_time` falls within the local day (in the `timezone` query param if given, else the user's profile timezone), ordered ascending, with optional `project` / `branches` filters.
+**Decision**: `GET /external_durations?date=...` returns durations whose `start_time` falls within the local day (in the `timezone` query param if given, else the user's profile timezone), ordered ascending, with optional `project` / `branches` filters. Invalid IANA timezone values return 400.
 
 **Rationale**:
 - Mirrors `GET /heartbeats?date=` (same `getEpochBoundsForDate` helper, same timezone convention) so the two day-views behave identically.
+- Existing timezone-aware read endpoints validate the timezone query before computing local-day bounds; external durations should follow that pattern instead of letting `Intl.DateTimeFormat` throw.
 - Filtering on `start_time` (rather than overlap) is the simplest, most predictable rule and uses the existing `idx_ext_durations_user_time` index.
 
 **Alternative considered**: overlap filtering (durations spanning the day boundary). Rejected for the first cut — adds complexity for a rare case; `start_time` bucketing matches how heartbeats are listed.

--- a/specs/106-external-durations/research.md
+++ b/specs/106-external-durations/research.md
@@ -1,0 +1,59 @@
+# Research: External Durations
+
+## Decision 1: Upsert on `(user_id, external_id)`
+
+**Decision**: `createExternalDuration` and `createExternalDurationsBulk` use `INSERT … ON CONFLICT (user_id, external_id) DO UPDATE`. Re-sending the same `external_id` updates the existing row.
+
+**Rationale**:
+- External durations come from external sources (calendar, meetings) that are **synced repeatedly**. The natural key is the source's `external_id`. Idempotent upsert lets a client replay a sync without creating duplicates or having to diff first.
+- The table already declares `UNIQUE(user_id, external_id)`, signalling this exact intent.
+
+**Alternative considered**: reject duplicates with 409. Rejected — forces clients to track which events they have already pushed; worse ergonomics for a sync source.
+
+---
+
+## Decision 2: Parallel series — not aggregated into `summaries`
+
+**Decision**: External durations are exposed only through `GET /external_durations`. They are **not** folded into `summaries`; the cron aggregator is untouched.
+
+**Rationale**:
+- `summaries` back `/stats`, `/summaries`, goals, and insights — all of which mean **coding** time. Merging non-coding calendar/meeting time into them would silently inflate coding metrics and break every existing surface's meaning.
+- Keeping a parallel series is the smaller, safer change and matches the issue's "keep them as a parallel series" option. A future product decision could add an opt-in merge.
+
+**Alternative considered**: aggregate into `summaries` with a category flag. Rejected for the first cut — large blast radius on existing read paths and ambiguous product semantics.
+
+---
+
+## Decision 3: Bulk cap 100, all-or-nothing validation
+
+**Decision**: The bulk create cap is 100 (the declared `maxItems`), and validation is all-or-nothing: validate every element, and if any fails return 400 with nothing written.
+
+**Rationale**:
+- **Cap**: the OpenAPI schema (`maxItems: 100`) is the single source of truth per the SDD rule, so it wins over the issue prose's "max 25". 100 also suits calendar imports, which are bulkier than heartbeat flushes.
+- **All-or-nothing**: the declared bulk response is a flat `{data: ExternalDuration[]}` with no per-item error channel (unlike `heartbeats.bulk`'s `{responses}`), so partial success cannot be expressed. Validate-then-batch keeps the contract honest and avoids half-applied syncs.
+
+**Alternative considered**: per-item `{responses}` like heartbeats. Rejected — the declared response shape is a flat array; changing it would be a larger contract change than warranted.
+
+---
+
+## Decision 4: GET is day-scoped by `start_time`
+
+**Decision**: `GET /external_durations?date=…` returns durations whose `start_time` falls within the local day (in the `timezone` query param if given, else the user's profile timezone), ordered ascending, with optional `project` / `branches` filters.
+
+**Rationale**:
+- Mirrors `GET /heartbeats?date=` (same `getEpochBoundsForDate` helper, same timezone convention) so the two day-views behave identically.
+- Filtering on `start_time` (rather than overlap) is the simplest, most predictable rule and uses the existing `idx_ext_durations_user_time` index.
+
+**Alternative considered**: overlap filtering (durations spanning the day boundary). Rejected for the first cut — adds complexity for a rare case; `start_time` bucketing matches how heartbeats are listed.
+
+---
+
+## Decision 5: Delete by id within day, unknown ids ignored
+
+**Decision**: `DELETE .bulk` with `{date, ids}` deletes the user's durations whose `id ∈ ids` and whose `start_time` is on `date`. Unknown / unowned ids are silently ignored.
+
+**Rationale**:
+- Mirrors `DELETE /heartbeats.bulk` (id + date + `user_id` scoping). Ignoring unknown ids makes deletion idempotent and avoids leaking which ids exist.
+- The `date` guard keeps deletion symmetric with the day-scoped GET.
+
+**Alternative considered**: 404 when any id is missing. Rejected — leaks existence and breaks idempotent re-deletes.

--- a/specs/106-external-durations/spec.md
+++ b/specs/106-external-durations/spec.md
@@ -70,6 +70,7 @@ As an authenticated user, I want to remove external durations I no longer want.
 - **Cross-user `external_id` collision**: none — the unique key is `(user_id, external_id)`, scoped per user.
 - **Bulk with duplicate `external_id` within one request**: the last one wins after the upserts apply; not an error.
 - **Timezone**: `date` is interpreted in the `timezone` query param if provided, else the user's profile timezone (same as `GET /heartbeats`).
+- **Invalid timezone**: unrecognised IANA timezone values return 400 instead of falling through to a worker exception.
 - **Unknown ids in delete**: silently ignored (delete is scoped by `id IN (…) AND user_id`).
 
 ---
@@ -81,7 +82,7 @@ As an authenticated user, I want to remove external durations I no longer want.
 - **FR-001**: `POST /api/v1/users/current/external_durations` MUST create one external duration and return `201` with `{data: ExternalDuration}`. It MUST upsert on `(user_id, external_id)` (re-sent `external_id` updates in place).
 - **FR-002**: The server MUST generate `id` and `created_at`; `user_id` comes from the session. Validation: `external_id`, `entity`, `type ∈ {file,app,domain}`, `start_time`, `end_time` required and numeric; `end_time` ≥ `start_time`. Violations → 400, nothing stored.
 - **FR-003**: `POST /api/v1/users/current/external_durations.bulk` MUST validate every element first and, only if all pass, upsert them in one batch returning `{data: ExternalDuration[]}` (201). Any invalid element → 400, nothing written. > 100 elements → 400.
-- **FR-004**: `GET /api/v1/users/current/external_durations?date=YYYY-MM-DD` MUST return the user's durations whose `start_time` is within that local day, ordered by `start_time` ascending, as `{data: ExternalDuration[]}`. Optional `project` and `branches` (comma-separated) filter further. Missing/invalid `date` → 400.
+- **FR-004**: `GET /api/v1/users/current/external_durations?date=YYYY-MM-DD` MUST return the user's durations whose `start_time` is within that local day, ordered by `start_time` ascending, as `{data: ExternalDuration[]}`. Optional `project` and `branches` (comma-separated) filter further. Missing/invalid `date` or invalid `timezone` -> 400.
 - **FR-005**: `DELETE /api/v1/users/current/external_durations.bulk` with `{date, ids}` MUST delete the user's matching durations on that day and return `204`. Unknown/unowned ids are ignored. Malformed body → 400.
 - **FR-006**: All endpoints MUST require authentication (401) and be strictly scoped by `user_id`.
 - **FR-007**: External durations MUST NOT be aggregated into `summaries`; the cron aggregator is unchanged. They are exposed only via `GET /external_durations`.

--- a/specs/106-external-durations/spec.md
+++ b/specs/106-external-durations/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: External Durations
+
+**Feature Branch**: `106-external-durations`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: The `external_durations` D1 table and four OpenAPI operations (`getExternalDurations`, `createExternalDuration`, `createExternalDurationsBulk`, `deleteExternalDurationsBulk`) are declared, but no route is mounted.
+
+## Background
+
+External durations let a user push **non-coding** time into the same timeline — calendar events, meeting blocks, manually logged planning time — typically synced from an external source (Google Calendar, Zoom, etc.). Each entry carries an `external_id` from its source system so syncs are replayable.
+
+This feature wires the four declared operations to handlers backed by the existing `external_durations` table. It is **low priority** for single-user (only useful when a user actively pipes external time), but the table and contract already exist, so wiring them is small and self-contained.
+
+## Spec-level decisions (resolved in this PR)
+
+- **Idempotent on `(user_id, external_id)`**: create / bulk-create upsert on the existing unique constraint, so re-syncing the same source event updates in place instead of erroring or duplicating.
+- **Parallel series, not merged into `summaries`**: external durations are non-coding time. Folding them into `summaries` would contaminate the coding metrics behind `/stats`, `/summaries`, goals, and insights. They stay a separate series exposed only by `GET /external_durations`. The cron aggregator is **not** touched.
+- **Bulk cap = 100**: the declared schema says `maxItems: 100`. Per the SDD rule (OpenAPI is the single source of truth) this wins over the issue's prose "max 25"; 100 also suits calendar imports.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Push external time (Priority: P2)
+
+As an authenticated user, I want to create external durations (single or batch) so my non-coding time appears alongside my coding timeline.
+
+**Independent Test**: `POST /external_durations` with a valid body returns 201 with the stored row (server `id`, `user_id`, `created_at`). Re-POST the same `external_id` with a new `end_time`; the row updates in place (no duplicate, same `id` row by `external_id`).
+
+**Acceptance Scenarios**:
+1. **Given** a valid body, **When** POSTing, **Then** 201 with `{data: ExternalDuration}` echoing the input plus server fields.
+2. **Given** a duplicate `external_id`, **When** POSTing again, **Then** the existing `(user_id, external_id)` row is updated (idempotent), not duplicated.
+3. **Given** a body missing a required field / unknown `type` / `end_time` < `start_time`, **When** POSTing, **Then** 400 and nothing stored.
+4. **Given** a bulk array, **When** POSTing to `.bulk`, **Then** 201 with `{data: ExternalDuration[]}` for all items.
+5. **Given** a bulk array with one invalid element, **When** POSTing, **Then** 400 and **nothing** is written (all-or-nothing).
+6. **Given** > 100 items, **When** POSTing to `.bulk`, **Then** 400.
+7. **Given** an unauthenticated request, **Then** 401 and nothing stored.
+
+---
+
+### User Story 2 - List external time for a day (Priority: P2)
+
+As an authenticated user, I want to list a day's external durations so a client can render them.
+
+**Independent Test**: Seed durations across two days. `GET /external_durations?date=YYYY-MM-DD` returns only the entries whose `start_time` is on that day (in the user's timezone), ordered ascending.
+
+**Acceptance Scenarios**:
+1. **Given** durations on several days, **When** listing for one `date`, **Then** only that day's entries (by `start_time`) return, ascending.
+2. **Given** `project` / `branches` filters, **When** listing, **Then** only matching entries return.
+3. **Given** no `date`, **When** listing, **Then** 400.
+4. **Given** another user's durations, **When** listing, **Then** none appear.
+5. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 3 - Delete external time (Priority: P2)
+
+As an authenticated user, I want to remove external durations I no longer want.
+
+**Acceptance Scenarios**:
+1. **Given** owned durations, **When** `DELETE .bulk` with `{date, ids}`, **Then** matching rows on that day are removed; 204.
+2. **Given** ids not owned / unknown, **When** deleting, **Then** they are ignored (no error); owned matches still deleted; 204.
+3. **Given** a malformed body (no `date`/`ids`, bad `date`), **Then** 400.
+4. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### Edge Cases
+
+- **`end_time` == `start_time`**: allowed (zero-length marker). `end_time` < `start_time` → 400.
+- **`type` outside `file|app|domain`**: 400.
+- **Cross-user `external_id` collision**: none — the unique key is `(user_id, external_id)`, scoped per user.
+- **Bulk with duplicate `external_id` within one request**: the last one wins after the upserts apply; not an error.
+- **Timezone**: `date` is interpreted in the `timezone` query param if provided, else the user's profile timezone (same as `GET /heartbeats`).
+- **Unknown ids in delete**: silently ignored (delete is scoped by `id IN (…) AND user_id`).
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `POST /api/v1/users/current/external_durations` MUST create one external duration and return `201` with `{data: ExternalDuration}`. It MUST upsert on `(user_id, external_id)` (re-sent `external_id` updates in place).
+- **FR-002**: The server MUST generate `id` and `created_at`; `user_id` comes from the session. Validation: `external_id`, `entity`, `type ∈ {file,app,domain}`, `start_time`, `end_time` required and numeric; `end_time` ≥ `start_time`. Violations → 400, nothing stored.
+- **FR-003**: `POST /api/v1/users/current/external_durations.bulk` MUST validate every element first and, only if all pass, upsert them in one batch returning `{data: ExternalDuration[]}` (201). Any invalid element → 400, nothing written. > 100 elements → 400.
+- **FR-004**: `GET /api/v1/users/current/external_durations?date=YYYY-MM-DD` MUST return the user's durations whose `start_time` is within that local day, ordered by `start_time` ascending, as `{data: ExternalDuration[]}`. Optional `project` and `branches` (comma-separated) filter further. Missing/invalid `date` → 400.
+- **FR-005**: `DELETE /api/v1/users/current/external_durations.bulk` with `{date, ids}` MUST delete the user's matching durations on that day and return `204`. Unknown/unowned ids are ignored. Malformed body → 400.
+- **FR-006**: All endpoints MUST require authentication (401) and be strictly scoped by `user_id`.
+- **FR-007**: External durations MUST NOT be aggregated into `summaries`; the cron aggregator is unchanged. They are exposed only via `GET /external_durations`.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Bulk create MUST use a single `db.batch()` (one statement per element); no per-row round-trip. Bounded at 100 elements.
+- **NFR-002**: No D1 schema migration; the `external_durations` table already exists with `UNIQUE(user_id, external_id)`.
+- **NFR-003**: GET MUST issue a single indexed `SELECT` (the `idx_ext_durations_user_time` index covers `user_id, start_time`).
+
+### Key Entities *(no schema change)*
+
+`external_durations` (`id`, `user_id`, `external_id`, `entity`, `type`, `category`, `start_time`, `end_time`, `project`, `branch`, `language`, `meta`, `created_at`, `UNIQUE(user_id, external_id)`, `ON DELETE CASCADE`). Response uses the existing `ExternalDuration` / `ExternalDurationInput` schemas.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Create, bulk-create, list-by-day, and bulk-delete all work end-to-end against a seeded DB.
+- **SC-002**: Re-sending an `external_id` updates rather than duplicates.
+- **SC-003**: A bulk request with one invalid element writes nothing and returns 400.
+- **SC-004**: Listing is day-scoped and user-scoped; cross-user never leaks.
+- **SC-005**: `/stats` and `/summaries` are unchanged by the presence of external durations.
+
+## Out of Scope
+
+- **Aggregating external durations into summaries / stats / insights.** Parallel series only (FR-007).
+- **A live calendar/Zoom integration.** This endpoint accepts pushed data; the source-side sync is a separate concern.
+- **Per-id single DELETE.** Deletion is via the declared `.bulk` operation only.
+- **Overlap/merge logic** between external durations and heartbeats.

--- a/specs/106-external-durations/tasks.md
+++ b/specs/106-external-durations/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: External Durations
+
+**Branch**: `106-external-durations`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (3 stories, FR-001..FR-007, edge cases, spec-level decisions).
+- [x] **T-002**: Author `plan.md` (Constitution Check, validation + SQL sketches).
+- [x] **T-003**: Author `research.md` (5 documented decisions).
+- [x] **T-004**: Author `data-model.md` (existing table; upsert/list/delete statements).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–H).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add `400` responses + descriptions to both external-duration path files (keep `maxItems: 100`).
+- [x] **T-009**: Run `npm run generate`; verify the 400 responses appear and no body type-shape change; run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Validation
+
+- [ ] **T-101**: `src/utils/external-duration-input.ts` — `validateExternalDuration(body)` → `{ ok, value | error }` (required `external_id`/`entity`, `type ∈ file|app|domain`, numeric `start_time`/`end_time`, `end_time ≥ start_time`, optional strings).
+- [ ] **T-102**: Unit tests for the validator.
+
+### Route
+
+- [ ] **T-103**: `src/routes/external-durations.ts` — Hono sub-app, all four handlers behind `authMiddleware`:
+  - `POST /external_durations` (validate → upsert → `201 {data}`)
+  - `POST /external_durations.bulk` (validate all ≤100 → `db.batch` upsert → `201 {data[]}`; any invalid → 400)
+  - `GET /external_durations?date=` (day bounds via `getEpochBoundsForDate`, `project`/`branches` filters, `400` bad date)
+  - `DELETE /external_durations.bulk` (`{date, ids}`, scoped delete, `204`, `400` bad body)
+- [ ] **T-104**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", externalDurations)`.
+
+### Tests
+
+- [ ] **T-105**: `tests/integration/external-durations.test.ts` — create/upsert, bulk all-or-nothing, list-by-day + filters, bulk delete + unknown-id ignore, cross-user, 401; assert `/stats` unaffected.
+
+### Verification
+
+- [ ] **T-106**: `npm run typecheck` — zero errors.
+- [ ] **T-107**: `npm test` — full suite green incl. new unit + integration.
+- [ ] **T-108**: Manual run of `quickstart.md` A / B / D / G against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-109**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #106.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010              (PR1)
+T-010 → T-101 .. T-109              (PR2 after PR1 merge)
+T-101 → T-102 ; T-101 → T-103 → T-104
+T-103 / T-104 → T-105 → T-106 → T-107 → T-108 → T-109
+```
+
+## Out of scope
+
+- Aggregating external durations into `summaries` / stats / insights.
+- A live calendar / Zoom sync integration (source side).
+- Per-id single DELETE (bulk only).
+- Overlap/merge logic with heartbeats.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -900,7 +900,8 @@ export interface paths {
          *     falls on `date`, ordered by `start_time` ascending. `date` is interpreted
          *     in the `timezone` query param when supplied, otherwise the user's profile
          *     timezone (same convention as `GET /heartbeats`). Optional `project` and
-         *     `branches` (comma-separated) further filter the results.
+         *     `branches` (comma-separated) further filter the results. Missing or
+         *     malformed `date`, or an invalid IANA `timezone`, returns 400.
          *
          *     External durations are a parallel, non-coding time series — they are
          *     **not** aggregated into `summaries`, so they do not affect `/stats`,
@@ -3184,6 +3185,7 @@ export interface operations {
                 date: string;
                 project?: string;
                 branches?: string;
+                /** @description IANA timezone (e.g. Asia/Tokyo). Determines the local-day bounds for `date`. Defaults to the authenticated user's profile timezone when omitted. */
                 timezone?: string;
             };
             header?: never;

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -894,10 +894,28 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List external durations for a day */
+        /**
+         * List external durations for a day
+         * @description Returns the authenticated user's external durations whose `start_time`
+         *     falls on `date`, ordered by `start_time` ascending. `date` is interpreted
+         *     in the `timezone` query param when supplied, otherwise the user's profile
+         *     timezone (same convention as `GET /heartbeats`). Optional `project` and
+         *     `branches` (comma-separated) further filter the results.
+         *
+         *     External durations are a parallel, non-coding time series — they are
+         *     **not** aggregated into `summaries`, so they do not affect `/stats`,
+         *     `/summaries`, goals, or insights.
+         */
         get: operations["getExternalDurations"];
         put?: never;
-        /** Create a single external duration */
+        /**
+         * Create a single external duration
+         * @description Creates one external duration and returns it. Idempotent on
+         *     `(user_id, external_id)`: re-sending the same `external_id` updates the
+         *     existing row in place (so calendar/meeting syncs can be replayed safely).
+         *     Validation failures (missing required fields, unknown `type`, or
+         *     `end_time` < `start_time`) return 400.
+         */
         post: operations["createExternalDuration"];
         delete?: never;
         options?: never;
@@ -914,9 +932,23 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create up to 100 external durations */
+        /**
+         * Create up to 100 external durations
+         * @description Batch-creates external durations (all-or-nothing): every element is
+         *     validated first, and any invalid element returns 400 with nothing
+         *     written. Each element is idempotent on `(user_id, external_id)` — a
+         *     re-sent `external_id` updates the existing row. Returns the persisted
+         *     rows. The cap is 100 per request (larger than the heartbeat bulk cap, to
+         *     suit calendar imports).
+         */
         post: operations["createExternalDurationsBulk"];
-        /** Delete external durations */
+        /**
+         * Delete external durations
+         * @description Deletes the listed external durations (by `id`) whose `start_time` falls
+         *     on `date`, scoped to the authenticated user. Returns 204. A malformed
+         *     body (missing `date`/`ids`, or invalid `date`) returns 400. Unknown ids
+         *     are ignored.
+         */
         delete: operations["deleteExternalDurationsBulk"];
         options?: never;
         head?: never;
@@ -3171,6 +3203,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };
@@ -3198,6 +3231,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };
@@ -3225,6 +3259,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };
@@ -3252,6 +3287,7 @@ export interface operations {
                 };
                 content?: never;
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };


### PR DESCRIPTION
## Summary

Spec-first PR1 for **External Durations** (issue #106) — calendar / non-coding time tracking. The four operations (`getExternalDurations`, `createExternalDuration`, `createExternalDurationsBulk`, `deleteExternalDurationsBulk`) and the `ExternalDuration`/`ExternalDurationInput` schemas already existed; this PR adds the missing `400` responses, documents behavior, and lands the SpecKit design. **No implementation code** — handlers land in PR2.

## Spec-level decisions

- **Idempotent upsert on `(user_id, external_id)`** — re-syncing the same source event updates in place (calendar/meeting syncs are replayable).
- **Parallel series, not merged into `summaries`** — external durations are non-coding time; folding them into `summaries` would inflate the coding metrics behind `/stats`, `/summaries`, goals, and insights. The cron aggregator is untouched; they are exposed only via `GET /external_durations`.
- **Bulk cap = 100** — the declared `maxItems: 100` is kept. Per AGENTS.md the OpenAPI is the single source of truth, so it supersedes the issue prose's "max 25" (and 100 suits calendar imports).
- **Bulk create is all-or-nothing** — the declared response is a flat `{data: ExternalDuration[]}` (no per-item error channel), so validate-all-then-write; any invalid element -> 400, nothing stored.
- **GET is day-scoped by `start_time`** in the user's (or `timezone` query) timezone, with `project`/`branches` filters. Missing/bad `date` or invalid IANA `timezone` -> 400.

## What's in this PR

- **OpenAPI** — add `400` (BadRequest) to all four operations; document upsert idempotency, day-scoping, invalid timezone behavior, all-or-nothing bulk, and the parallel-series note.
- **Generated types** — adds the 400 responses + JSDoc; no request/response body type-shape change.
- **SpecKit artifacts** under `specs/106-external-durations/`.

## No schema migration

Uses the existing `external_durations` table (`UNIQUE(user_id, external_id)`, `idx_ext_durations_user_time`).

## Test plan

- [x] `npm run generate`
- [x] `npm run lint:api`
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] PR2: validation helper, four handlers, integration tests (incl. `/stats` unaffected)
