### PR TITLE
spec: Commits read endpoints (PR1/2) #107

### DIFF
--- a/schemas/components/schemas/Commit.yaml
+++ b/schemas/components/schemas/Commit.yaml
@@ -3,6 +3,7 @@ required:
   - hash
   - message
   - author_date
+  - human_readable_total
 properties:
   hash:
     type: string
@@ -29,6 +30,7 @@ properties:
     format: double
   human_readable_total:
     type: string
+    description: Human-readable duration derived from total_seconds, treating missing stored time as zero.
   url:
     type: string
     format: uri

--- a/schemas/paths/commits/commit.yaml
+++ b/schemas/paths/commits/commit.yaml
@@ -7,7 +7,8 @@ get:
     Returns a single commit identified by `project` + `hash` for the
     authenticated user, with `human_readable_total` derived from
     `total_seconds`. A commit not found for this user/project (or unknown
-    `hash`) returns 404 — never another user's commit.
+    `hash`) returns 404 — never another user's commit. If `branch` is supplied,
+    it filters the commit `ref`; a branch mismatch returns 404.
   parameters:
     - name: project
       in: path
@@ -21,6 +22,7 @@ get:
         type: string
     - name: branch
       in: query
+      description: Optional exact match against the commit `ref`.
       schema:
         type: string
   responses:

--- a/schemas/paths/commits/commit.yaml
+++ b/schemas/paths/commits/commit.yaml
@@ -3,6 +3,11 @@ get:
   tags:
     - commits
   summary: Get a single commit with coding time
+  description: |
+    Returns a single commit identified by `project` + `hash` for the
+    authenticated user, with `human_readable_total` derived from
+    `total_seconds`. A commit not found for this user/project (or unknown
+    `hash`) returns 404 — never another user's commit.
   parameters:
     - name: project
       in: path

--- a/schemas/paths/commits/commits.yaml
+++ b/schemas/paths/commits/commits.yaml
@@ -31,8 +31,11 @@ get:
         type: string
     - name: page
       in: query
+      description: 1-based page number. Defaults to 1; values below 1 return 400.
       schema:
         type: integer
+        minimum: 1
+        default: 1
   responses:
     '200':
       description: List of commits
@@ -42,6 +45,8 @@ get:
             type: object
             required:
               - data
+              - page
+              - total_pages
             properties:
               data:
                 type: array
@@ -49,8 +54,10 @@ get:
                   $ref: ../../components/schemas/Commit.yaml
               page:
                 type: integer
+                minimum: 1
               total_pages:
                 type: integer
+                minimum: 0
     '400':
       $ref: ../../components/responses/BadRequest.yaml
     '401':

--- a/schemas/paths/commits/commits.yaml
+++ b/schemas/paths/commits/commits.yaml
@@ -3,6 +3,18 @@ get:
   tags:
     - commits
   summary: List commits for a project with coding time
+  description: |
+    Returns a page of the authenticated user's commits for `project`, ordered
+    by `author_date` descending, 100 per page. `page` defaults to 1; the
+    response includes `page` and `total_pages`. Optional `author` (matches
+    `author_email`) and `branch` (matches the commit `ref`) filter the
+    results. `human_readable_total` is derived from `total_seconds`.
+
+    Commits are stored in the `commits` table. This is the read surface only —
+    the ingestion path (a coding-time plugin posting commits, or a git
+    webhook) is a deliberate follow-up decision and is out of scope here, so
+    the list is empty until commits are populated. An invalid `page` returns
+    400.
   parameters:
     - name: project
       in: path
@@ -39,5 +51,7 @@ get:
                 type: integer
               total_pages:
                 type: integer
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/specs/107-commits/checklists/requirements.md
+++ b/specs/107-commits/checklists/requirements.md
@@ -6,12 +6,12 @@
 - [x] `spec.md` records the scope decision (read path first; ingestion deferred).
 - [x] `plan.md` Constitution Check has all five principles marked PASS.
 - [x] `research.md` documents the 5 design decisions.
-- [x] `data-model.md` confirms no schema change and documents the read queries.
+- [x] `data-model.md` confirms no D1 schema change and documents the read queries.
 - [x] `quickstart.md` enumerates scenarios A–F.
 - [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
-- [x] `contracts/openapi-diff.md` documents the `400` + descriptions.
+- [x] `contracts/openapi-diff.md` documents the `400`, descriptions, pagination requirements, and `human_readable_total` requiredness.
 - [x] Both commit path files carry the descriptions; the list has a `400`.
-- [x] `npm run generate` adds the 400 + JSDoc (no body type-shape change); `npm run typecheck` passes.
+- [x] `npm run generate` adds the 400, JSDoc, required list pagination fields, and required `human_readable_total`; `npm run typecheck` passes.
 - [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
 - [x] PR1 references issue #107.
 
@@ -21,7 +21,7 @@
 
 - [ ] `src/routes/commits.ts` implements both handlers behind `authMiddleware`:
   - `GET /projects/:project/commits` — `COUNT` + paged `SELECT` (100/page, `author_date` DESC), `author`/`branch` filters, `{data, page, total_pages}`, `400` on invalid `page`.
-  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, `404` when absent.
+  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, optional `branch` exact-matches `ref`, `404` when absent or mismatched.
   - `rowToCommit` adds `human_readable_total = formatHumanReadable(total_seconds ?? 0)` and normalises dates.
 - [ ] `src/index.ts` mounts the router at `/api/v1/users/current` (coexists with the users router's `/projects`).
 - [ ] No ingestion path; heartbeat ingestion untouched.
@@ -30,11 +30,11 @@
 ### Behaviour (per `quickstart.md`)
 
 - [ ] A: list newest-first with `human_readable_total`; B: pagination + invalid-page 400; C: author/branch filters.
-- [ ] D: single returns commit / 404 unknown; E: empty project `{data:[], total_pages:0}`; F: 401 + cross-user isolation.
+- [ ] D: single returns commit / 404 unknown or branch mismatch; E: empty project `{data:[], total_pages:0}`; F: 401 + cross-user isolation.
 
 ### Tests
 
-- [ ] `tests/integration/commits.test.ts`: seed commits → list ordering/pagination/filters, single + 404, empty project, invalid page 400, cross-user, 401.
+- [ ] `tests/integration/commits.test.ts`: seed commits → list ordering/pagination/filters, single + 404 including branch mismatch, empty project, invalid page 400, cross-user, 401.
 - [ ] `npm test` stays green with the new coverage.
 
 ## Post-deployment gate

--- a/specs/107-commits/checklists/requirements.md
+++ b/specs/107-commits/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Acceptance Checklist: Commits Read Endpoints
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-007 (list + single, read-only) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` records the scope decision (read path first; ingestion deferred).
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 5 design decisions.
+- [x] `data-model.md` confirms no schema change and documents the read queries.
+- [x] `quickstart.md` enumerates scenarios A–F.
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the `400` + descriptions.
+- [x] Both commit path files carry the descriptions; the list has a `400`.
+- [x] `npm run generate` adds the 400 + JSDoc (no body type-shape change); `npm run typecheck` passes.
+- [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
+- [x] PR1 references issue #107.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/routes/commits.ts` implements both handlers behind `authMiddleware`:
+  - `GET /projects/:project/commits` — `COUNT` + paged `SELECT` (100/page, `author_date` DESC), `author`/`branch` filters, `{data, page, total_pages}`, `400` on invalid `page`.
+  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, `404` when absent.
+  - `rowToCommit` adds `human_readable_total = formatHumanReadable(total_seconds ?? 0)` and normalises dates.
+- [ ] `src/index.ts` mounts the router at `/api/v1/users/current` (coexists with the users router's `/projects`).
+- [ ] No ingestion path; heartbeat ingestion untouched.
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: list newest-first with `human_readable_total`; B: pagination + invalid-page 400; C: author/branch filters.
+- [ ] D: single returns commit / 404 unknown; E: empty project `{data:[], total_pages:0}`; F: 401 + cross-user isolation.
+
+### Tests
+
+- [ ] `tests/integration/commits.test.ts`: seed commits → list ordering/pagination/filters, single + 404, empty project, invalid page 400, cross-user, 401.
+- [ ] `npm test` stays green with the new coverage.
+
+## Post-deployment gate
+
+- [ ] Seed a commit via `wrangler d1 execute` and confirm it lists / fetches with correct `human_readable_total`.
+- [ ] No 500s on the endpoints in the first 7 days.
+- [ ] Follow-up issue filed for commit ingestion (plugin vs webhook).

--- a/specs/107-commits/contracts/openapi-diff.md
+++ b/specs/107-commits/contracts/openapi-diff.md
@@ -1,35 +1,42 @@
 # OpenAPI Diff
 
 The two `commits` read operations (`getProjectCommits`, `getProjectCommit`)
-and the `Commit` schema already existed. This PR adds descriptions and a `400`
-on the list. No schema field changes.
+and the `Commit` schema already existed. This PR adds descriptions, a `400`
+on the list, explicit pagination requirements, and makes
+`human_readable_total` required because handlers always derive it from stored
+seconds.
 
 ## Files touched
 
 1. `schemas/paths/commits/commits.yaml` — `getProjectCommits`: add `description`
    (pagination 100/page, `author_date` DESC, `author`/`branch` filters,
-   `human_readable_total` derivation, read-only / ingestion-deferred note) and
-   a `400` response (invalid `page`).
+   `human_readable_total` derivation, read-only / ingestion-deferred note), a
+   `400` response (invalid `page`), `page` default/minimum, and required
+   `page` / `total_pages` response fields.
 2. `schemas/paths/commits/commit.yaml` — `getProjectCommit`: add `description`
-   (single by `project` + `hash`, 404 for unknown/cross-user).
+   (single by `project` + `hash`, optional `branch`/`ref` filter, 404 for
+   unknown/cross-user/branch mismatch).
+3. `schemas/components/schemas/Commit.yaml` — make `human_readable_total`
+   required and document that it is derived from `total_seconds`.
 
-No new operations, no path changes, no schema field changes.
+No new operations or path changes.
 
-## Contract (shape unchanged)
+## Contract
 
 - `GET /users/current/projects/{project}/commits?page=&author=&branch=` →
   `200 {data: Commit[], page, total_pages}`, `400`, `401`.
-- `GET /users/current/projects/{project}/commits/{hash}` →
+- `GET /users/current/projects/{project}/commits/{hash}?branch=` →
   `200 {data: Commit}`, `401`, `404`.
 
 `Commit` carries `hash`, `message`, author/committer name/email/date,
-`total_seconds`, `human_readable_total`, `ref`, `url`.
+`total_seconds`, required `human_readable_total`, `ref`, `url`.
 
 ## Generated-types impact
 
 `npm run generate` adds the `400` (BadRequest) response to
-`operations["getProjectCommits"]` plus the JSDoc descriptions. No
-request/response **body** type changes — `Commit` is untouched.
+`operations["getProjectCommits"]` plus the JSDoc descriptions. The list
+response now requires `page` and `total_pages`; `Commit` now requires
+`human_readable_total`.
 
 ## Ingestion — explicitly not in the contract
 

--- a/specs/107-commits/contracts/openapi-diff.md
+++ b/specs/107-commits/contracts/openapi-diff.md
@@ -1,0 +1,43 @@
+# OpenAPI Diff
+
+The two `commits` read operations (`getProjectCommits`, `getProjectCommit`)
+and the `Commit` schema already existed. This PR adds descriptions and a `400`
+on the list. No schema field changes.
+
+## Files touched
+
+1. `schemas/paths/commits/commits.yaml` — `getProjectCommits`: add `description`
+   (pagination 100/page, `author_date` DESC, `author`/`branch` filters,
+   `human_readable_total` derivation, read-only / ingestion-deferred note) and
+   a `400` response (invalid `page`).
+2. `schemas/paths/commits/commit.yaml` — `getProjectCommit`: add `description`
+   (single by `project` + `hash`, 404 for unknown/cross-user).
+
+No new operations, no path changes, no schema field changes.
+
+## Contract (shape unchanged)
+
+- `GET /users/current/projects/{project}/commits?page=&author=&branch=` →
+  `200 {data: Commit[], page, total_pages}`, `400`, `401`.
+- `GET /users/current/projects/{project}/commits/{hash}` →
+  `200 {data: Commit}`, `401`, `404`.
+
+`Commit` carries `hash`, `message`, author/committer name/email/date,
+`total_seconds`, `human_readable_total`, `ref`, `url`.
+
+## Generated-types impact
+
+`npm run generate` adds the `400` (BadRequest) response to
+`operations["getProjectCommits"]` plus the JSDoc descriptions. No
+request/response **body** type changes — `Commit` is untouched.
+
+## Ingestion — explicitly not in the contract
+
+No `POST` / create operation is added. Ingestion (CLI-plugin vs git-webhook)
+is deferred to a follow-up (see research Decision 1); the read endpoints
+return whatever is in the `commits` table.
+
+## SDD compliance note
+
+PR1 lands SpecKit + the `400` / descriptions + regenerated types. PR2 lands
+the two read handlers + tests. No runtime code in PR1.

--- a/specs/107-commits/data-model.md
+++ b/specs/107-commits/data-model.md
@@ -61,11 +61,12 @@ SELECT hash, message, author_name, author_email, author_date,
 
 | Column | Treatment |
 |---|---|
-| `hash`, `message`, `author_name`, `author_email` | Pass through (null → omitted) |
-| `author_date`, `committer_date` | `normalizeDateTime` → ISO 8601 |
-| `committer_name`, `committer_email`, `ref`, `url` | Pass through |
+| `hash`, `message` | Pass through; required by the `Commit` response schema |
+| `author_name`, `author_email`, `committer_name`, `committer_email`, `ref`, `url` | Pass through (null → omitted) |
+| `author_date` | `normalizeDateTime` → ISO 8601; required by the `Commit` response schema |
+| `committer_date` | `normalizeDateTime` → ISO 8601 when present |
 | `total_seconds` | Pass through (null → 0 / omitted) |
-| `human_readable_total` | `formatHumanReadable(total_seconds ?? 0)` |
+| `human_readable_total` | Always include `formatHumanReadable(total_seconds ?? 0)` |
 
 `id`, `user_id`, `created_at`, `project` are not part of the `Commit` response schema and are not surfaced.
 

--- a/specs/107-commits/data-model.md
+++ b/specs/107-commits/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Commits Read Endpoints
+
+No schema changes. Reads the existing `commits` table.
+
+## `commits` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS commits (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  project TEXT NOT NULL,
+  hash TEXT NOT NULL,
+  message TEXT,
+  author_name TEXT,
+  author_email TEXT,
+  author_date TEXT,
+  committer_name TEXT,
+  committer_email TEXT,
+  committer_date TEXT,
+  total_seconds REAL,
+  ref TEXT,
+  url TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, project, hash)
+);
+```
+
+`UNIQUE(user_id, project, hash)` backs the single-commit lookup and per-user/project scoping. `total_seconds` is nullable (a commit may have no time attribution).
+
+## Read queries
+
+### List (paginated)
+```sql
+-- count for total_pages:
+SELECT COUNT(*) AS n FROM commits
+ WHERE user_id = ? AND project = ?
+   /* optional: AND author_email = ?  AND ref = ? */;
+
+-- page:
+SELECT hash, message, author_name, author_email, author_date,
+       committer_name, committer_email, committer_date, total_seconds, ref, url
+  FROM commits
+ WHERE user_id = ? AND project = ?
+   /* optional filters as above */
+ ORDER BY author_date DESC, hash ASC
+ LIMIT 100 OFFSET ?;          -- OFFSET = (page - 1) * 100
+```
+
+`total_pages = ceil(n / 100)` (0 when `n = 0`).
+
+### Single
+```sql
+SELECT hash, message, author_name, author_email, author_date,
+       committer_name, committer_email, committer_date, total_seconds, ref, url
+  FROM commits
+ WHERE user_id = ? AND project = ? AND hash = ?;   -- 404 when no row
+```
+
+## Field treatment in the handler (`rowToCommit`)
+
+| Column | Treatment |
+|---|---|
+| `hash`, `message`, `author_name`, `author_email` | Pass through (null → omitted) |
+| `author_date`, `committer_date` | `normalizeDateTime` → ISO 8601 |
+| `committer_name`, `committer_email`, `ref`, `url` | Pass through |
+| `total_seconds` | Pass through (null → 0 / omitted) |
+| `human_readable_total` | `formatHumanReadable(total_seconds ?? 0)` |
+
+`id`, `user_id`, `created_at`, `project` are not part of the `Commit` response schema and are not surfaced.
+
+## No writes
+
+Read-only. No ingestion path in this feature (see research Decision 1). `commits` cascades on user delete.

--- a/specs/107-commits/plan.md
+++ b/specs/107-commits/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Commits Read Endpoints
+
+**Branch**: `107-commits` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/107-commits/spec.md`
+
+## Summary
+
+Wire the two declared read operations (`getProjectCommits`, `getProjectCommit`) to handlers over the existing `commits` table. List is paginated (100/page, `author_date` DESC) with `author`/`branch` filters; single is by `(user_id, project, hash)` → 404 when absent. Ingestion is deferred (read path first, mirroring Goals #95/#96).
+
+PR1 (this PR): SpecKit artifacts + OpenAPI descriptions + a `400` on the list (invalid page). PR2: the route + tests.
+
+No D1 migration, no new binding.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`commits`, existing)
+**Testing**: Vitest + workers pool — integration tests over seeded `commits`
+**Performance Goals**: <10ms CPU — one `COUNT` + one page `SELECT` for list; one `SELECT` for single
+**Constraints**: page size 100; `(user_id, project, hash)` scoping
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Operations already declared; PR1 adds descriptions + a `400`, PR2 implements. `npm run generate` adds the 400 response + JSDoc. |
+| II. Cloudflare-Native | PASS | Indexed D1 reads + the shared duration formatter. No new bindings. |
+| III. Type Safety | PASS | Handler uses `components["schemas"]["Commit"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Read contract from our own schema; no upstream source/assets. |
+| V. Simplicity First | PASS | One router, two handlers, read-only. Ingestion deferred to avoid an unresolved plugin-vs-webhook decision. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/107-commits/
+├── plan.md, spec.md, research.md, data-model.md, quickstart.md, tasks.md
+├── contracts/openapi-diff.md
+└── checklists/requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── commits.ts          # NEW: getProjectCommits + getProjectCommit handlers
+└── index.ts                # NEW route mount
+```
+
+**Structure Decision**: A new `commits.ts` router mounted at `/users/current`, defining `/projects/:project/commits` and `/projects/:project/commits/:hash`. These paths are more specific than the users router's `/projects`, so they coexist. `human_readable_total` reuses `formatHumanReadable` from `time-format.ts`.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Read path first; ingestion deferred** (plugin-vs-webhook is an open product decision).
+2. **Pagination**: 100/page, `author_date` DESC, `page` 1-based, invalid page → 400.
+3. **Filters**: `author` → `author_email` exact; `branch` → `ref` exact.
+4. **Single → 404** for unknown/cross-user (no existence leak).
+5. **`human_readable_total`** derived from `total_seconds` (0 when NULL).
+
+## Phase 1 — Design Outputs
+
+### Route sketch
+
+```ts
+const PAGE_SIZE = 100;
+
+commits.get("/projects/:project/commits", async (c) => {
+  const project = c.req.param("project");
+  const page = parsePage(c.req.query("page"));      // 400 if invalid
+  if (page === null) return c.json({ error: "Invalid page" }, 400);
+  const conditions = ["user_id = ?", "project = ?"]; const binds = [userId, project];
+  if (author) { conditions.push("author_email = ?"); binds.push(author); }
+  if (branch) { conditions.push("ref = ?"); binds.push(branch); }
+  const total = (await db.prepare(`SELECT COUNT(*) AS n FROM commits WHERE …`).bind(…).first()).n;
+  const rows = await db.prepare(
+    `SELECT … FROM commits WHERE … ORDER BY author_date DESC, hash ASC LIMIT ? OFFSET ?`,
+  ).bind(…, PAGE_SIZE, (page-1)*PAGE_SIZE).all();
+  return c.json({ data: rows.map(rowToCommit), page, total_pages: Math.ceil(total / PAGE_SIZE) });
+});
+
+commits.get("/projects/:project/commits/:hash", async (c) => {
+  const row = await db.prepare(
+    `SELECT … FROM commits WHERE user_id = ? AND project = ? AND hash = ?`,
+  ).bind(userId, project, hash).first();
+  if (!row) return c.json({ error: "Not found" }, 404);
+  return c.json({ data: rowToCommit(row) });
+});
+```
+
+`rowToCommit` maps the row to the `Commit` schema, adding `human_readable_total = formatHumanReadable(total_seconds ?? 0)` and normalising date-time fields.
+
+### OpenAPI surface
+
+Already declared; PR1 adds descriptions + a `400` on the list — see [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+Bounded: two read handlers over an indexed table, mirroring existing list/single read endpoints (goals, user_agents). The only nuance is pagination math.

--- a/specs/107-commits/plan.md
+++ b/specs/107-commits/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Wire the two declared read operations (`getProjectCommits`, `getProjectCommit`) to handlers over the existing `commits` table. List is paginated (100/page, `author_date` DESC) with `author`/`branch` filters; single is by `(user_id, project, hash)` → 404 when absent. Ingestion is deferred (read path first, mirroring Goals #95/#96).
+Wire the two declared read operations (`getProjectCommits`, `getProjectCommit`) to handlers over the existing `commits` table. List is paginated (100/page, `author_date` DESC) with `author`/`branch` filters; single is by `(user_id, project, hash)` plus optional `branch`/`ref` filtering → 404 when absent or mismatched. Ingestion is deferred (read path first, mirroring Goals #95/#96).
 
 PR1 (this PR): SpecKit artifacts + OpenAPI descriptions + a `400` on the list (invalid page). PR2: the route + tests.
 
@@ -58,7 +58,7 @@ See [research.md](./research.md). Key decisions:
 1. **Read path first; ingestion deferred** (plugin-vs-webhook is an open product decision).
 2. **Pagination**: 100/page, `author_date` DESC, `page` 1-based, invalid page → 400.
 3. **Filters**: `author` → `author_email` exact; `branch` → `ref` exact.
-4. **Single → 404** for unknown/cross-user (no existence leak).
+4. **Single → 404** for unknown/cross-user/branch mismatch (no existence leak).
 5. **`human_readable_total`** derived from `total_seconds` (0 when NULL).
 
 ## Phase 1 — Design Outputs
@@ -83,9 +83,10 @@ commits.get("/projects/:project/commits", async (c) => {
 });
 
 commits.get("/projects/:project/commits/:hash", async (c) => {
-  const row = await db.prepare(
-    `SELECT … FROM commits WHERE user_id = ? AND project = ? AND hash = ?`,
-  ).bind(userId, project, hash).first();
+  const conditions = ["user_id = ?", "project = ?", "hash = ?"];
+  const binds = [userId, project, hash];
+  if (branch) { conditions.push("ref = ?"); binds.push(branch); }
+  const row = await db.prepare(`SELECT … FROM commits WHERE ${conditions.join(" AND ")}`).bind(...binds).first();
   if (!row) return c.json({ error: "Not found" }, 404);
   return c.json({ data: rowToCommit(row) });
 });

--- a/specs/107-commits/quickstart.md
+++ b/specs/107-commits/quickstart.md
@@ -51,7 +51,7 @@ curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits?branch=main"
 
 ```bash
 curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits/abc123"
-curl -si "$H" "$BASE/users/current/projects/cloudtime/commits/nope"
+curl -si -H "$H" "$BASE/users/current/projects/cloudtime/commits/nope"
 ```
 
 **Expected**: the first returns `{data: Commit}` with `human_readable_total`; the unknown hash returns 404.

--- a/specs/107-commits/quickstart.md
+++ b/specs/107-commits/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart: Commits Read Endpoints
+
+Manual verification once PR2 (implementation) is deployed. Because ingestion
+is deferred, seed the `commits` table directly first.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+```
+
+Seed a couple of commits (substitute your `user_id`):
+
+```bash
+wrangler d1 execute cloudtime-db --remote --command "
+  INSERT INTO commits (id, user_id, project, hash, message, author_name, author_email,
+                       author_date, total_seconds, ref) VALUES
+   (lower(hex(randomblob(16))),'<uid>','cloudtime','abc123','fix bug','Nao','nao@example.com','2026-05-20T10:00:00Z',1800,'main'),
+   (lower(hex(randomblob(16))),'<uid>','cloudtime','def456','add feature','Nao','nao@example.com','2026-05-21T10:00:00Z',3600,'main');
+"
+```
+
+## Scenario A — List a project's commits
+
+```bash
+curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits"
+```
+
+**Expected**: `{data:[…], page:1, total_pages:1}` ordered newest-first (`def456` then `abc123`), each with `human_readable_total` (e.g. "1 hr", "30 mins").
+
+## Scenario B — Pagination
+
+```bash
+curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits?page=2"
+```
+
+**Expected**: with ≤100 commits, page 2 returns `{data:[], page:2, total_pages:1}` (empty, not an error). An invalid `page` (e.g. `?page=abc` or `?page=0`) returns 400.
+
+## Scenario C — Filters
+
+```bash
+curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits?author=nao@example.com"
+curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits?branch=main"
+```
+
+**Expected**: only commits matching `author_email` / `ref` return.
+
+## Scenario D — Single commit
+
+```bash
+curl -sH "$H" "$BASE/users/current/projects/cloudtime/commits/abc123"
+curl -si "$H" "$BASE/users/current/projects/cloudtime/commits/nope"
+```
+
+**Expected**: the first returns `{data: Commit}` with `human_readable_total`; the unknown hash returns 404.
+
+## Scenario E — Empty project
+
+```bash
+curl -sH "$H" "$BASE/users/current/projects/never-seen/commits"
+```
+
+**Expected**: `{data:[], page:1, total_pages:0}` with 200.
+
+## Scenario F — Auth / isolation
+
+```bash
+curl -si "$BASE/users/current/projects/cloudtime/commits"   # no auth → 401
+```
+
+**Expected**: 401. Another user's commits for a same-named project never appear.
+
+## Reverting / cleanup
+
+Read-only. Removing the route + mount disables the feature with no data impact.

--- a/specs/107-commits/research.md
+++ b/specs/107-commits/research.md
@@ -1,0 +1,59 @@
+# Research: Commits Read Endpoints
+
+## Decision 1: Ship the read path first; defer ingestion
+
+**Decision**: Implement only the two declared read operations (`getProjectCommits`, `getProjectCommit`). Do not add a `POST` create or any ingestion path in this feature.
+
+**Rationale**:
+- The declared OpenAPI surface is read-only, and per the SDD rule the schema is the single source of truth.
+- The issue explicitly leaves the ingestion mechanism open — a coding-time CLI/editor plugin (matches WakaTime) vs a server-side git webhook. Each carries different auth, source-of-truth, and operator-effort trade-offs; rushing it inside a low-priority read feature would lock in a contract prematurely.
+- Mirrors Goals (#95/#96): the read path established the contract and handlers, then mutation followed. The `commits` table can be seeded out of band (`wrangler d1 execute`) meanwhile, and a future ingestion PR makes it live.
+
+**Alternative considered**: add a `POST .../commits` create now (client-plugin ingestion). Rejected for the first cut — it presupposes the plugin-vs-webhook decision and expands a low-priority feature; recommended as the likely follow-up (a client-plugin `POST` best matches the compatible ecosystem).
+
+---
+
+## Decision 2: Pagination — 100/page, `author_date` DESC, 1-based, invalid → 400
+
+**Decision**: The list returns 100 commits per page ordered by `author_date` descending (ties by `hash`). `page` is 1-based and defaults to 1; a non-integer or `< 1` page returns 400; a page beyond the end returns an empty `data`.
+
+**Rationale**:
+- Newest-first is the natural commit-log order. A fixed 100/page keeps each response bounded and the query cheap (one `COUNT` + one `LIMIT/OFFSET` read).
+- Rejecting a malformed `page` (rather than silently clamping) surfaces client bugs; an out-of-range-but-valid page returning empty is standard and avoids an error for benign over-paging.
+
+**Alternative considered**: cursor pagination. Rejected — offset/page matches the declared `page`/`total_pages` response shape and is sufficient at this scale.
+
+---
+
+## Decision 3: Filters — `author` → `author_email`, `branch` → `ref`
+
+**Decision**: The optional `author` query filters on `author_email` (exact); `branch` filters on the commit `ref` column (exact).
+
+**Rationale**:
+- `author_email` is the stable identity in git metadata (names vary); exact match is predictable and indexable-friendly.
+- The table's `ref` column is where a branch/ref is stored, so `branch` maps to it directly.
+
+**Alternative considered**: fuzzy/`LIKE` matching or matching `author_name`. Rejected for the first cut — exact match is unambiguous; fuzzy search can be added later without breaking the contract.
+
+---
+
+## Decision 4: Single commit → 404 for unknown / cross-user
+
+**Decision**: `getProjectCommit` looks up `(user_id, project, hash)` and returns 404 when there is no match — whether the hash is unknown or owned by another user.
+
+**Rationale**:
+- Consistent with every other single-resource read in the project (goals, etc.): `user_id`-scoped `WHERE`, 404 over 403, no existence leak.
+
+**Alternative considered**: 403 for owned-by-other. Rejected — leaks existence.
+
+---
+
+## Decision 5: `human_readable_total` derived, NULL `total_seconds` → 0
+
+**Decision**: `human_readable_total` is computed from `total_seconds` using the shared `formatHumanReadable` helper; a NULL `total_seconds` is treated as 0.
+
+**Rationale**:
+- A commit may be recorded without time attribution (`total_seconds` is nullable). Treating NULL as 0 keeps the response well-formed (`human_readable_total` always a string) rather than leaking nulls or erroring.
+- Reusing the existing formatter keeps `human_readable_total` consistent with `/stats` and insights.
+
+**Alternative considered**: omit `human_readable_total` when `total_seconds` is NULL. Rejected — an always-present human string is friendlier for clients and matches the schema's intent.

--- a/specs/107-commits/research.md
+++ b/specs/107-commits/research.md
@@ -6,7 +6,7 @@
 
 **Rationale**:
 - The declared OpenAPI surface is read-only, and per the SDD rule the schema is the single source of truth.
-- The issue explicitly leaves the ingestion mechanism open — a coding-time CLI/editor plugin (matches WakaTime) vs a server-side git webhook. Each carries different auth, source-of-truth, and operator-effort trade-offs; rushing it inside a low-priority read feature would lock in a contract prematurely.
+- The issue explicitly leaves the ingestion mechanism open — a WakaTime-compatible CLI/editor plugin vs a server-side git webhook. Each carries different auth, source-of-truth, and operator-effort trade-offs; rushing it inside a low-priority read feature would lock in a contract prematurely.
 - Mirrors Goals (#95/#96): the read path established the contract and handlers, then mutation followed. The `commits` table can be seeded out of band (`wrangler d1 execute`) meanwhile, and a future ingestion PR makes it live.
 
 **Alternative considered**: add a `POST .../commits` create now (client-plugin ingestion). Rejected for the first cut — it presupposes the plugin-vs-webhook decision and expands a low-priority feature; recommended as the likely follow-up (a client-plugin `POST` best matches the compatible ecosystem).

--- a/specs/107-commits/spec.md
+++ b/specs/107-commits/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Commits Read Endpoints
+
+**Feature Branch**: `107-commits`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: The `commits` D1 table and two OpenAPI operations (`getProjectCommits`, `getProjectCommit`) are declared, but no route is mounted and no ingestion path populates the table.
+
+## Background
+
+Commit endpoints attribute coding time to individual git commits ("how long did the work that produced `abc123` take"). Two read operations are declared:
+
+- `GET /api/v1/users/current/projects/{project}/commits` — paginated list,
+- `GET /api/v1/users/current/projects/{project}/commits/{hash}` — single commit.
+
+This feature wires those two **read** endpoints to the existing `commits` table. It is **low priority** for single-user — useful but not on the core "heartbeats → today's stats" path.
+
+## Scope decision: read path first, ingestion deferred
+
+The declared OpenAPI surface is **read-only**. There is no ingestion path, and the issue explicitly leaves the ingestion mechanism open: a coding-time CLI/editor plugin that posts commits as they're authored, versus a server-side git webhook. That is a genuine product/integration decision with auth and source-of-truth implications, not something to settle inside a low-priority read feature.
+
+So this feature ships the **two read endpoints only**, mirroring how Goals shipped its read path before CRUD (#95/#96). The `commits` table is populated out of band for now (operator `wrangler d1 execute`, or a future ingestion PR). Establishing the read contract + handlers now means commits are immediately queryable once an ingestion path lands.
+
+**Out of scope (deferred to a follow-up):** `POST` create, the plugin-vs-webhook decision, and any change to heartbeat ingestion.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List a project's commits (Priority: P3)
+
+As an authenticated user, I want to page through my commits for a project, newest first, so I can see per-commit coding time.
+
+**Independent Test**: Seed several `commits` rows for a project across dates. `GET …/projects/{project}/commits` returns them as `{data: Commit[], page, total_pages}` ordered by `author_date` descending, 100 per page, with `human_readable_total` derived from `total_seconds`.
+
+**Acceptance Scenarios**:
+1. **Given** commits across several dates, **When** listing, **Then** they return ordered by `author_date` descending, with `page` and `total_pages` set.
+2. **Given** more than 100 commits, **When** listing `?page=2`, **Then** the second 100 return and `total_pages` reflects the count.
+3. **Given** `author` / `branch` filters, **When** listing, **Then** only commits matching `author_email` / `ref` return.
+4. **Given** no commits for the project, **When** listing, **Then** `{data: [], page: 1, total_pages: 0}` with 200.
+5. **Given** an invalid `page` (non-integer, < 1), **When** listing, **Then** 400.
+6. **Given** another user's commits for the same project name, **When** listing, **Then** none appear (strict per-user scoping).
+7. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 2 - Inspect a single commit (Priority: P3)
+
+As an authenticated user, I want a single commit by hash so a client can show its detail.
+
+**Acceptance Scenarios**:
+1. **Given** an owned commit, **When** requesting `…/commits/{hash}`, **Then** `{data: Commit}` with `human_readable_total`.
+2. **Given** an unknown `hash`, or a hash owned by another user, **When** requesting, **Then** 404 (no existence leak).
+3. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### Edge Cases
+
+- **`total_seconds` NULL** (commit recorded without time attribution): `total_seconds` returns 0 / omitted and `human_readable_total` is the zero string.
+- **Same `hash` across two projects**: scoped by `(user_id, project, hash)` (the table's unique key); listing/single are project-scoped.
+- **Duplicate project names across users**: `user_id` scoping keeps them separate.
+- **Pagination past the end**: a `page` beyond `total_pages` returns `{data: []}` (not an error).
+- **Author filter case**: `author_email` exact match.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `GET /api/v1/users/current/projects/{project}/commits` MUST return the user's commits for `project` as `{data: Commit[], page, total_pages}`, ordered by `author_date` descending (ties by `hash`), 100 per page.
+- **FR-002**: `page` defaults to 1; an invalid `page` (non-integer or < 1) MUST return 400. A `page` beyond the last returns an empty `data` (not an error).
+- **FR-003**: Optional `author` filters on `author_email` (exact); optional `branch` filters on `ref` (exact).
+- **FR-004**: Each `Commit` MUST include `human_readable_total` derived from `total_seconds` (0 when NULL), reusing the shared duration formatter.
+- **FR-005**: `GET /api/v1/users/current/projects/{project}/commits/{hash}` MUST return a single owned commit as `{data: Commit}`; an unknown/unowned `(project, hash)` MUST return 404 (never 403, never another user's row).
+- **FR-006**: All endpoints MUST require authentication (401) and be strictly scoped by `user_id`.
+- **FR-007**: This feature MUST NOT add an ingestion path or modify heartbeat ingestion; the `commits` table is read-only here.
+
+### Non-Functional Requirements
+
+- **NFR-001**: List MUST issue at most two indexed reads (one `COUNT` for `total_pages`, one page `SELECT`); single MUST issue one. The `commits` table is keyed by `(user_id, project, hash)`.
+- **NFR-002**: No D1 schema migration; no new binding or dependency.
+
+### Key Entities *(no schema change)*
+
+`commits` (`id`, `user_id`, `project`, `hash`, `message`, `author_name/email/date`, `committer_name/email/date`, `total_seconds`, `ref`, `url`, `created_at`, `UNIQUE(user_id, project, hash)`, `ON DELETE CASCADE`). Response uses the existing `Commit` schema.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A seeded project's commits list newest-first with correct pagination and `human_readable_total`.
+- **SC-002**: `author` / `branch` filters narrow the list correctly.
+- **SC-003**: Single-commit returns the row; unknown/cross-user returns 404.
+- **SC-004**: Invalid `page` → 400; unauthenticated → 401; cross-user never leaks.
+
+## Out of Scope
+
+- **Commit ingestion** (`POST` create, CLI-plugin vs git-webhook decision). Deferred to a follow-up issue.
+- **Branch as a separate dimension** beyond the `ref` exact-match filter.
+- **Diff/line-level attribution** or linking commits to specific heartbeats.
+- **Pagination cursors** (offset/page only).

--- a/specs/107-commits/spec.md
+++ b/specs/107-commits/spec.md
@@ -48,7 +48,8 @@ As an authenticated user, I want a single commit by hash so a client can show it
 **Acceptance Scenarios**:
 1. **Given** an owned commit, **When** requesting `…/commits/{hash}`, **Then** `{data: Commit}` with `human_readable_total`.
 2. **Given** an unknown `hash`, or a hash owned by another user, **When** requesting, **Then** 404 (no existence leak).
-3. **Given** an unauthenticated request, **Then** 401.
+3. **Given** a `branch` query that does not match the commit `ref`, **When** requesting, **Then** 404.
+4. **Given** an unauthenticated request, **Then** 401.
 
 ---
 
@@ -70,7 +71,7 @@ As an authenticated user, I want a single commit by hash so a client can show it
 - **FR-002**: `page` defaults to 1; an invalid `page` (non-integer or < 1) MUST return 400. A `page` beyond the last returns an empty `data` (not an error).
 - **FR-003**: Optional `author` filters on `author_email` (exact); optional `branch` filters on `ref` (exact).
 - **FR-004**: Each `Commit` MUST include `human_readable_total` derived from `total_seconds` (0 when NULL), reusing the shared duration formatter.
-- **FR-005**: `GET /api/v1/users/current/projects/{project}/commits/{hash}` MUST return a single owned commit as `{data: Commit}`; an unknown/unowned `(project, hash)` MUST return 404 (never 403, never another user's row).
+- **FR-005**: `GET /api/v1/users/current/projects/{project}/commits/{hash}` MUST return a single owned commit as `{data: Commit}`; an unknown/unowned `(project, hash)` MUST return 404 (never 403, never another user's row). If `branch` is supplied, it MUST exact-match the commit `ref`; a mismatch returns 404.
 - **FR-006**: All endpoints MUST require authentication (401) and be strictly scoped by `user_id`.
 - **FR-007**: This feature MUST NOT add an ingestion path or modify heartbeat ingestion; the `commits` table is read-only here.
 

--- a/specs/107-commits/tasks.md
+++ b/specs/107-commits/tasks.md
@@ -13,8 +13,8 @@
 - [x] **T-005**: Author `quickstart.md` (scenarios A–F).
 - [x] **T-006**: Author `contracts/openapi-diff.md`.
 - [x] **T-007**: Author `checklists/requirements.md`.
-- [x] **T-008**: Add descriptions to both commit path files; add `400` to `getProjectCommits`.
-- [x] **T-009**: Run `npm run generate` (400 + JSDoc, no body type change); run `npm run typecheck`.
+- [x] **T-008**: Add descriptions to both commit path files; add `400` to `getProjectCommits`; encode pagination requirements; require derived `human_readable_total`.
+- [x] **T-009**: Run `npm run generate` (400 + JSDoc + required pagination fields + required `human_readable_total`); run `npm run typecheck`.
 - [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
 
 ## PR2 — Implementation (after PR1 merges)
@@ -23,13 +23,13 @@
 
 - [ ] **T-101**: `src/routes/commits.ts` — Hono sub-app, both handlers behind `authMiddleware`:
   - `GET /projects/:project/commits` — parse/validate `page` (400 if invalid), build `WHERE` (`user_id`, `project`, optional `author_email`, `ref`), `COUNT` + paged `SELECT` (100/page, `ORDER BY author_date DESC, hash ASC`), return `{data, page, total_pages}`.
-  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, `404` when absent.
+  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, optional `branch` exact-matches `ref`, `404` when absent or mismatched.
   - `rowToCommit` (adds `human_readable_total`, normalises dates).
 - [ ] **T-102**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", commits)`.
 
 ### Tests
 
-- [ ] **T-103**: `tests/integration/commits.test.ts` — list ordering/pagination/filters, single + 404, empty project, invalid page 400, cross-user, 401.
+- [ ] **T-103**: `tests/integration/commits.test.ts` — list ordering/pagination/filters, single + 404 including branch mismatch, empty project, invalid page 400, cross-user, 401.
 
 ### Verification
 

--- a/specs/107-commits/tasks.md
+++ b/specs/107-commits/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Commits Read Endpoints
+
+**Branch**: `107-commits`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (2 read stories, FR-001..FR-007, scope decision, edge cases).
+- [x] **T-002**: Author `plan.md` (Constitution Check, route sketch).
+- [x] **T-003**: Author `research.md` (5 documented decisions, incl. ingestion deferral).
+- [x] **T-004**: Author `data-model.md` (existing table; read queries).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–F).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add descriptions to both commit path files; add `400` to `getProjectCommits`.
+- [x] **T-009**: Run `npm run generate` (400 + JSDoc, no body type change); run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Route
+
+- [ ] **T-101**: `src/routes/commits.ts` — Hono sub-app, both handlers behind `authMiddleware`:
+  - `GET /projects/:project/commits` — parse/validate `page` (400 if invalid), build `WHERE` (`user_id`, `project`, optional `author_email`, `ref`), `COUNT` + paged `SELECT` (100/page, `ORDER BY author_date DESC, hash ASC`), return `{data, page, total_pages}`.
+  - `GET /projects/:project/commits/:hash` — single by `(user_id, project, hash)`, `404` when absent.
+  - `rowToCommit` (adds `human_readable_total`, normalises dates).
+- [ ] **T-102**: Mount in `src/index.ts`: `app.route("/api/v1/users/current", commits)`.
+
+### Tests
+
+- [ ] **T-103**: `tests/integration/commits.test.ts` — list ordering/pagination/filters, single + 404, empty project, invalid page 400, cross-user, 401.
+
+### Verification
+
+- [ ] **T-104**: `npm run typecheck` — zero errors.
+- [ ] **T-105**: `npm test` — full suite green incl. new integration.
+- [ ] **T-106**: Manual run of `quickstart.md` A / B / D against a staging worker (seed via wrangler).
+
+### PR2 submission
+
+- [ ] **T-107**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #107.
+
+## Follow-up (separate issue)
+
+- [ ] Commit ingestion: decide CLI-plugin `POST` vs git-webhook; add the create path.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010          (PR1)
+T-010 → T-101 → T-102 → T-103 → T-104 → T-105 → T-106 → T-107   (PR2)
+```
+
+## Out of scope
+
+- Commit ingestion / `POST` create (follow-up).
+- Line-level attribution; commit↔heartbeat linking.
+- Cursor pagination; fuzzy author search.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -963,7 +963,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List commits for a project with coding time */
+        /**
+         * List commits for a project with coding time
+         * @description Returns a page of the authenticated user's commits for `project`, ordered
+         *     by `author_date` descending, 100 per page. `page` defaults to 1; the
+         *     response includes `page` and `total_pages`. Optional `author` (matches
+         *     `author_email`) and `branch` (matches the commit `ref`) filter the
+         *     results. `human_readable_total` is derived from `total_seconds`.
+         *
+         *     Commits are stored in the `commits` table. This is the read surface only —
+         *     the ingestion path (a coding-time plugin posting commits, or a git
+         *     webhook) is a deliberate follow-up decision and is out of scope here, so
+         *     the list is empty until commits are populated. An invalid `page` returns
+         *     400.
+         */
         get: operations["getProjectCommits"];
         put?: never;
         post?: never;
@@ -980,7 +993,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get a single commit with coding time */
+        /**
+         * Get a single commit with coding time
+         * @description Returns a single commit identified by `project` + `hash` for the
+         *     authenticated user, with `human_readable_total` derived from
+         *     `total_seconds`. A commit not found for this user/project (or unknown
+         *     `hash`) returns 404 — never another user's commit.
+         */
         get: operations["getProjectCommit"];
         put?: never;
         post?: never;
@@ -3321,6 +3340,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
         };
     };

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -998,7 +998,8 @@ export interface paths {
          * @description Returns a single commit identified by `project` + `hash` for the
          *     authenticated user, with `human_readable_total` derived from
          *     `total_seconds`. A commit not found for this user/project (or unknown
-         *     `hash`) returns 404 — never another user's commit.
+         *     `hash`) returns 404 — never another user's commit. If `branch` is supplied,
+         *     it filters the commit `ref`; a branch mismatch returns 404.
          */
         get: operations["getProjectCommit"];
         put?: never;
@@ -1764,7 +1765,8 @@ export interface components {
             committer_date?: string;
             /** Format: double */
             total_seconds?: number;
-            human_readable_total?: string;
+            /** @description Human-readable duration derived from total_seconds, treating missing stored time as zero. */
+            human_readable_total: string;
             /** Format: uri */
             url?: string;
             ref?: string;
@@ -3317,6 +3319,7 @@ export interface operations {
             query?: {
                 author?: string;
                 branch?: string;
+                /** @description 1-based page number. Defaults to 1; values below 1 return 400. */
                 page?: number;
             };
             header?: never;
@@ -3335,8 +3338,8 @@ export interface operations {
                 content: {
                     "application/json": {
                         data: components["schemas"]["Commit"][];
-                        page?: number;
-                        total_pages?: number;
+                        page: number;
+                        total_pages: number;
                     };
                 };
             };
@@ -3347,6 +3350,7 @@ export interface operations {
     getProjectCommit: {
         parameters: {
             query?: {
+                /** @description Optional exact match against the commit `ref`. */
                 branch?: string;
             };
             header?: never;


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Commits** (issue #107) — per-commit coding-time read endpoints. The two operations (`getProjectCommits`, `getProjectCommit`) and the `Commit` schema already existed; this PR adds descriptions and a `400` on the list, and lands the SpecKit design. **No implementation code** — the read handlers land in PR2.

## Scope decision (please sanity-check)

**Read path first; ingestion deferred.** The declared OpenAPI surface is read-only, and the issue explicitly leaves the ingestion mechanism open — a coding-time CLI/editor plugin (matches the compatible ecosystem) vs a server-side git webhook. That's a genuine product decision with auth/source-of-truth implications, so it's a deliberate follow-up rather than something to lock in inside a low-priority read feature. This mirrors how Goals shipped its read path (#95/#96) before mutation. The `commits` table is seeded out of band (`wrangler d1 execute`) until a future ingestion PR.

## What's in this PR

- **OpenAPI** — `getProjectCommits`: document pagination (100/page, `author_date` DESC), `author`/`branch` filters, `human_readable_total` derivation, read-only note; add `400` (invalid `page`). `getProjectCommit`: document single-by-hash + 404 for unknown/cross-user.
- **Generated types** — adds the 400 response + JSDoc; `Commit` body unchanged.
- **SpecKit artifacts** under `specs/107-commits/`.

## Design highlights (see `research.md`)

- Pagination: 100/page, `author_date` DESC (ties by `hash`), 1-based `page`, invalid page → 400, over-paging → empty `data`.
- Filters: `author` → `author_email` (exact), `branch` → `ref` (exact).
- Single → 404 for unknown / cross-user (no existence leak).
- `human_readable_total` derived from `total_seconds` (0 when NULL), via the shared formatter.

## No schema migration

Uses the existing `commits` table (`UNIQUE(user_id, project, hash)`).

## Test plan

- [x] `npm run generate` → 400 + JSDoc, no body type change
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly
- [ ] PR2: two read handlers + integration tests (seed commits, list/pagination/filters, single/404, cross-user, 401)