### PR TITLE
feat: Commits read endpoints (PR2/2) #107

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import goals from "./routes/goals";
 import customRules from "./routes/custom-rules";
 import insights from "./routes/insights";
 import externalDurations from "./routes/external-durations";
+import commits from "./routes/commits";
 import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { aggregateHeartbeats } from "./cron/aggregate";
@@ -137,6 +138,9 @@ app.route("/api/v1/users/current", insights);
 
 // External durations routes (mounted at /users/current, sub-app defines /external_durations, /external_durations.bulk)
 app.route("/api/v1/users/current", externalDurations);
+
+// Commits routes (mounted at /users/current, sub-app defines /projects/:project/commits[/:hash])
+app.route("/api/v1/users/current", commits);
 
 // Machine names routes (mounted at /users/current, sub-app defines /machine_names)
 app.route("/api/v1/users/current", machines);

--- a/src/routes/commits.ts
+++ b/src/routes/commits.ts
@@ -1,0 +1,145 @@
+/**
+ * Per-commit coding-time read endpoints (specs/107-commits/).
+ *
+ * Read surface only: a paginated list and a single-commit lookup over the
+ * existing `commits` table. Ingestion (a coding-time plugin posting commits,
+ * or a git webhook) is a deliberate follow-up; the table is seeded out of
+ * band until then.
+ */
+import { Hono } from "hono";
+import type { AuthEnv } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { normalizeDateTime } from "../utils/user";
+import { formatHumanReadable } from "../utils/time-format";
+
+type Commit = components["schemas"]["Commit"];
+
+const PAGE_SIZE = 100;
+
+interface CommitRow {
+  hash: string;
+  message: string | null;
+  author_name: string | null;
+  author_email: string | null;
+  author_date: string | null;
+  committer_name: string | null;
+  committer_email: string | null;
+  committer_date: string | null;
+  total_seconds: number | null;
+  ref: string | null;
+  url: string | null;
+}
+
+const SELECT_COLUMNS =
+  "hash, message, author_name, author_email, author_date, committer_name, committer_email, committer_date, total_seconds, ref, url";
+
+function rowToCommit(row: CommitRow): Commit {
+  return {
+    hash: row.hash,
+    message: row.message ?? "",
+    author_name: row.author_name ?? undefined,
+    author_email: row.author_email ?? undefined,
+    author_date: row.author_date ? normalizeDateTime(row.author_date) : "",
+    committer_name: row.committer_name ?? undefined,
+    committer_email: row.committer_email ?? undefined,
+    committer_date: row.committer_date ? normalizeDateTime(row.committer_date) : undefined,
+    total_seconds: row.total_seconds ?? undefined,
+    human_readable_total: formatHumanReadable(row.total_seconds ?? 0),
+    ref: row.ref ?? undefined,
+    url: row.url ?? undefined,
+  };
+}
+
+/** Parse the 1-based `page` query param; null when invalid (non-integer or < 1). */
+function parsePage(raw: string | undefined): number | null {
+  if (raw === undefined) return 1;
+  if (!/^\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  return n >= 1 ? n : null;
+}
+
+const commits = new Hono<AuthEnv>();
+
+commits.use("/projects/:project/commits", authMiddleware);
+commits.use("/projects/:project/commits/*", authMiddleware);
+
+commits.get("/projects/:project/commits", async (c) => {
+  const userId = c.get("userId");
+  const project = c.req.param("project");
+
+  const page = parsePage(c.req.query("page"));
+  if (page === null) {
+    return c.json({ error: "Invalid page; must be an integer >= 1" }, 400);
+  }
+
+  const conditions = ["user_id = ?", "project = ?"];
+  const binds: (string | number)[] = [userId, project];
+  const author = c.req.query("author");
+  if (author !== undefined) {
+    conditions.push("author_email = ?");
+    binds.push(author);
+  }
+  const branch = c.req.query("branch");
+  if (branch !== undefined) {
+    conditions.push("ref = ?");
+    binds.push(branch);
+  }
+  const where = conditions.join(" AND ");
+
+  try {
+    const countRow = await c.env.DB.prepare(`SELECT COUNT(*) AS n FROM commits WHERE ${where}`)
+      .bind(...binds)
+      .first<{ n: number }>();
+    const total = countRow?.n ?? 0;
+
+    const { results } = await c.env.DB.prepare(
+      `SELECT ${SELECT_COLUMNS} FROM commits
+        WHERE ${where}
+        ORDER BY author_date DESC, hash ASC
+        LIMIT ? OFFSET ?`,
+    )
+      .bind(...binds, PAGE_SIZE, (page - 1) * PAGE_SIZE)
+      .all<CommitRow>();
+
+    return c.json({
+      data: results.map(rowToCommit),
+      page,
+      total_pages: Math.ceil(total / PAGE_SIZE),
+    });
+  } catch (err) {
+    console.error("GET /projects/:project/commits error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+commits.get("/projects/:project/commits/:hash", async (c) => {
+  const userId = c.get("userId");
+  const project = c.req.param("project");
+  const hash = c.req.param("hash");
+
+  const conditions = ["user_id = ?", "project = ?", "hash = ?"];
+  const binds: string[] = [userId, project, hash];
+  const branch = c.req.query("branch");
+  if (branch !== undefined) {
+    conditions.push("ref = ?");
+    binds.push(branch);
+  }
+
+  try {
+    const row = await c.env.DB.prepare(
+      `SELECT ${SELECT_COLUMNS} FROM commits WHERE ${conditions.join(" AND ")}`,
+    )
+      .bind(...binds)
+      .first<CommitRow>();
+    if (!row) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    return c.json({ data: rowToCommit(row) });
+  } catch (err) {
+    console.error("GET /projects/:project/commits/:hash error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export default commits;

--- a/src/routes/commits.ts
+++ b/src/routes/commits.ts
@@ -29,10 +29,11 @@ interface CommitRow {
   total_seconds: number | null;
   ref: string | null;
   url: string | null;
+  created_at: string;
 }
 
 const SELECT_COLUMNS =
-  "hash, message, author_name, author_email, author_date, committer_name, committer_email, committer_date, total_seconds, ref, url";
+  "hash, message, author_name, author_email, author_date, committer_name, committer_email, committer_date, total_seconds, ref, url, created_at";
 
 function rowToCommit(row: CommitRow): Commit {
   return {
@@ -40,7 +41,7 @@ function rowToCommit(row: CommitRow): Commit {
     message: row.message ?? "",
     author_name: row.author_name ?? undefined,
     author_email: row.author_email ?? undefined,
-    author_date: row.author_date ? normalizeDateTime(row.author_date) : "",
+    author_date: normalizeDateTime(row.author_date ?? row.created_at),
     committer_name: row.committer_name ?? undefined,
     committer_email: row.committer_email ?? undefined,
     committer_date: row.committer_date ? normalizeDateTime(row.committer_date) : undefined,

--- a/tests/integration/commits.test.ts
+++ b/tests/integration/commits.test.ts
@@ -41,7 +41,8 @@ function bearer(apiKey: string): Record<string, string> {
 
 interface SeedCommit {
   hash: string;
-  authorDate: string;
+  authorDate?: string | null;
+  message?: string | null;
   totalSeconds?: number | null;
   authorEmail?: string;
   ref?: string;
@@ -58,9 +59,9 @@ async function seedCommits(userId: string, items: SeedCommit[]): Promise<void> {
       userId,
       c.project ?? PROJECT,
       c.hash,
-      `msg ${c.hash}`,
+      Object.prototype.hasOwnProperty.call(c, "message") ? (c.message ?? null) : `msg ${c.hash}`,
       c.authorEmail ?? "nao@example.com",
-      c.authorDate,
+      c.authorDate ?? null,
       c.totalSeconds ?? null,
       c.ref ?? "main",
     ),
@@ -70,6 +71,8 @@ async function seedCommits(userId: string, items: SeedCommit[]): Promise<void> {
 
 interface CommitShape {
   hash: string;
+  message: string;
+  author_date: string;
   human_readable_total: string;
   total_seconds?: number;
   ref?: string;
@@ -168,6 +171,18 @@ describe("GET .../commits/:hash (single)", () => {
   it("404s on an unknown hash", async () => {
     const res = await call(`${COMMITS}/nope`, { headers: bearer(user.apiKey) });
     expect(res.status).toBe(404);
+  });
+
+  it("keeps required response fields schema-valid when nullable DB fields are missing", async () => {
+    await seedCommits(user.userId, [{ hash: "partial", authorDate: null, message: null, totalSeconds: null }]);
+
+    const res = await call(`${COMMITS}/partial`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    const { data } = (await res.json()) as { data: CommitShape };
+    expect(data.message).toBe("");
+    expect(data.author_date).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(data.human_readable_total).toBe("0 secs");
+    expect(data).not.toHaveProperty("total_seconds");
   });
 
   it("404s for another user's commit", async () => {

--- a/tests/integration/commits.test.ts
+++ b/tests/integration/commits.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for the Commits read endpoints (specs/107-commits/).
+ * Seeds the `commits` table directly (ingestion is deferred) and exercises
+ * list pagination/ordering/filters, single + 404, empty project, invalid
+ * page, cross-user isolation, and auth.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const PROJECT = "cloudtime";
+const COMMITS = `/api/v1/users/current/projects/${PROJECT}/commits`;
+
+let user: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", email: "alice@example.test", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("commits", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+interface SeedCommit {
+  hash: string;
+  authorDate: string;
+  totalSeconds?: number | null;
+  authorEmail?: string;
+  ref?: string;
+  project?: string;
+}
+
+async function seedCommits(userId: string, items: SeedCommit[]): Promise<void> {
+  const stmts = items.map((c) =>
+    env.DB.prepare(
+      `INSERT INTO commits (id, user_id, project, hash, message, author_name, author_email, author_date, total_seconds, ref)
+       VALUES (?, ?, ?, ?, ?, 'Nao', ?, ?, ?, ?)`,
+    ).bind(
+      crypto.randomUUID(),
+      userId,
+      c.project ?? PROJECT,
+      c.hash,
+      `msg ${c.hash}`,
+      c.authorEmail ?? "nao@example.com",
+      c.authorDate,
+      c.totalSeconds ?? null,
+      c.ref ?? "main",
+    ),
+  );
+  await env.DB.batch(stmts);
+}
+
+interface CommitShape {
+  hash: string;
+  human_readable_total: string;
+  total_seconds?: number;
+  ref?: string;
+}
+
+describe("GET .../commits (list)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    expect((await call(COMMITS)).status).toBe(401);
+  });
+
+  it("lists newest-first with page/total_pages and human_readable_total", async () => {
+    await seedCommits(user.userId, [
+      { hash: "old", authorDate: "2026-05-20T10:00:00Z", totalSeconds: 1800 },
+      { hash: "new", authorDate: "2026-05-22T10:00:00Z", totalSeconds: 3600 },
+      { hash: "mid", authorDate: "2026-05-21T10:00:00Z", totalSeconds: null },
+    ]);
+
+    const res = await call(COMMITS, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: CommitShape[]; page: number; total_pages: number };
+    expect(body.page).toBe(1);
+    expect(body.total_pages).toBe(1);
+    expect(body.data.map((c) => c.hash)).toEqual(["new", "mid", "old"]);
+    // NULL total_seconds → human_readable_total still present
+    expect(body.data.find((c) => c.hash === "mid")?.human_readable_total).toBeTruthy();
+  });
+
+  it("paginates at 100 per page", async () => {
+    const items: SeedCommit[] = Array.from({ length: 101 }, (_, i) => ({
+      hash: `h${String(i).padStart(3, "0")}`,
+      authorDate: `2026-05-${String((i % 28) + 1).padStart(2, "0")}T${String(i % 24).padStart(2, "0")}:00:00Z`,
+    }));
+    await seedCommits(user.userId, items);
+
+    const p1 = await call(`${COMMITS}?page=1`, { headers: bearer(user.apiKey) });
+    const b1 = (await p1.json()) as { data: CommitShape[]; total_pages: number };
+    expect(b1.data).toHaveLength(100);
+    expect(b1.total_pages).toBe(2);
+
+    const p2 = await call(`${COMMITS}?page=2`, { headers: bearer(user.apiKey) });
+    const b2 = (await p2.json()) as { data: CommitShape[] };
+    expect(b2.data).toHaveLength(1);
+  });
+
+  it("filters by author and branch", async () => {
+    await seedCommits(user.userId, [
+      { hash: "a", authorDate: "2026-05-20T10:00:00Z", authorEmail: "nao@example.com", ref: "main" },
+      { hash: "b", authorDate: "2026-05-21T10:00:00Z", authorEmail: "other@example.com", ref: "dev" },
+    ]);
+
+    const byAuthor = await call(`${COMMITS}?author=nao@example.com`, { headers: bearer(user.apiKey) });
+    expect(((await byAuthor.json()) as { data: CommitShape[] }).data.map((c) => c.hash)).toEqual(["a"]);
+
+    const byBranch = await call(`${COMMITS}?branch=dev`, { headers: bearer(user.apiKey) });
+    expect(((await byBranch.json()) as { data: CommitShape[] }).data.map((c) => c.hash)).toEqual(["b"]);
+  });
+
+  it("returns {data:[], total_pages:0} for an empty project", async () => {
+    const res = await call("/api/v1/users/current/projects/never-seen/commits", { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [], page: 1, total_pages: 0 });
+  });
+
+  it("400s on an invalid page", async () => {
+    expect((await call(`${COMMITS}?page=abc`, { headers: bearer(user.apiKey) })).status).toBe(400);
+    expect((await call(`${COMMITS}?page=0`, { headers: bearer(user.apiKey) })).status).toBe(400);
+  });
+
+  it("isolates commits per user (same project name)", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await seedCommits(bob.userId, [{ hash: "bobs", authorDate: "2026-05-20T10:00:00Z" }]);
+
+    const res = await call(COMMITS, { headers: bearer(user.apiKey) });
+    expect(((await res.json()) as { data: CommitShape[] }).data).toEqual([]);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+});
+
+describe("GET .../commits/:hash (single)", () => {
+  it("returns the commit, with branch filter support", async () => {
+    await seedCommits(user.userId, [{ hash: "abc123", authorDate: "2026-05-20T10:00:00Z", totalSeconds: 1800, ref: "main" }]);
+
+    const res = await call(`${COMMITS}/abc123`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(200);
+    const { data } = (await res.json()) as { data: CommitShape };
+    expect(data.hash).toBe("abc123");
+    expect(data.total_seconds).toBe(1800);
+
+    // matching branch ok
+    expect((await call(`${COMMITS}/abc123?branch=main`, { headers: bearer(user.apiKey) })).status).toBe(200);
+    // branch mismatch → 404
+    expect((await call(`${COMMITS}/abc123?branch=dev`, { headers: bearer(user.apiKey) })).status).toBe(404);
+  });
+
+  it("404s on an unknown hash", async () => {
+    const res = await call(`${COMMITS}/nope`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for another user's commit", async () => {
+    const bob = await seedUser({ username: "bob", email: "bob@example.test" });
+    await seedCommits(bob.userId, [{ hash: "bobs", authorDate: "2026-05-20T10:00:00Z" }]);
+
+    const res = await call(`${COMMITS}/bobs`, { headers: bearer(user.apiKey) });
+    expect(res.status).toBe(404);
+
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    expect((await call(`${COMMITS}/abc123`)).status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for **Commits** (issue #107), following the SpecKit 2-PR workflow. Wires the two read operations spec'd in #127 (merged) to handlers over the existing `commits` table — read path only; ingestion remains a deferred follow-up.

## Endpoints

| Method | Path | Result |
|---|---|---|
| `GET` | `/users/current/projects/{project}/commits` | 200 `{data, page, total_pages}` |
| `GET` | `/users/current/projects/{project}/commits/{hash}` | 200 `{data}` / 404 |

## What's in this PR

- **`src/routes/commits.ts`**:
  - `getProjectCommits` — `COUNT` + paged `SELECT` (100/page, `ORDER BY author_date DESC, hash ASC`), optional `author` (→`author_email`) and `branch` (→`ref`) filters, `page` validated (invalid → 400), returns `{data, page, total_pages}`.
  - `getProjectCommit` — by `(user_id, project, hash)` with optional `branch` (→`ref`) filter; 404 when absent / branch-mismatch / cross-user.
  - `rowToCommit` adds `human_readable_total = formatHumanReadable(total_seconds ?? 0)` and normalises dates; coalesces nullable `message`/`author_date` for the required `Commit` fields.
  - Mounted in `index.ts` (coexists with the users router's `/projects`).
- **Read-only** — no ingestion path; heartbeat ingestion untouched.
- **Tests** — `tests/integration/commits.test.ts`: list ordering, pagination (101 rows → 2 pages), author/branch filters, single + branch filter + 404, empty project, invalid page 400, cross-user isolation, 401.

## No schema / type change

OpenAPI + generated types landed in PR1 (#127). This PR is implementation + tests only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 266 passing (254 prior + 12 new)
- [ ] Manual `quickstart.md` A / B / D against a staging worker (seed via wrangler)

## Follow-up

Commit ingestion (CLI-plugin `POST` vs git webhook) remains a separate, deferred decision per the spec.