### PR TITLE
feat: External Durations endpoints (PR2/2) #106

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import users from "./routes/users";
 import goals from "./routes/goals";
 import customRules from "./routes/custom-rules";
 import insights from "./routes/insights";
+import externalDurations from "./routes/external-durations";
 import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
@@ -133,6 +134,9 @@ app.route("/api/v1/users/current", customRules);
 
 // Insights routes (mounted at /users/current, sub-app defines /insights/:insight_type/:range)
 app.route("/api/v1/users/current", insights);
+
+// External durations routes (mounted at /users/current, sub-app defines /external_durations, /external_durations.bulk)
+app.route("/api/v1/users/current", externalDurations);
 
 // Machine names routes (mounted at /users/current, sub-app defines /machine_names)
 app.route("/api/v1/users/current", machines);

--- a/src/routes/external-durations.ts
+++ b/src/routes/external-durations.ts
@@ -56,6 +56,17 @@ ON CONFLICT (user_id, external_id) DO UPDATE SET
   meta = excluded.meta
 RETURNING ${RETURNING_COLUMNS}`;
 
+function parseDateString(date: string): boolean {
+  if (!DATE_RE.test(date)) return false;
+  const [y, m, d] = date.split("-").map(Number);
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  return (
+    utc.getUTCFullYear() === y &&
+    utc.getUTCMonth() === m - 1 &&
+    utc.getUTCDate() === d
+  );
+}
+
 function upsertStmt(
   db: D1Database,
   userId: string,
@@ -104,7 +115,7 @@ externalDurations.get("/external_durations", async (c) => {
   const userId = c.get("userId");
 
   const date = c.req.query("date");
-  if (!date || !DATE_RE.test(date)) {
+  if (!date || !parseDateString(date)) {
     return c.json({ error: "date query parameter is required (YYYY-MM-DD)" }, 400);
   }
   const tzParam = c.req.query("timezone");
@@ -232,7 +243,7 @@ externalDurations.delete("/external_durations.bulk", async (c) => {
 
   const date = body.date;
   const ids = body.ids;
-  if (typeof date !== "string" || !DATE_RE.test(date)) {
+  if (typeof date !== "string" || !parseDateString(date)) {
     return c.json({ error: "date is required (YYYY-MM-DD)" }, 400);
   }
   if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => typeof id === "string" && id.length > 0)) {

--- a/src/routes/external-durations.ts
+++ b/src/routes/external-durations.ts
@@ -1,0 +1,260 @@
+/**
+ * External durations — calendar / non-coding time (specs/106-external-durations/).
+ *
+ * A parallel, non-coding time series: create/bulk-create upsert on
+ * (user_id, external_id) so syncs are idempotent; list is day-scoped by
+ * start_time; bulk delete removes by id within a day. NOT aggregated into
+ * summaries — the cron aggregator is untouched.
+ */
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware, getUserTimezone } from "../middleware/auth";
+import { getEpochBoundsForDate, isValidTimezone } from "../utils/time-format";
+import { normalizeDateTime } from "../utils/user";
+import {
+  validateExternalDuration,
+  type ValidatedExternalDuration,
+} from "../utils/external-duration-input";
+
+type ExternalDuration = components["schemas"]["ExternalDuration"];
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_BULK = 100;
+
+interface ExternalDurationRow {
+  id: string;
+  user_id: string;
+  external_id: string;
+  entity: string;
+  type: string;
+  category: string | null;
+  start_time: number;
+  end_time: number;
+  project: string | null;
+  branch: string | null;
+  language: string | null;
+  meta: string | null;
+  created_at: string;
+}
+
+const RETURNING_COLUMNS =
+  "id, user_id, external_id, entity, type, category, start_time, end_time, project, branch, language, meta, created_at";
+
+const UPSERT_SQL = `INSERT INTO external_durations
+  (id, user_id, external_id, entity, type, category, start_time, end_time, project, branch, language, meta)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (user_id, external_id) DO UPDATE SET
+  entity = excluded.entity,
+  type = excluded.type,
+  category = excluded.category,
+  start_time = excluded.start_time,
+  end_time = excluded.end_time,
+  project = excluded.project,
+  branch = excluded.branch,
+  language = excluded.language,
+  meta = excluded.meta
+RETURNING ${RETURNING_COLUMNS}`;
+
+function upsertStmt(
+  db: D1Database,
+  userId: string,
+  v: ValidatedExternalDuration,
+): D1PreparedStatement {
+  return db.prepare(UPSERT_SQL).bind(
+    crypto.randomUUID(),
+    userId,
+    v.external_id,
+    v.entity,
+    v.type,
+    v.category,
+    v.start_time,
+    v.end_time,
+    v.project,
+    v.branch,
+    v.language,
+    v.meta,
+  );
+}
+
+function rowToExternalDuration(row: ExternalDurationRow): ExternalDuration {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    external_id: row.external_id,
+    entity: row.entity,
+    type: row.type as ExternalDuration["type"],
+    category: (row.category ?? undefined) as ExternalDuration["category"],
+    start_time: row.start_time,
+    end_time: row.end_time,
+    project: row.project ?? undefined,
+    branch: row.branch ?? undefined,
+    language: row.language ?? undefined,
+    meta: row.meta ?? undefined,
+    created_at: normalizeDateTime(row.created_at),
+  };
+}
+
+const externalDurations = new Hono<AuthEnv>();
+
+externalDurations.use("/external_durations", authMiddleware);
+externalDurations.use("/external_durations.bulk", authMiddleware);
+
+externalDurations.get("/external_durations", async (c) => {
+  const userId = c.get("userId");
+
+  const date = c.req.query("date");
+  if (!date || !DATE_RE.test(date)) {
+    return c.json({ error: "date query parameter is required (YYYY-MM-DD)" }, 400);
+  }
+  const tzParam = c.req.query("timezone");
+  if (tzParam !== undefined && !isValidTimezone(tzParam)) {
+    return c.json({ error: "Invalid timezone" }, 400);
+  }
+  const tz = tzParam ?? (await getUserTimezone(c));
+  const { start, end } = getEpochBoundsForDate(date, tz);
+
+  const conditions = ["user_id = ?", "start_time >= ?", "start_time < ?"];
+  const binds: (string | number)[] = [userId, start, end];
+
+  const project = c.req.query("project");
+  if (project !== undefined) {
+    conditions.push("project = ?");
+    binds.push(project);
+  }
+  const branches = c.req.query("branches");
+  if (branches !== undefined) {
+    const list = branches.split(",").map((b) => b.trim()).filter((b) => b.length > 0);
+    if (list.length > 0) {
+      conditions.push(`branch IN (${list.map(() => "?").join(", ")})`);
+      binds.push(...list);
+    }
+  }
+
+  try {
+    const { results } = await c.env.DB.prepare(
+      `SELECT ${RETURNING_COLUMNS} FROM external_durations
+        WHERE ${conditions.join(" AND ")}
+        ORDER BY start_time ASC`,
+    )
+      .bind(...binds)
+      .all<ExternalDurationRow>();
+    return c.json({ data: results.map(rowToExternalDuration) });
+  } catch (err) {
+    console.error("GET /external_durations error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+externalDurations.post("/external_durations", async (c) => {
+  const userId = c.get("userId");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const parsed = validateExternalDuration(body);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+
+  try {
+    const row = await upsertStmt(c.env.DB, userId, parsed.value).first<ExternalDurationRow>();
+    if (!row) {
+      console.error("POST /external_durations error: upsert returned no row");
+      return c.json({ error: "Internal server error" }, 500);
+    }
+    return c.json({ data: rowToExternalDuration(row) }, 201);
+  } catch (err) {
+    console.error("POST /external_durations error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+externalDurations.post("/external_durations.bulk", async (c) => {
+  const userId = c.get("userId");
+
+  let inputs: unknown;
+  try {
+    inputs = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  if (!Array.isArray(inputs)) {
+    return c.json({ error: "Request body must be an array" }, 400);
+  }
+  if (inputs.length > MAX_BULK) {
+    return c.json({ error: `Maximum ${MAX_BULK} external durations per request` }, 400);
+  }
+
+  // All-or-nothing: validate every element before writing anything.
+  const validated: ValidatedExternalDuration[] = [];
+  for (let i = 0; i < inputs.length; i++) {
+    const parsed = validateExternalDuration(inputs[i]);
+    if (!parsed.ok) {
+      return c.json({ error: `item ${i}: ${parsed.error}` }, 400);
+    }
+    validated.push(parsed.value);
+  }
+
+  if (validated.length === 0) {
+    return c.json({ data: [] }, 201);
+  }
+
+  try {
+    const batchResults = await c.env.DB.batch<ExternalDurationRow>(
+      validated.map((v) => upsertStmt(c.env.DB, userId, v)),
+    );
+    const data = batchResults
+      .map((res) => res.results?.[0])
+      .filter((row): row is ExternalDurationRow => row !== undefined)
+      .map(rowToExternalDuration);
+    return c.json({ data }, 201);
+  } catch (err) {
+    console.error("POST /external_durations.bulk error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+externalDurations.delete("/external_durations.bulk", async (c) => {
+  const userId = c.get("userId");
+
+  let body: { date?: unknown; ids?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const date = body.date;
+  const ids = body.ids;
+  if (typeof date !== "string" || !DATE_RE.test(date)) {
+    return c.json({ error: "date is required (YYYY-MM-DD)" }, 400);
+  }
+  if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => typeof id === "string" && id.length > 0)) {
+    return c.json({ error: "ids must be a non-empty array of strings" }, 400);
+  }
+
+  const tz = await getUserTimezone(c);
+  const { start, end } = getEpochBoundsForDate(date, tz);
+
+  try {
+    const placeholders = ids.map(() => "?").join(", ");
+    await c.env.DB.prepare(
+      `DELETE FROM external_durations
+        WHERE user_id = ? AND start_time >= ? AND start_time < ? AND id IN (${placeholders})`,
+    )
+      .bind(userId, start, end, ...ids)
+      .run();
+    return c.body(null, 204);
+  } catch (err) {
+    console.error("DELETE /external_durations.bulk error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default externalDurations;

--- a/src/utils/external-duration-input.ts
+++ b/src/utils/external-duration-input.ts
@@ -4,10 +4,35 @@
  * Pure: turns an untrusted parsed JSON value into a normalised row ready to
  * upsert, or a 400-worthy error. No D1, no I/O.
  */
+import type { components } from "../types/generated";
 
 export type ExternalDurationType = "file" | "app" | "domain";
+type Category = components["schemas"]["Category"];
 
 const TYPES = new Set<string>(["file", "app", "domain"]);
+const VALID_CATEGORIES = new Set<string>([
+  "coding",
+  "building",
+  "indexing",
+  "debugging",
+  "browsing",
+  "running tests",
+  "writing tests",
+  "manual testing",
+  "writing docs",
+  "communicating",
+  "code reviewing",
+  "notes",
+  "researching",
+  "learning",
+  "designing",
+  "ai coding",
+  "advising",
+  "meeting",
+  "planning",
+  "supporting",
+  "translating",
+]);
 
 export interface ValidatedExternalDuration {
   external_id: string;
@@ -15,7 +40,7 @@ export interface ValidatedExternalDuration {
   type: ExternalDurationType;
   start_time: number;
   end_time: number;
-  category: string | null;
+  category: Category | null;
   project: string | null;
   branch: string | null;
   language: string | null;
@@ -58,7 +83,15 @@ export function validateExternalDuration(body: unknown): ValidationResult<Valida
   if (r.end_time < r.start_time) {
     return fail("end_time must be greater than or equal to start_time");
   }
-  for (const field of ["category", "project", "branch", "language", "meta"] as const) {
+  if (r.category !== undefined && r.category !== null) {
+    if (typeof r.category !== "string") {
+      return fail("category must be a string");
+    }
+    if (!VALID_CATEGORIES.has(r.category)) {
+      return fail(`category must be one of: ${[...VALID_CATEGORIES].join(", ")}`);
+    }
+  }
+  for (const field of ["project", "branch", "language", "meta"] as const) {
     if (r[field] !== undefined && r[field] !== null && typeof r[field] !== "string") {
       return fail(`${field} must be a string`);
     }
@@ -72,7 +105,7 @@ export function validateExternalDuration(body: unknown): ValidationResult<Valida
       type: r.type as ExternalDurationType,
       start_time: r.start_time,
       end_time: r.end_time,
-      category: optionalString(r.category),
+      category: (r.category ?? null) as Category | null,
       project: optionalString(r.project),
       branch: optionalString(r.branch),
       language: optionalString(r.language),

--- a/src/utils/external-duration-input.ts
+++ b/src/utils/external-duration-input.ts
@@ -1,0 +1,82 @@
+/**
+ * Validation for the external-duration request bodies (specs/106-external-durations/).
+ *
+ * Pure: turns an untrusted parsed JSON value into a normalised row ready to
+ * upsert, or a 400-worthy error. No D1, no I/O.
+ */
+
+export type ExternalDurationType = "file" | "app" | "domain";
+
+const TYPES = new Set<string>(["file", "app", "domain"]);
+
+export interface ValidatedExternalDuration {
+  external_id: string;
+  entity: string;
+  type: ExternalDurationType;
+  start_time: number;
+  end_time: number;
+  category: string | null;
+  project: string | null;
+  branch: string | null;
+  language: string | null;
+  meta: string | null;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function fail(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+function optionalString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+export function validateExternalDuration(body: unknown): ValidationResult<ValidatedExternalDuration> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return fail("Request body must be a JSON object");
+  }
+  const r = body as Record<string, unknown>;
+
+  if (typeof r.external_id !== "string" || r.external_id.length === 0) {
+    return fail("external_id is required and must be a non-empty string");
+  }
+  if (typeof r.entity !== "string" || r.entity.length === 0) {
+    return fail("entity is required and must be a non-empty string");
+  }
+  if (!TYPES.has(r.type as string)) {
+    return fail("type must be one of file, app, domain");
+  }
+  if (typeof r.start_time !== "number" || !Number.isFinite(r.start_time)) {
+    return fail("start_time must be a number");
+  }
+  if (typeof r.end_time !== "number" || !Number.isFinite(r.end_time)) {
+    return fail("end_time must be a number");
+  }
+  if (r.end_time < r.start_time) {
+    return fail("end_time must be greater than or equal to start_time");
+  }
+  for (const field of ["category", "project", "branch", "language", "meta"] as const) {
+    if (r[field] !== undefined && r[field] !== null && typeof r[field] !== "string") {
+      return fail(`${field} must be a string`);
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      external_id: r.external_id,
+      entity: r.entity,
+      type: r.type as ExternalDurationType,
+      start_time: r.start_time,
+      end_time: r.end_time,
+      category: optionalString(r.category),
+      project: optionalString(r.project),
+      branch: optionalString(r.branch),
+      language: optionalString(r.language),
+      meta: optionalString(r.meta),
+    },
+  };
+}

--- a/tests/aggregation/external-duration-input.test.ts
+++ b/tests/aggregation/external-duration-input.test.ts
@@ -46,6 +46,10 @@ describe("validateExternalDuration", () => {
     expect(validateExternalDuration({ ...valid, type: "meeting" }).ok).toBe(false);
   });
 
+  it("rejects an unknown category", () => {
+    expect(validateExternalDuration({ ...valid, category: "not-a-category" }).ok).toBe(false);
+  });
+
   it("rejects non-numeric or reversed times", () => {
     expect(validateExternalDuration({ ...valid, start_time: "1" as unknown as number }).ok).toBe(false);
     expect(validateExternalDuration({ ...valid, end_time: valid.start_time - 1 }).ok).toBe(false);

--- a/tests/aggregation/external-duration-input.test.ts
+++ b/tests/aggregation/external-duration-input.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for src/utils/external-duration-input.ts (specs/106-external-durations/).
+ * Pure validation — no D1.
+ */
+import { describe, expect, it } from "vitest";
+import { validateExternalDuration } from "../../src/utils/external-duration-input";
+
+const valid = {
+  external_id: "evt-1",
+  entity: "Standup",
+  type: "app",
+  start_time: 1_717_000_000,
+  end_time: 1_717_000_900,
+};
+
+describe("validateExternalDuration", () => {
+  it("accepts a valid body and normalises optional fields to null", () => {
+    const r = validateExternalDuration(valid);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.external_id).toBe("evt-1");
+    expect(r.value.type).toBe("app");
+    expect(r.value.category).toBeNull();
+    expect(r.value.project).toBeNull();
+  });
+
+  it("keeps provided optional strings", () => {
+    const r = validateExternalDuration({ ...valid, category: "meeting", project: "Personal" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.category).toBe("meeting");
+      expect(r.value.project).toBe("Personal");
+    }
+  });
+
+  it("allows end_time == start_time (zero-length marker)", () => {
+    expect(validateExternalDuration({ ...valid, end_time: valid.start_time }).ok).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(validateExternalDuration({ ...valid, external_id: undefined }).ok).toBe(false);
+    expect(validateExternalDuration({ ...valid, entity: "" }).ok).toBe(false);
+  });
+
+  it("rejects an unknown type", () => {
+    expect(validateExternalDuration({ ...valid, type: "meeting" }).ok).toBe(false);
+  });
+
+  it("rejects non-numeric or reversed times", () => {
+    expect(validateExternalDuration({ ...valid, start_time: "1" as unknown as number }).ok).toBe(false);
+    expect(validateExternalDuration({ ...valid, end_time: valid.start_time - 1 }).ok).toBe(false);
+  });
+
+  it("rejects a non-object body", () => {
+    expect(validateExternalDuration(null).ok).toBe(false);
+    expect(validateExternalDuration([valid]).ok).toBe(false);
+  });
+
+  it("rejects a non-string optional field", () => {
+    expect(validateExternalDuration({ ...valid, project: 5 as unknown as string }).ok).toBe(false);
+  });
+});

--- a/tests/integration/external-durations.test.ts
+++ b/tests/integration/external-durations.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for the External Durations endpoints
+ * (specs/106-external-durations/): create/upsert, bulk all-or-nothing,
+ * list-by-day + filters, bulk delete, isolation, auth — plus a check that
+ * /stats is unaffected (parallel series).
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const EXT = "/api/v1/users/current/external_durations";
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("external_durations", "summaries", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authJson(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+interface ExtShape {
+  id: string;
+  external_id: string;
+  entity: string;
+  start_time: number;
+  end_time: number;
+  project?: string;
+}
+
+// 2026-03-15 in UTC
+const D = "2026-03-15";
+const T0 = Math.floor(Date.UTC(2026, 2, 15, 9, 0, 0) / 1000);
+
+function body(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    external_id: "evt-1",
+    entity: "Standup",
+    type: "app",
+    start_time: T0,
+    end_time: T0 + 900,
+    ...overrides,
+  };
+}
+
+describe("POST /external_durations", () => {
+  it("creates one and echoes server fields (201)", async () => {
+    const res = await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(body()) });
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: ExtShape };
+    expect(data.id).toMatch(/[0-9a-f-]{36}/);
+    expect(data.external_id).toBe("evt-1");
+    expect(data.end_time).toBe(T0 + 900);
+  });
+
+  it("is idempotent on (user_id, external_id) — re-send updates in place", async () => {
+    await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(body()) });
+    await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(body({ end_time: T0 + 1800 })) });
+
+    const list = await call(`${EXT}?date=${D}`, { headers: bearer(user.apiKey) });
+    const { data } = (await list.json()) as { data: ExtShape[] };
+    expect(data).toHaveLength(1);
+    expect(data[0].end_time).toBe(T0 + 1800);
+  });
+
+  it("rejects invalid bodies with 400", async () => {
+    const bad = [
+      body({ entity: undefined }),
+      body({ type: "meeting" }),
+      body({ start_time: 100, end_time: 50 }),
+    ];
+    for (const b of bad) {
+      const res = await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(b) });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await call(EXT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body()),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /external_durations.bulk", () => {
+  it("creates all on success (201)", async () => {
+    const res = await call(`${EXT}.bulk`, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([body({ external_id: "a" }), body({ external_id: "b" })]),
+    });
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: ExtShape[] };
+    expect(data.map((d) => d.external_id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("is all-or-nothing: one invalid element writes nothing (400)", async () => {
+    const res = await call(`${EXT}.bulk`, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([body({ external_id: "a" }), body({ external_id: "b", type: "bad" })]),
+    });
+    expect(res.status).toBe(400);
+    const list = await call(`${EXT}?date=${D}`, { headers: bearer(user.apiKey) });
+    expect(((await list.json()) as { data: ExtShape[] }).data).toEqual([]);
+  });
+
+  it("rejects more than 100 items with 400", async () => {
+    const many = Array.from({ length: 101 }, (_, i) => body({ external_id: `e${i}` }));
+    const res = await call(`${EXT}.bulk`, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(many) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /external_durations", () => {
+  it("returns only the requested day's entries, ascending, with project filter", async () => {
+    await call(`${EXT}.bulk`, {
+      method: "POST",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify([
+        body({ external_id: "a", start_time: T0 + 200, end_time: T0 + 400, project: "X" }),
+        body({ external_id: "b", start_time: T0, end_time: T0 + 100, project: "Y" }),
+        // next day
+        body({ external_id: "c", start_time: T0 + 86400, end_time: T0 + 86500 }),
+      ]),
+    });
+
+    const res = await call(`${EXT}?date=${D}`, { headers: bearer(user.apiKey) });
+    const { data } = (await res.json()) as { data: ExtShape[] };
+    expect(data.map((d) => d.external_id)).toEqual(["b", "a"]); // ascending by start_time, day-scoped
+
+    const filtered = await call(`${EXT}?date=${D}&project=X`, { headers: bearer(user.apiKey) });
+    expect(((await filtered.json()) as { data: ExtShape[] }).data.map((d) => d.external_id)).toEqual(["a"]);
+  });
+
+  it("400s on missing date and on invalid timezone", async () => {
+    expect((await call(EXT, { headers: bearer(user.apiKey) })).status).toBe(400);
+    expect((await call(`${EXT}?date=${D}&timezone=Not/AZone`, { headers: bearer(user.apiKey) })).status).toBe(400);
+  });
+
+  it("isolates results per user", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await call(EXT, { method: "POST", headers: authJson(bob.apiKey), body: JSON.stringify(body({ external_id: "bob-evt" })) });
+
+    const res = await call(`${EXT}?date=${D}`, { headers: bearer(user.apiKey) });
+    expect(((await res.json()) as { data: ExtShape[] }).data).toEqual([]);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    expect((await call(`${EXT}?date=${D}`)).status).toBe(401);
+  });
+});
+
+describe("DELETE /external_durations.bulk", () => {
+  it("deletes by id within the day (204) and ignores unknown ids", async () => {
+    const created = await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(body()) });
+    const id = ((await created.json()) as { data: ExtShape }).data.id;
+
+    const del = await call(`${EXT}.bulk`, {
+      method: "DELETE",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ date: D, ids: [id, "does-not-exist"] }),
+    });
+    expect(del.status).toBe(204);
+
+    const list = await call(`${EXT}?date=${D}`, { headers: bearer(user.apiKey) });
+    expect(((await list.json()) as { data: ExtShape[] }).data).toEqual([]);
+  });
+
+  it("400s on a malformed body", async () => {
+    const res = await call(`${EXT}.bulk`, {
+      method: "DELETE",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ ids: ["x"] }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("parallel series", () => {
+  it("does not affect /stats totals", async () => {
+    await call(EXT, { method: "POST", headers: authJson(user.apiKey), body: JSON.stringify(body({ end_time: T0 + 100000 })) });
+    const stats = await call(`/api/v1/users/current/stats/last_7_days`, { headers: bearer(user.apiKey) });
+    const json = (await stats.json()) as { data?: { total_seconds?: number } };
+    // No summaries seeded → stats total stays 0 regardless of external durations.
+    expect(json.data?.total_seconds ?? 0).toBe(0);
+  });
+});

--- a/tests/integration/external-durations.test.ts
+++ b/tests/integration/external-durations.test.ts
@@ -90,6 +90,7 @@ describe("POST /external_durations", () => {
     const bad = [
       body({ entity: undefined }),
       body({ type: "meeting" }),
+      body({ category: "not-a-category" }),
       body({ start_time: 100, end_time: 50 }),
     ];
     for (const b of bad) {
@@ -159,8 +160,9 @@ describe("GET /external_durations", () => {
     expect(((await filtered.json()) as { data: ExtShape[] }).data.map((d) => d.external_id)).toEqual(["a"]);
   });
 
-  it("400s on missing date and on invalid timezone", async () => {
+  it("400s on missing date, invalid dates, and invalid timezone", async () => {
     expect((await call(EXT, { headers: bearer(user.apiKey) })).status).toBe(400);
+    expect((await call(`${EXT}?date=2026-02-31`, { headers: bearer(user.apiKey) })).status).toBe(400);
     expect((await call(`${EXT}?date=${D}&timezone=Not/AZone`, { headers: bearer(user.apiKey) })).status).toBe(400);
   });
 
@@ -202,6 +204,13 @@ describe("DELETE /external_durations.bulk", () => {
       body: JSON.stringify({ ids: ["x"] }),
     });
     expect(res.status).toBe(400);
+
+    const invalidDate = await call(`${EXT}.bulk`, {
+      method: "DELETE",
+      headers: authJson(user.apiKey),
+      body: JSON.stringify({ date: "2026-02-31", ids: ["x"] }),
+    });
+    expect(invalidDate.status).toBe(400);
   });
 });
 


### PR DESCRIPTION
## Summary

Implementation PR2 for **External Durations** (issue #106), following the SpecKit 2-PR workflow. Wires the four operations spec'd in #125 (merged) to handlers backed by the existing `external_durations` table — a parallel, non-coding time series.

## Endpoints

| Method | Path | Result |
|---|---|---|
| `POST` | `/users/current/external_durations` | 201 `{data}` (upsert) |
| `POST` | `/users/current/external_durations.bulk` | 201 `{data[]}` (≤100, all-or-nothing) |
| `GET` | `/users/current/external_durations?date=` | 200 `{data[]}` (day-scoped) |
| `DELETE` | `/users/current/external_durations.bulk` | 204 |

## What's in this PR

- **`src/utils/external-duration-input.ts`** — pure `validateExternalDuration` (required `external_id`/`entity`, `type ∈ file|app|domain`, numeric times, `end_time ≥ start_time`, optional strings).
- **`src/routes/external-durations.ts`**:
  - `POST` — `INSERT … ON CONFLICT (user_id, external_id) DO UPDATE … RETURNING` → idempotent upsert, 201.
  - `POST .bulk` — validate all (≤100) then one `db.batch` of upserts; **all-or-nothing** (any invalid → 400, nothing written).
  - `GET ?date=` — timezone-validated local-day bounds via `getEpochBoundsForDate`, `project`/`branches` filters, ordered by `start_time`; 400 on missing/bad `date` or invalid `timezone`.
  - `DELETE .bulk` — `{date, ids}` scoped by `user_id` within the day; unknown ids ignored; 204; 400 on bad body.
  - Mounted in `index.ts`.
- **Parallel series** — the cron aggregator and `summaries` are untouched.
- **Tests** — validator unit tests + integration (create/upsert, bulk all-or-nothing + >100, list day-scoped + project filter + tz 400, bulk delete + unknown-id ignore, cross-user isolation, 401, and a `/stats`-unaffected check).

## No schema / type change

OpenAPI + generated types landed in PR1 (#125). This PR is implementation + tests only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 254 passing (232 prior + 22 new)
- [ ] Manual `quickstart.md` A / B / D / G against a staging worker