### PR TITLE
spec: Data Dumps export (PR1/2) #102

### DIFF
--- a/schemas/components/responses/ServiceUnavailable.yaml
+++ b/schemas/components/responses/ServiceUnavailable.yaml
@@ -6,6 +6,8 @@ content:
   application/json:
     schema:
       type: object
+      required:
+        - error
       properties:
         error:
           type: string

--- a/schemas/components/responses/ServiceUnavailable.yaml
+++ b/schemas/components/responses/ServiceUnavailable.yaml
@@ -1,0 +1,12 @@
+description: |
+  The requested capability is not configured on this instance. Returned, for
+  example, when a data export is requested but no R2 bucket (`R2_BUCKET`) is
+  bound — the same fail-closed pattern as email delivery (`EMAIL_PROVIDER`).
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Data export not configured

--- a/schemas/components/schemas/DataDump.yaml
+++ b/schemas/components/schemas/DataDump.yaml
@@ -8,22 +8,34 @@ properties:
     type: string
   type:
     type: string
+    description: |
+      `daily` exports per-day summary buckets; `full` exports a complete
+      bundle (user profile + summaries + per-day records + raw heartbeats).
     enum:
       - daily
-      - heartbeats
+      - full
   status:
     type: string
+    description: |
+      Lifecycle: `pending` (queued) → `processing` (cron is building it) →
+      `completed` (`download_url` available) or `failed`. `expired` once the
+      dump has passed `expires_at` and its stored object has been purged.
     enum:
       - pending
       - processing
       - completed
       - failed
+      - expired
   download_url:
     type: string
     format: uri
+    description: |
+      Short-lived signed URL to the export, present only when `status` is
+      `completed` and before `expires_at`.
   created_at:
     type: string
     format: date-time
   expires_at:
     type: string
     format: date-time
+    description: When the dump (and its stored object) is purged. Defaults to 7 days after creation.

--- a/schemas/components/schemas/DataDump.yaml
+++ b/schemas/components/schemas/DataDump.yaml
@@ -3,6 +3,7 @@ required:
   - id
   - type
   - status
+  - created_at
 properties:
   id:
     type: string
@@ -35,6 +36,7 @@ properties:
   created_at:
     type: string
     format: date-time
+    description: When the export request was created.
   expires_at:
     type: string
     format: date-time

--- a/schemas/paths/users/data-dumps.yaml
+++ b/schemas/paths/users/data-dumps.yaml
@@ -3,6 +3,13 @@ get:
   tags:
     - data_dumps
   summary: List data exports
+  description: |
+    Lists the authenticated user's data exports, newest first, with their
+    `status` and (once `completed`) a short-lived `download_url`.
+
+    Data export is gated on a bound R2 bucket (`R2_BUCKET`). When export is
+    not configured on this instance, the endpoint returns 503 — the same
+    fail-closed pattern as email delivery.
   responses:
     '200':
       description: List of data dumps
@@ -19,11 +26,23 @@ get:
                   $ref: ../../components/schemas/DataDump.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
+    '503':
+      $ref: ../../components/responses/ServiceUnavailable.yaml
 post:
   operationId: createDataDump
   tags:
     - data_dumps
   summary: Start a data export
+  description: |
+    Requests a data export. The server records a `pending` dump and an
+    async cron sweep builds it (`processing` → `completed`), uploading the
+    output to R2 and setting a short-lived `download_url`; `expires_at`
+    defaults to 7 days. `daily` exports per-day summaries; `full` bundles
+    user profile + summaries + per-day records + raw heartbeats.
+
+    Gated on a bound R2 bucket (`R2_BUCKET`); returns 503 when export is not
+    configured. `email_when_finished` is accepted but only acts when email
+    delivery is configured (multi-user mode). An unknown `type` returns 400.
   requestBody:
     required: true
     content:
@@ -37,7 +56,7 @@ post:
               type: string
               enum:
                 - daily
-                - heartbeats
+                - full
             email_when_finished:
               type: boolean
               default: true
@@ -53,5 +72,9 @@ post:
             properties:
               data:
                 $ref: ../../components/schemas/DataDump.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
     '401':
       $ref: ../../components/responses/Unauthorized.yaml
+    '503':
+      $ref: ../../components/responses/ServiceUnavailable.yaml

--- a/specs/102-data-dumps/checklists/requirements.md
+++ b/specs/102-data-dumps/checklists/requirements.md
@@ -9,9 +9,9 @@
 - [x] `data-model.md` confirms no D1 schema change, documents the R2 key + lifecycle statements + bundle shape.
 - [x] `quickstart.md` enumerates scenarios A–H (incl. the 503-when-unbound path).
 - [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
-- [x] `contracts/openapi-diff.md` documents the enum reconciliation + `400`/`503` additions.
-- [x] `ServiceUnavailable.yaml` exists; `DataDump.yaml` + `data-dumps.yaml` carry the reconciled enums, descriptions, and 400/503.
-- [x] `npm run generate` reflects `type: daily|full`, `status` + `expired`, and the new responses; `npm run typecheck` passes.
+- [x] `contracts/openapi-diff.md` documents the enum reconciliation, required `created_at`, required 503 error body, and `400`/`503` additions.
+- [x] `ServiceUnavailable.yaml` exists; `DataDump.yaml` + `data-dumps.yaml` carry the reconciled enums, required `created_at`, descriptions, and 400/503.
+- [x] `npm run generate` reflects `type: daily|full`, `status` + `expired`, required `created_at`, and the new responses; `npm run typecheck` passes.
 - [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
 - [x] PR1 references issue #102 and flags the `type` reconciliation for review.
 

--- a/specs/102-data-dumps/checklists/requirements.md
+++ b/specs/102-data-dumps/checklists/requirements.md
@@ -1,0 +1,51 @@
+# Acceptance Checklist: Data Dumps (Export)
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-009 (request / list / async build / expiry / gating) with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` records the spec-level decisions (R2-gated 503, cron sweep, `type` `daily|full`, `status` + `expired`).
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 6 design decisions (incl. the flagged `heartbeats`→`full` reconciliation and worker-mediated download).
+- [x] `data-model.md` confirms no D1 schema change, documents the R2 key + lifecycle statements + bundle shape.
+- [x] `quickstart.md` enumerates scenarios A–H (incl. the 503-when-unbound path).
+- [x] `tasks.md` separates PR1 from PR2 with dependency arrows.
+- [x] `contracts/openapi-diff.md` documents the enum reconciliation + `400`/`503` additions.
+- [x] `ServiceUnavailable.yaml` exists; `DataDump.yaml` + `data-dumps.yaml` carry the reconciled enums, descriptions, and 400/503.
+- [x] `npm run generate` reflects `type: daily|full`, `status` + `expired`, and the new responses; `npm run typecheck` passes.
+- [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
+- [x] PR1 references issue #102 and flags the `type` reconciliation for review.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/types.ts` adds `R2_BUCKET?: R2Bucket`; `wrangler.toml` documents the (commented, opt-in) `[[r2_buckets]]` binding.
+- [ ] `src/routes/data-dumps.ts`: both handlers gate on `R2_BUCKET` (503 when unbound), behind `authMiddleware`:
+  - `POST` — validate `type ∈ {daily, full}` (400), dedupe in-flight, insert `pending`, return `201 {data}`.
+  - `GET` — list user's dumps newest-first; omit `download_url` unless `completed` & unexpired.
+- [ ] `src/utils/export-bundle.ts`: `buildDailyExport` / `buildFullExport` — `user_id`-scoped D1 reads → JSON; unit-tested for shape.
+- [ ] `src/cron/data-dumps.ts`: `processPendingDumps` (bounded per run: pending → processing → R2 put → completed/failed) and `purgeExpiredDumps` (R2 delete + status `expired`); wired into `scheduled()` via `Promise.allSettled`.
+- [ ] Download mechanism (worker-mediated route or presigned), short-lived + owner-only; expired/unknown → 404.
+- [ ] `src/index.ts` mounts the route (+ cron wiring).
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: 503 when R2 unbound (both endpoints). B: POST → pending. C: dedupe returns the in-flight dump. D: cron → completed with `download_url`/`expires_at`.
+- [ ] E: download returns the bundle (correct keys per `type`). F: unknown `type` 400. G: expiry → `expired` + 404 + R2 object gone. H: 401 + cross-user isolation.
+
+### Tests
+
+- [ ] `tests/integration/data-dumps.test.ts`: 503-when-unbound, create/dedupe, list/ownership, validation 400, 401. (Cron build/purge + R2 via the test pool's R2 binding or a stub.)
+- [ ] `tests/aggregation/export-bundle.test.ts` (or similar): bundle shape for `daily` and `full`.
+- [ ] `npm test` stays green with the new coverage.
+
+### Docs
+
+- [ ] `docs/operations.md`: section on enabling export (R2 binding, retention, download).
+
+## Post-deployment gate
+
+- [ ] With R2 bound, request a `full` export, confirm the cron builds it and the download round-trips the data.
+- [ ] Confirm an expired dump is purged from R2 and marked `expired`.
+- [ ] Without R2 bound, confirm 503 and no errors in logs.

--- a/specs/102-data-dumps/contracts/openapi-diff.md
+++ b/specs/102-data-dumps/contracts/openapi-diff.md
@@ -7,10 +7,10 @@ responses (`400`, `503`). No new operations.
 ## Files touched
 
 1. `schemas/components/responses/ServiceUnavailable.yaml` — **new** `503`
-   response (capability not configured).
+   response (capability not configured) with required `error`.
 2. `schemas/components/schemas/DataDump.yaml` — `type` `daily|heartbeats` →
-   **`daily|full`**; `status` adds **`expired`**; field descriptions
-   (`download_url`, `expires_at`).
+   **`daily|full`**; `status` adds **`expired`**; make `created_at`
+   required; field descriptions (`download_url`, `created_at`, `expires_at`).
 3. `schemas/paths/users/data-dumps.yaml`
    - `getDataDumps`: add `503`; document R2 gating + status/`download_url`.
    - `createDataDump`: request `type` enum → `daily|full`; add `400` + `503`;
@@ -37,14 +37,14 @@ No path changes; no new operations.
 
 `DataDump`: `type ∈ {daily, full}`, `status ∈ {pending, processing,
 completed, failed, expired}`, optional `download_url` (when completed),
-`created_at`, `expires_at`.
+required `created_at`, optional `expires_at`.
 
 ## Generated-types impact
 
 `npm run generate` updates `components["schemas"]["DataDump"]` (`type`,
-`status` enums), adds the `503` response to both operations and `400` to
-`createDataDump`, and the `createDataDump` request `type` enum. No other
-body shapes change.
+`status` enums, required `created_at`), adds the `503` response to both
+operations and `400` to `createDataDump`, and the `createDataDump` request
+`type` enum. `ServiceUnavailable.error` is required.
 
 ## SDD compliance note
 

--- a/specs/102-data-dumps/contracts/openapi-diff.md
+++ b/specs/102-data-dumps/contracts/openapi-diff.md
@@ -1,0 +1,53 @@
+# OpenAPI Diff
+
+The `getDataDumps` / `createDataDump` operations and the `DataDump` schema
+already existed. This PR reconciles the enums and adds the missing error
+responses (`400`, `503`). No new operations.
+
+## Files touched
+
+1. `schemas/components/responses/ServiceUnavailable.yaml` — **new** `503`
+   response (capability not configured).
+2. `schemas/components/schemas/DataDump.yaml` — `type` `daily|heartbeats` →
+   **`daily|full`**; `status` adds **`expired`**; field descriptions
+   (`download_url`, `expires_at`).
+3. `schemas/paths/users/data-dumps.yaml`
+   - `getDataDumps`: add `503`; document R2 gating + status/`download_url`.
+   - `createDataDump`: request `type` enum → `daily|full`; add `400` + `503`;
+     document async cron lifecycle, 7-day expiry, and `email_when_finished`
+     (multi-user only).
+
+No path changes; no new operations.
+
+## Reconciliations (flagged for review)
+
+- **`type`: `heartbeats` → `full`.** The issue's scope says `type=daily|full`
+  and describes a multi-file bundle; `full` (user + summaries + daily +
+  heartbeats) serves migration/portability, where `heartbeats`-only did not.
+  This corrects the declared enum toward the issue's intent — a spec-first
+  change called out for sign-off.
+- **`status`: add `expired`.** Needed to represent dumps past `expires_at`
+  whose R2 object has been purged (distinct from `completed`).
+
+## Contract
+
+- `GET /users/current/data_dumps` → `200 {data: DataDump[]}`, `401`, `503`.
+- `POST /users/current/data_dumps` (`{type: daily|full, email_when_finished?}`)
+  → `201 {data: DataDump}`, `400`, `401`, `503`.
+
+`DataDump`: `type ∈ {daily, full}`, `status ∈ {pending, processing,
+completed, failed, expired}`, optional `download_url` (when completed),
+`created_at`, `expires_at`.
+
+## Generated-types impact
+
+`npm run generate` updates `components["schemas"]["DataDump"]` (`type`,
+`status` enums), adds the `503` response to both operations and `400` to
+`createDataDump`, and the `createDataDump` request `type` enum. No other
+body shapes change.
+
+## SDD compliance note
+
+PR1 lands SpecKit + the enum/response reconciliation + regenerated types.
+PR2 lands the `R2_BUCKET` binding, the route handlers, the cron build/purge,
+the export bundler, and tests. No runtime code in PR1.

--- a/specs/102-data-dumps/data-model.md
+++ b/specs/102-data-dumps/data-model.md
@@ -83,7 +83,8 @@ Built by `src/utils/export-bundle.ts` from D1 reads (`users`, `summaries`, `hear
 |---|---|
 | `id`, `type`, `status` | Pass through (enums) |
 | `download_url` | Present only when `status = completed` and unexpired; else omitted |
-| `created_at`, `expires_at` | `normalizeDateTime` → ISO 8601 (expires_at omitted when null) |
+| `created_at` | Always present; `normalizeDateTime` → ISO 8601 |
+| `expires_at` | `normalizeDateTime` → ISO 8601 when present; omitted when null |
 
 `user_id` is not surfaced in the `DataDump` response.
 

--- a/specs/102-data-dumps/data-model.md
+++ b/specs/102-data-dumps/data-model.md
@@ -1,0 +1,92 @@
+# Data Model: Data Dumps (Export)
+
+No D1 schema changes. Adds an R2 binding (PR2) and uses the existing
+`data_dumps` table plus R2 objects.
+
+## `data_dumps` (existing, unchanged)
+
+```sql
+CREATE TABLE IF NOT EXISTS data_dumps (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'daily',        -- daily | full
+  status TEXT NOT NULL DEFAULT 'pending',     -- pending | processing | completed | failed | expired
+  download_url TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+
+The application owns the `type` / `status` vocabularies (the column has no CHECK), so the enum reconciliation is contract-only.
+
+## R2 (new binding in PR2)
+
+- **Binding**: `R2_BUCKET` (optional). The feature is gated on its presence.
+- **Object key**: `dumps/{user_id}/{dump_id}.json`.
+- **Lifecycle**: written by the cron on `completed`; deleted by the cron on expiry.
+
+## Lifecycle / statements
+
+### Create (POST)
+```sql
+-- dedupe: reuse an in-flight dump of the same type
+SELECT * FROM data_dumps
+ WHERE user_id = ? AND type = ? AND status IN ('pending','processing')
+ ORDER BY created_at DESC LIMIT 1;
+-- else insert pending:
+INSERT INTO data_dumps (id, user_id, type, status) VALUES (?, ?, ?, 'pending');
+```
+
+### List (GET)
+```sql
+SELECT id, type, status, download_url, created_at, expires_at
+  FROM data_dumps WHERE user_id = ? ORDER BY created_at DESC;
+```
+
+### Cron — build pending
+```sql
+SELECT id, user_id, type FROM data_dumps WHERE status = 'pending' LIMIT N;   -- bounded per run
+UPDATE data_dumps SET status = 'processing' WHERE id = ?;
+-- build bundle → R2.put(key, json) →
+UPDATE data_dumps SET status = 'completed', download_url = ?, expires_at = datetime('now','+7 days') WHERE id = ?;
+-- on error:
+UPDATE data_dumps SET status = 'failed' WHERE id = ?;
+```
+
+### Cron — purge expired
+```sql
+SELECT id, user_id FROM data_dumps
+ WHERE status = 'completed' AND expires_at IS NOT NULL AND expires_at < datetime('now');
+-- R2.delete(key) → UPDATE data_dumps SET status = 'expired', download_url = NULL WHERE id = ?;
+```
+
+## Export bundle shape (JSON object stored in R2)
+
+```jsonc
+// daily
+{ "user": { … profile … },
+  "summaries": [ { "date": "YYYY-MM-DD", "total_seconds": n, … } ] }
+
+// full
+{ "user": { … },
+  "summaries": [ … ],
+  "daily": [ { "date": "YYYY-MM-DD", … per-day rollup … } ],
+  "heartbeats": [ { … raw heartbeat … } ] }
+```
+
+Built by `src/utils/export-bundle.ts` from D1 reads (`users`, `summaries`, `heartbeats`), all `user_id`-scoped.
+
+## Field treatment (`rowToDump`)
+
+| Column | Treatment |
+|---|---|
+| `id`, `type`, `status` | Pass through (enums) |
+| `download_url` | Present only when `status = completed` and unexpired; else omitted |
+| `created_at`, `expires_at` | `normalizeDateTime` → ISO 8601 (expires_at omitted when null) |
+
+`user_id` is not surfaced in the `DataDump` response.
+
+## Cleanup / cascade
+
+`data_dumps` cascades on user delete. R2 objects are purged by the expiry sweep; orphaned objects from a deleted user are a known minor follow-up (a future cron could reconcile R2 against D1).

--- a/specs/102-data-dumps/plan.md
+++ b/specs/102-data-dumps/plan.md
@@ -7,7 +7,7 @@
 
 Wire `getDataDumps` / `createDataDump` to handlers over the existing `data_dumps` table, with an R2-backed async build run by the existing hourly cron. The feature is gated on a bound `R2_BUCKET` (503 when unbound), so it ships safely without R2 provisioned and operators opt in by binding the bucket.
 
-PR1 (this PR): SpecKit artifacts + OpenAPI reconciliation (`type` `daily|full`, `status` + `expired`, `503`/`400` responses, new `ServiceUnavailable` response). PR2: the `R2_BUCKET` binding, the two route handlers, the cron sweep (build + purge), the export bundler, the download mechanism, and tests.
+PR1 (this PR): SpecKit artifacts + OpenAPI reconciliation (`type` `daily|full`, `status` + `expired`, required `created_at`, `503`/`400` responses, new `ServiceUnavailable` response). PR2: the `R2_BUCKET` binding, the two route handlers, the cron sweep (build + purge), the export bundler, the download mechanism, and tests.
 
 ## Technical Context
 
@@ -22,7 +22,7 @@ PR1 (this PR): SpecKit artifacts + OpenAPI reconciliation (`type` `daily|full`, 
 
 | Principle | Status | Notes |
 |-----------|--------|-------|
-| I. SDD | PASS | Operations already declared; PR1 reconciles enums + adds 503/400, PR2 implements. `npm run generate` reflects the enum/response changes. |
+| I. SDD | PASS | Operations already declared; PR1 reconciles enums + required fields and adds 503/400, PR2 implements. `npm run generate` reflects the enum/response changes. |
 | II. Cloudflare-Native | PASS | R2 binding for object storage; reuses the existing hourly cron for async (no Queues). Fail-closed when unbound. |
 | III. Type Safety | PASS | Handlers use `components["schemas"]["DataDump"]`. No hand-edited types. |
 | IV. Legal/Trademark | PASS | Export shape derived from our own schema/data; "WakaTime-compatible" only in docs. |

--- a/specs/102-data-dumps/plan.md
+++ b/specs/102-data-dumps/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Data Dumps (Export)
+
+**Branch**: `102-data-dumps` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/102-data-dumps/spec.md`
+
+## Summary
+
+Wire `getDataDumps` / `createDataDump` to handlers over the existing `data_dumps` table, with an R2-backed async build run by the existing hourly cron. The feature is gated on a bound `R2_BUCKET` (503 when unbound), so it ships safely without R2 provisioned and operators opt in by binding the bucket.
+
+PR1 (this PR): SpecKit artifacts + OpenAPI reconciliation (`type` `daily|full`, `status` + `expired`, `503`/`400` responses, new `ServiceUnavailable` response). PR2: the `R2_BUCKET` binding, the two route handlers, the cron sweep (build + purge), the export bundler, the download mechanism, and tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`data_dumps`, existing) + R2 (`R2_BUCKET`, new binding in PR2)
+**Testing**: Vitest + workers pool — handler tests (503 when unbound, create/list, ownership) and bundler unit tests; R2 exercised via the test pool's R2 binding or a stub
+**Performance Goals**: <10ms CPU on the request path (the build runs in cron)
+**Constraints**: Workers CPU budget; D1 row-size (dumps live in R2, not D1)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Operations already declared; PR1 reconciles enums + adds 503/400, PR2 implements. `npm run generate` reflects the enum/response changes. |
+| II. Cloudflare-Native | PASS | R2 binding for object storage; reuses the existing hourly cron for async (no Queues). Fail-closed when unbound. |
+| III. Type Safety | PASS | Handlers use `components["schemas"]["DataDump"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Export shape derived from our own schema/data; "WakaTime-compatible" only in docs. |
+| V. Simplicity First | PASS | Cron sweep over Queues; JSON bundle over zip; worker-mediated download over S3 presigning (no extra creds). |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/102-data-dumps/
+├── plan.md, spec.md, research.md, data-model.md, quickstart.md, tasks.md
+├── contracts/openapi-diff.md
+└── checklists/requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── data-dumps.ts        # NEW: getDataDumps + createDataDump (R2-gated, 503 when unbound)
+├── cron/
+│   └── data-dumps.ts        # NEW: processPendingDumps + purgeExpiredDumps (called from scheduled())
+├── utils/
+│   └── export-bundle.ts     # NEW: buildDailyExport / buildFullExport (pure-ish D1 readers → JSON)
+├── types.ts                 # R2_BUCKET?: R2Bucket binding
+├── index.ts                 # cron wiring + route mount (+ optional download route)
+└── wrangler.toml            # documented [[r2_buckets]] binding (commented opt-in)
+```
+
+**Structure Decision**: Thin handlers (gate on binding, write/read one row) keep the request path cheap; all heavy lifting (read D1 → serialise → upload R2) is in the cron module. The bundler is separated so its JSON shape is unit-testable.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **R2-gated, 503 when unbound** (email-style fail-closed).
+2. **Async = existing hourly cron sweep** (build pending + purge expired); no Queues.
+3. **`type` `daily|full`**, **`status` + `expired`** (reconciled).
+4. **JSON bundle** (no zip); R2 key `dumps/{user_id}/{dump_id}.json`.
+5. **Download** = worker-mediated, token-guarded route (no S3 presign creds); 7-day expiry.
+6. **Dedupe**: a `POST` returns an existing `pending`/`processing` dump of the same `type`.
+
+## Phase 1 — Design Outputs
+
+### Handlers (gate first)
+
+```ts
+function exportEnabled(env: Env): boolean { return !!env.R2_BUCKET; }
+
+dataDumps.post("/data_dumps", async (c) => {
+  if (!exportEnabled(c.env)) return c.json({ error: "Data export not configured" }, 503);
+  const { type } = await c.req.json();                 // validate ∈ {daily, full} → 400
+  const existing = await findPending(c.env.DB, userId, type);
+  if (existing) return c.json({ data: rowToDump(existing) }, 201);
+  const id = crypto.randomUUID();
+  await insertPending(c.env.DB, id, userId, type);
+  return c.json({ data: rowToDump(await selectDump(c.env.DB, id, userId)) }, 201);
+});
+
+dataDumps.get("/data_dumps", async (c) => {
+  if (!exportEnabled(c.env)) return c.json({ error: "Data export not configured" }, 503);
+  // SELECT … WHERE user_id = ? ORDER BY created_at DESC
+});
+```
+
+### Cron sweep (in scheduled())
+
+```ts
+// process a bounded number of pending dumps per run
+for (const dump of pending) {
+  setStatus(dump.id, "processing");
+  const body = dump.type === "full" ? await buildFullExport(env.DB, dump.user_id)
+                                     : await buildDailyExport(env.DB, dump.user_id);
+  await env.R2_BUCKET.put(`dumps/${dump.user_id}/${dump.id}.json`, JSON.stringify(body));
+  setCompleted(dump.id, downloadUrlFor(dump), addDays(now, 7));   // or "failed" on throw
+}
+// purge: for dumps past expires_at → R2 delete + status="expired"
+```
+
+### Download
+
+`download_url` points at a worker-mediated route that validates ownership + a short-lived token and streams the R2 object; expired/unknown → 404. (Presigned R2 S3 URLs are an alternative if S3 creds are configured — see research.) The exact route is finalised in PR2; it is not a new OpenAPI operation in PR1.
+
+### OpenAPI surface
+
+Reconciled in PR1 — see [contracts/openapi-diff.md](./contracts/openapi-diff.md).
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+The genuinely new pieces are the R2 binding and the cron build/purge. Both are isolated: handlers gate-and-record only; the bundler is pure D1 reads → JSON; the download path is the one open design point, resolved in PR2 with a worker-mediated default to avoid S3 credentials.

--- a/specs/102-data-dumps/quickstart.md
+++ b/specs/102-data-dumps/quickstart.md
@@ -1,0 +1,100 @@
+# Quickstart: Data Dumps (Export)
+
+Manual verification once PR2 (implementation) is deployed.
+
+## Prerequisites
+
+```bash
+export API_KEY=ck_xxx
+export BASE=https://cloudtime.example.dev/api/v1
+export H="Authorization: Bearer $API_KEY"
+export DUMPS="$BASE/users/current/data_dumps"
+```
+
+Enable export by binding R2 in `wrangler.toml` and redeploying:
+
+```toml
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "cloudtime-dumps"
+```
+
+## Scenario A — Export not configured (no R2)
+
+With **no** `R2_BUCKET` bound:
+
+```bash
+curl -si "$DUMPS" -H "$H"
+curl -siX POST "$DUMPS" -H "$H" -H "Content-Type: application/json" -d '{"type":"full"}'
+```
+
+**Expected**: both return **503** `{"error":"Data export not configured"}`; nothing is created.
+
+## Scenario B — Request a full export
+
+With R2 bound:
+
+```bash
+curl -sX POST "$DUMPS" -H "$H" -H "Content-Type: application/json" -d '{"type":"full"}'
+```
+
+**Expected**: 201 with `{data:{id, type:"full", status:"pending", created_at}}`.
+
+## Scenario C — Dedupe in-flight requests
+
+```bash
+curl -sX POST "$DUMPS" -H "$H" -H "Content-Type: application/json" -d '{"type":"full"}'
+```
+
+**Expected**: returns the **same** pending dump `id` as Scenario B (no duplicate queued).
+
+## Scenario D — Cron builds it
+
+Wait for the hourly cron (or trigger a scheduled run in dev), then:
+
+```bash
+curl -s "$DUMPS" -H "$H"
+```
+
+**Expected**: the dump shows `status:"completed"` with a `download_url` and an `expires_at` ≈ 7 days out.
+
+## Scenario E — Download
+
+```bash
+curl -sL "<download_url from Scenario D>" -H "$H" | jq 'keys'
+```
+
+**Expected**: the bundle JSON — for `full`, keys `["daily","heartbeats","summaries","user"]`; for `daily`, `["summaries","user"]`.
+
+## Scenario F — Validation
+
+```bash
+curl -siX POST "$DUMPS" -H "$H" -H "Content-Type: application/json" -d '{"type":"everything"}'
+```
+
+**Expected**: 400 (unknown `type`).
+
+## Scenario G — Expiry
+
+After `expires_at` passes and the cron purge runs:
+
+```bash
+curl -s "$DUMPS" -H "$H"            # dump now status:"expired", no download_url
+curl -si "<old download_url>" -H "$H"  # 404
+```
+
+**Expected**: the dump is `expired`; the old URL 404s; the R2 object is gone.
+
+## Scenario H — Auth / isolation
+
+```bash
+curl -si "$DUMPS"   # no auth → 401 (when R2 bound; 503 takes precedence only after auth)
+```
+
+**Expected**: 401 unauthenticated. Another user never sees or downloads your dumps.
+
+## Reverting / cleanup
+
+Unbinding `R2_BUCKET` returns the feature to 503. Existing `data_dumps` rows
+remain in D1; their R2 objects are purged on expiry. Removing the route +
+cron hooks disables the feature without touching other data.

--- a/specs/102-data-dumps/quickstart.md
+++ b/specs/102-data-dumps/quickstart.md
@@ -91,7 +91,7 @@ curl -si "<old download_url>" -H "$H"  # 404
 curl -si "$DUMPS"   # no auth → 401 (when R2 bound; 503 takes precedence only after auth)
 ```
 
-**Expected**: 401 unauthenticated. Another user never sees or downloads your dumps.
+**Expected**: 401 unauthenticated. Auth is checked before R2 gating; another user never sees or downloads your dumps.
 
 ## Reverting / cleanup
 

--- a/specs/102-data-dumps/research.md
+++ b/specs/102-data-dumps/research.md
@@ -1,0 +1,72 @@
+# Research: Data Dumps (Export)
+
+## Decision 1: R2-gated, fail-closed (503 when unbound)
+
+**Decision**: The feature requires a bound `R2_BUCKET`. When it is not bound, `getDataDumps` and `createDataDump` return 503 ("Data export not configured"). Operators opt in by binding the bucket in `wrangler.toml`.
+
+**Rationale**:
+- Exports of any size belong in object storage, not D1 (row-size limits) or inline response bodies (defeats async). R2 is the Cloudflare-native choice.
+- Gating on the binding mirrors the email-delivery pattern (`EMAIL_PROVIDER` → 503), so the feature can merge and run on instances that have not provisioned R2 without erroring confusingly — it simply reports "not configured".
+
+**Alternative considered**: inline body on first GET (no R2). Rejected — defeats async semantics and breaks for large `full` dumps. D1 BLOB: rejected — row-size limited.
+
+---
+
+## Decision 2: Async via the existing hourly cron sweep (not Queues)
+
+**Decision**: `POST` records a `pending` row; the existing hourly cron builds pending dumps and purges expired ones. No Cloudflare Queues binding is introduced.
+
+**Rationale**:
+- The project already runs an hourly cron (aggregation + session cleanup + heartbeat purge). Adding a dump sweep there reuses proven wiring and avoids a new Queues binding/consumer to operate.
+- Export latency of up to ~1 hour is acceptable for a migration/backup feature; it is not interactive.
+
+**Alternative considered**: Cloudflare Queues for near-immediate processing. Rejected for the first cut — more infrastructure for a non-interactive feature; can be added later behind the same `data_dumps` contract.
+
+---
+
+## Decision 3: `type` = `daily | full`; `status` + `expired`
+
+**Decision**: Reconcile the declared `type` enum `daily | heartbeats` → **`daily | full`**, and add **`expired`** to the `status` enum (`pending | processing | completed | failed | expired`).
+
+**Rationale**:
+- The issue's scope states `type = daily | full`, and its "output format" lists a multi-file bundle (user / summaries / daily / heartbeats). A `full` export serves the migration/portability use cases far better than a heartbeats-only dump; `heartbeats` is a *component* of `full`, not a useful standalone primary type.
+- `expired` is needed to represent dumps whose 7-day window has passed and whose R2 object was purged — distinct from `completed`.
+
+**Flagged for review**: this changes the declared `heartbeats` enum value to `full`. It is a deliberate spec-first reconciliation toward the issue's intent; called out in the PR description for sign-off.
+
+**Alternative considered**: keep `daily | heartbeats` (strict SSoT). Rejected — it contradicts the issue's own scope and output description; the SSoT is being corrected here, which is what a spec-first PR is for.
+
+---
+
+## Decision 4: JSON bundle; R2 key per dump
+
+**Decision**: A dump is a single JSON object stored at `dumps/{user_id}/{dump_id}.json`. `daily` = `{ user, summaries (per-day) }`; `full` = `{ user, summaries, daily, heartbeats }`. No zip/compression in the first cut.
+
+**Rationale**:
+- A single JSON object is trivial to produce in a Worker (no zip library) and to consume downstream. The per-user/per-dump key namespaces objects and makes purge a single delete.
+- Compression can be layered later (e.g. gzip on `put`) without changing the contract.
+
+**Alternative considered**: a zip of separate files (`user.json`, `heartbeats.json`, …). Rejected for the first cut — needs a zip lib in the Worker; the one-object JSON is simpler and equivalent for tooling.
+
+---
+
+## Decision 5: Worker-mediated download (no S3 presign creds)
+
+**Decision**: `download_url` points at a worker-mediated route that validates ownership + a short-lived token and streams the R2 object, rather than an S3 presigned URL. Expired/unknown → 404.
+
+**Rationale**:
+- R2 S3 presigned URLs require provisioning S3 API credentials and signing — extra setup and secrets. A worker route that reads the object via the existing `R2_BUCKET` binding and checks auth/token is simpler and needs no new credentials.
+- Keeps the "short-lived, owner-only" guarantee (token + expiry) without public durable links.
+
+**Alternative considered**: R2 S3 presigned URLs. Viable when an operator has S3 creds configured; left as an option for PR2 but not the default. The exact download route is finalised in PR2 (it is not a new OpenAPI operation in PR1).
+
+---
+
+## Decision 6: Dedupe pending requests
+
+**Decision**: A `POST` for a `type` that already has a `pending` or `processing` dump returns that existing dump instead of creating another.
+
+**Rationale**:
+- Bounds work and storage: a user (or a retrying client) cannot queue dozens of identical full exports. Returning the in-flight dump is the least-surprising idempotent behaviour.
+
+**Alternative considered**: 409 Conflict on a duplicate. Rejected — returning the existing dump is friendlier and lets clients poll the same id.

--- a/specs/102-data-dumps/spec.md
+++ b/specs/102-data-dumps/spec.md
@@ -7,7 +7,7 @@
 
 ## Background
 
-A user-facing self-service export supports migration (between CloudTime instances, or to/from official WakaTime-compatible tooling), personal backup, and data-portability hygiene — distinct from operator-side D1 backups. A dump is requested, built asynchronously, and made available at a short-lived URL for a limited window.
+A user-facing self-service export supports migration (between CloudTime instances, or to/from WakaTime-compatible tooling), personal backup, and data-portability hygiene — distinct from operator-side D1 backups. A dump is requested, built asynchronously, and made available at a short-lived URL for a limited window.
 
 ## Spec-level decisions (resolved in this PR)
 
@@ -72,7 +72,7 @@ As an authenticated user, I want to see my exports and their status so I know wh
 
 ### Non-Functional Requirements
 
-- **NFR-001**: Building a dump MUST happen in the cron (off the request path); the `POST`/`GET` handlers MUST stay within the 10ms CPU budget (single-row write / indexed list).
+- **NFR-001**: Building a dump MUST happen in the cron (off the request path); the `POST`/`GET` handlers MUST stay within the 10ms CPU budget (single-row write / bounded user-scoped list).
 - **NFR-002**: No new external dependency. R2 access uses the Workers R2 binding. The async path reuses the existing hourly cron (no Queues binding).
 - **NFR-003**: No D1 schema migration — the `data_dumps` table already exists.
 

--- a/specs/102-data-dumps/spec.md
+++ b/specs/102-data-dumps/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Data Dumps (Export)
+
+**Feature Branch**: `102-data-dumps`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: The `data_dumps` D1 table and the `getDataDumps` / `createDataDump` OpenAPI operations exist, but no route is implemented. Users cannot export their own data via the API.
+
+## Background
+
+A user-facing self-service export supports migration (between CloudTime instances, or to/from official WakaTime-compatible tooling), personal backup, and data-portability hygiene — distinct from operator-side D1 backups. A dump is requested, built asynchronously, and made available at a short-lived URL for a limited window.
+
+## Spec-level decisions (resolved in this PR)
+
+- **R2-gated, fail-closed**: the feature requires a bound R2 bucket (`R2_BUCKET`). When it is not bound, both endpoints return **503** ("Data export not configured") — the same pattern as email delivery (`EMAIL_PROVIDER`). Operators opt in by binding R2.
+- **Async via the existing hourly cron sweep** (not Cloudflare Queues): `POST` records a `pending` dump; the hourly cron builds pending dumps and purges expired ones. This avoids a new Queue binding and reuses the established cron.
+- **`type` = `daily | full`** (reconciled from the declared `daily | heartbeats`): `daily` exports per-day summaries; `full` bundles user profile + summaries + per-day records + raw heartbeats. This matches the issue's stated scope and the portability use case. *(Flagged for review — supersedes the prior `heartbeats` enum value.)*
+- **`status` adds `expired`**: lifecycle is `pending → processing → completed | failed`, plus `expired` once past `expires_at` and the stored object is purged.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Request and download an export (Priority: P2)
+
+As an authenticated user, I want to request an export and later download it, so I can migrate or back up my data.
+
+**Independent Test**: With R2 bound, `POST /data_dumps {type:"full"}` returns 201 with a `pending` dump. After the cron sweep runs, `GET /data_dumps` shows that dump `completed` with a `download_url`; fetching the URL returns the bundle.
+
+**Acceptance Scenarios**:
+1. **Given** R2 is bound, **When** POSTing a valid `type`, **Then** 201 with `{data: DataDump}` `status=pending`, `id`, `created_at`.
+2. **Given** a pending dump, **When** the cron sweep runs, **Then** it transitions to `processing` then `completed`, with `download_url` and `expires_at` (≈ now + 7 days) set.
+3. **Given** a completed dump, **When** the user GETs the list, **Then** the entry includes the `download_url`.
+4. **Given** an unknown `type`, **When** POSTing, **Then** 400.
+5. **Given** R2 is **not** bound, **When** POSTing or listing, **Then** 503 and nothing is created.
+6. **Given** an unauthenticated request, **Then** 401.
+
+---
+
+### User Story 2 - List my exports with status (Priority: P2)
+
+As an authenticated user, I want to see my exports and their status so I know when one is ready.
+
+**Acceptance Scenarios**:
+1. **Given** several dumps, **When** listing, **Then** they return newest-first with `status` and (when completed) `download_url`.
+2. **Given** another user's dumps, **When** listing, **Then** none appear.
+3. **Given** a dump past `expires_at`, **When** listing, **Then** its `status` is `expired` and it has no `download_url`.
+
+---
+
+### Edge Cases
+
+- **Duplicate request**: a `POST` for a `type` that already has a `pending`/`processing` dump returns the existing dump rather than queuing a duplicate (idempotent-ish; bounds work).
+- **R2 unbound mid-flight**: if R2 becomes unavailable during processing, the dump is marked `failed` (cron logs); the user can retry.
+- **`full` with no data**: produces a valid bundle with empty arrays.
+- **Expiry**: the cron purges the R2 object and marks the row `expired`; a later download attempt 404s.
+- **`email_when_finished`**: accepted but only acts when email delivery is configured (multi-user); a no-op in single-user.
+- **Large heartbeat volume**: `full` may be large; it is built in the cron (off the request hot path) and streamed to R2.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `POST /api/v1/users/current/data_dumps` MUST, when R2 is bound, create a `data_dumps` row with `status=pending` for `type ∈ {daily, full}` and return `201 {data: DataDump}`. Unknown `type` → 400.
+- **FR-002**: Both `data_dumps` endpoints MUST be gated on a bound `R2_BUCKET`; when unbound they MUST return `503` and create/return nothing.
+- **FR-003**: `GET /api/v1/users/current/data_dumps` MUST return the user's dumps newest-first with `status`, and `download_url` when `status=completed` and not yet expired.
+- **FR-004**: The hourly cron MUST process `pending` dumps: set `processing`, build the export, upload it to R2, set `download_url` + `expires_at` (default now + 7 days) + `status=completed`; on error set `status=failed`.
+- **FR-005**: `daily` MUST export per-day summary buckets; `full` MUST bundle user profile + summaries + per-day records + raw heartbeats.
+- **FR-006**: The cron MUST purge expired dumps: delete the R2 object and mark the row `expired` (download then 404s).
+- **FR-007**: `download_url` MUST be short-lived and only resolve for the owning user; an expired or unauthorized fetch MUST fail (no public, durable links).
+- **FR-008**: A `POST` while a `pending`/`processing` dump of the same `type` exists MAY return that existing dump instead of creating a duplicate.
+- **FR-009**: All endpoints MUST require authentication (401) and be strictly scoped by `user_id`.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Building a dump MUST happen in the cron (off the request path); the `POST`/`GET` handlers MUST stay within the 10ms CPU budget (single-row write / indexed list).
+- **NFR-002**: No new external dependency. R2 access uses the Workers R2 binding. The async path reuses the existing hourly cron (no Queues binding).
+- **NFR-003**: No D1 schema migration — the `data_dumps` table already exists.
+
+### Key Entities *(no schema change)*
+
+`data_dumps` (`id`, `user_id`, `type`, `status`, `download_url`, `created_at`, `expires_at`, `ON DELETE CASCADE`). Response uses the existing `DataDump` schema (with the reconciled `type`/`status` enums). R2 objects are keyed per dump (e.g. `dumps/{user_id}/{dump_id}.json`).
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: With R2 bound, a requested dump is built by the cron and becomes downloadable, then expires after 7 days.
+- **SC-002**: Without R2 bound, both endpoints return 503 and the feature is inert (safe to ship un-provisioned).
+- **SC-003**: A `full` export round-trips the user's data (user/summaries/daily/heartbeats) in a documented JSON shape.
+- **SC-004**: Cross-user listing/download never leaks another user's dump; unauthorized/expired downloads fail.
+
+## Out of Scope
+
+- **Import** (the reverse of export).
+- **Cloudflare Queues** (the async path is the existing cron sweep).
+- **Incremental / diff exports** (each dump is a full snapshot of its `type`).
+- **Zip/compression** in the first cut (JSON bundle; compression can follow).
+- **Presigned S3-style URLs requiring R2 S3 credentials** if a worker-mediated download is chosen in PR2 (see research).

--- a/specs/102-data-dumps/tasks.md
+++ b/specs/102-data-dumps/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Data Dumps (Export)
+
+**Branch**: `102-data-dumps`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (2 stories, FR-001..FR-009, edge cases, spec-level decisions).
+- [x] **T-002**: Author `plan.md` (Constitution Check, handler/cron/download sketches).
+- [x] **T-003**: Author `research.md` (6 documented decisions).
+- [x] **T-004**: Author `data-model.md` (existing table + R2 key + lifecycle statements + bundle shape).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–H).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add `ServiceUnavailable.yaml`; reconcile `DataDump.yaml` (`type` `daily|full`, `status` + `expired`); add `400`/`503` + descriptions + `type` enum to `data-dumps.yaml`.
+- [x] **T-009**: Run `npm run generate`; verify enums + responses; run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`. Flag the `heartbeats`→`full` reconciliation.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Binding + config
+
+- [ ] **T-101**: Add `R2_BUCKET?: R2Bucket` to `Env`; document the opt-in `[[r2_buckets]]` binding in `wrangler.toml`.
+
+### Bundler
+
+- [ ] **T-102**: `src/utils/export-bundle.ts` — `buildDailyExport(db, userId)` / `buildFullExport(db, userId)` (user_id-scoped D1 reads → JSON bundle).
+- [ ] **T-103**: Unit tests for the bundle shapes (`daily`, `full`, empty data).
+
+### Routes
+
+- [ ] **T-104**: `src/routes/data-dumps.ts` — `POST` (gate 503; validate `type` 400; dedupe in-flight; insert pending; `201 {data}`) and `GET` (gate 503; list newest-first; `download_url` only when completed/unexpired). Behind `authMiddleware`.
+- [ ] **T-105**: Mount in `src/index.ts`.
+
+### Cron + download
+
+- [ ] **T-106**: `src/cron/data-dumps.ts` — `processPendingDumps` (bounded; pending→processing→R2 put→completed/failed) + `purgeExpiredDumps` (R2 delete + status `expired`); wire into `scheduled()` via `Promise.allSettled`.
+- [ ] **T-107**: Download mechanism — worker-mediated, owner+token, short-lived; expired/unknown → 404.
+
+### Tests + docs
+
+- [ ] **T-108**: `tests/integration/data-dumps.test.ts` — 503-when-unbound, create/dedupe, list/ownership, 400, 401 (R2 via test-pool binding or stub).
+- [ ] **T-109**: `docs/operations.md` — enabling export (R2 binding, retention, download).
+
+### Verification
+
+- [ ] **T-110**: `npm run typecheck` — zero errors.
+- [ ] **T-111**: `npm test` — full suite green incl. new unit + integration.
+- [ ] **T-112**: Manual `quickstart.md` A / B / D / E with R2 bound on a staging worker.
+
+### PR2 submission
+
+- [ ] **T-113**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #102.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                         (PR1)
+T-010 → T-101 .. T-113                          (PR2 after PR1 merge)
+T-101 → T-102 → T-103 ; T-101 → T-104 → T-105
+T-102 / T-104 → T-106 → T-107
+T-104 / T-106 → T-108 ; T-102 → T-103
+T-108 → T-110 → T-111 → T-112 → T-113
+```
+
+## Out of scope
+
+- Import (reverse of export); Cloudflare Queues; incremental/diff exports;
+  zip/compression; S3-presigned URLs (unless operator configures S3 creds).

--- a/specs/102-data-dumps/tasks.md
+++ b/specs/102-data-dumps/tasks.md
@@ -13,8 +13,8 @@
 - [x] **T-005**: Author `quickstart.md` (scenarios A–H).
 - [x] **T-006**: Author `contracts/openapi-diff.md`.
 - [x] **T-007**: Author `checklists/requirements.md`.
-- [x] **T-008**: Add `ServiceUnavailable.yaml`; reconcile `DataDump.yaml` (`type` `daily|full`, `status` + `expired`); add `400`/`503` + descriptions + `type` enum to `data-dumps.yaml`.
-- [x] **T-009**: Run `npm run generate`; verify enums + responses; run `npm run typecheck`.
+- [x] **T-008**: Add `ServiceUnavailable.yaml`; reconcile `DataDump.yaml` (`type` `daily|full`, `status` + `expired`, required `created_at`); add `400`/`503` + descriptions + `type` enum to `data-dumps.yaml`.
+- [x] **T-009**: Run `npm run generate`; verify enums, required fields, and responses; run `npm run typecheck`.
 - [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`. Flag the `heartbeats`→`full` reconciliation.
 
 ## PR2 — Implementation (after PR1 merges)

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -1316,8 +1316,11 @@ export interface components {
              *     `completed` and before `expires_at`.
              */
             download_url?: string;
-            /** Format: date-time */
-            created_at?: string;
+            /**
+             * Format: date-time
+             * @description When the export request was created.
+             */
+            created_at: string;
             /**
              * Format: date-time
              * @description When the dump (and its stored object) is purged. Defaults to 7 days after creation.
@@ -1979,7 +1982,7 @@ export interface components {
             content: {
                 "application/json": {
                     /** @example Data export not configured */
-                    error?: string;
+                    error: string;
                 };
             };
         };

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -463,10 +463,29 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List data exports */
+        /**
+         * List data exports
+         * @description Lists the authenticated user's data exports, newest first, with their
+         *     `status` and (once `completed`) a short-lived `download_url`.
+         *
+         *     Data export is gated on a bound R2 bucket (`R2_BUCKET`). When export is
+         *     not configured on this instance, the endpoint returns 503 — the same
+         *     fail-closed pattern as email delivery.
+         */
         get: operations["getDataDumps"];
         put?: never;
-        /** Start a data export */
+        /**
+         * Start a data export
+         * @description Requests a data export. The server records a `pending` dump and an
+         *     async cron sweep builds it (`processing` → `completed`), uploading the
+         *     output to R2 and setting a short-lived `download_url`; `expires_at`
+         *     defaults to 7 days. `daily` exports per-day summaries; `full` bundles
+         *     user profile + summaries + per-day records + raw heartbeats.
+         *
+         *     Gated on a bound R2 bucket (`R2_BUCKET`); returns 503 when export is not
+         *     configured. `email_when_finished` is accepted but only acts when email
+         *     delivery is configured (multi-user mode). An unknown `type` returns 400.
+         */
         post: operations["createDataDump"];
         delete?: never;
         options?: never;
@@ -1278,15 +1297,31 @@ export interface components {
         };
         DataDump: {
             id: string;
-            /** @enum {string} */
-            type: "daily" | "heartbeats";
-            /** @enum {string} */
-            status: "pending" | "processing" | "completed" | "failed";
-            /** Format: uri */
+            /**
+             * @description `daily` exports per-day summary buckets; `full` exports a complete
+             *     bundle (user profile + summaries + per-day records + raw heartbeats).
+             * @enum {string}
+             */
+            type: "daily" | "full";
+            /**
+             * @description Lifecycle: `pending` (queued) → `processing` (cron is building it) →
+             *     `completed` (`download_url` available) or `failed`. `expired` once the
+             *     dump has passed `expires_at` and its stored object has been purged.
+             * @enum {string}
+             */
+            status: "pending" | "processing" | "completed" | "failed" | "expired";
+            /**
+             * Format: uri
+             * @description Short-lived signed URL to the export, present only when `status` is
+             *     `completed` and before `expires_at`.
+             */
             download_url?: string;
             /** Format: date-time */
             created_at?: string;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description When the dump (and its stored object) is purged. Defaults to 7 days after creation.
+             */
             expires_at?: string;
         };
         /** @enum {string} */
@@ -1932,6 +1967,22 @@ export interface components {
                 };
             };
         };
+        /**
+         * @description The requested capability is not configured on this instance. Returned, for
+         *     example, when a data export is requested but no R2 bucket (`R2_BUCKET`) is
+         *     bound — the same fail-closed pattern as email delivery (`EMAIL_PROVIDER`).
+         */
+        ServiceUnavailable: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @example Data export not configured */
+                    error?: string;
+                };
+            };
+        };
     };
     parameters: {
         /** @description Machine/device name (fallback if not provided in request body) */
@@ -2485,6 +2536,7 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     createDataDump: {
@@ -2498,7 +2550,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @enum {string} */
-                    type: "daily" | "heartbeats";
+                    type: "daily" | "full";
                     /** @default true */
                     email_when_finished?: boolean;
                 };
@@ -2516,7 +2568,9 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     getHeartbeats: {


### PR DESCRIPTION
## Summary

Spec-first PR1 for **Data Dumps / export** (issue #102). The `getDataDumps` / `createDataDump` operations and the `DataDump` schema already existed; this PR reconciles the enums, adds the missing `400`/`503` responses, and lands the SpecKit design. **No implementation code** — the R2 binding, handlers, cron sweep, and bundler land in PR2.

## Spec-level decisions (please sanity-check)

- **R2-gated, fail-closed**: the feature requires a bound `R2_BUCKET`; both endpoints return **503** ("Data export not configured") when it's unbound — the same pattern as email delivery. So this is safe to ship before R2 is provisioned; operators opt in by binding the bucket.
- **Async via the existing hourly cron sweep** (not Cloudflare Queues): `POST` records a `pending` dump; the cron builds pending dumps and purges expired ones. No new Queue binding.
- **`type`: `heartbeats` → `full`** ⚠️ *reconciliation flagged for review* — the issue's scope says `type=daily|full` and describes a multi-file bundle (user + summaries + daily + heartbeats). `full` serves migration/portability; `heartbeats` becomes a *component* of `full`. This corrects the declared enum toward the issue's intent.
- **`status` adds `expired`** — for dumps past `expires_at` whose R2 object was purged.
- **Download**: worker-mediated, short-lived, owner-only (no S3 presign credentials by default); exact route finalised in PR2.
- **Dedupe**: a `POST` for a `type` with an in-flight dump returns that dump.

## What's in this PR

- **OpenAPI** — new `ServiceUnavailable` (503) response; `DataDump` `type`→`daily|full`, `status`+`expired`; `data-dumps.yaml` request enum + `400`/`503` + descriptions (async lifecycle, R2 gating, 7-day expiry, `email_when_finished` multi-user only).
- **Generated types** — reflects the enum + response changes; no other body shapes change.
- **SpecKit artifacts** under `specs/102-data-dumps/`.

## No D1 schema migration

Uses the existing `data_dumps` table; R2 binding is added (opt-in) in PR2.

## Test plan

- [x] `npm run generate` reflects `daily|full`, `status`+`expired`, 400/503
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly
- [ ] PR2: `R2_BUCKET` binding, handlers (503-gated), cron build/purge, export bundler, download route, tests

## Note on R2

PR2 needs an R2 bucket bound to exercise the happy path end-to-end. Because the feature is gated (503 when unbound), PR2 can still merge and be tested for the un-provisioned path; the operator binds R2 to enable it. Happy to coordinate on R2 provisioning when we start PR2.