### PR TITLE
spec: global stats always aggregate in UTC (PR1/2) #29

### DIFF
--- a/schemas/paths/meta/global-stats.yaml
+++ b/schemas/paths/meta/global-stats.yaml
@@ -4,10 +4,12 @@ get:
     - meta
   summary: Aggregate stats of all users
   description: >-
-    Summary data is bucketed by each user's profile timezone at aggregation time.
-    In single-user mode, the query timezone and bucketing timezone align when the
-    user's profile timezone matches. Cross-user timezone aggregation is a known
-    limitation deferred to multi-user support.
+    Aggregates activity across all users over the requested range. This
+    endpoint is unauthenticated and **always aggregates in UTC** — it does not
+    accept a timezone. Fixing UTC keeps the response cacheable under a single
+    key per range (a client-supplied timezone would otherwise fragment the
+    cache on an unauthenticated endpoint) and avoids ambiguous cross-user date
+    boundaries when `summaries.date` is bucketed per user timezone (#29).
   security: []
   parameters:
     - name: range
@@ -18,15 +20,6 @@ get:
         description: >-
           last_7_days, last_30_days, last_6_months, last_year, all_time, or YYYY
           / YYYY-MM
-    - name: timezone
-      in: query
-      description: >-
-        IANA timezone (e.g. Asia/Tokyo). Shifts the date anchor used for range
-        resolution. Defaults to UTC when omitted. See endpoint description for
-        timezone bucketing notes.
-      schema:
-        type: string
-        example: Asia/Tokyo
   responses:
     '200':
       description: Aggregate statistics

--- a/schemas/paths/meta/global-stats.yaml
+++ b/schemas/paths/meta/global-stats.yaml
@@ -43,3 +43,5 @@ get:
                 $ref: ../../components/schemas/GlobalStats.yaml
               message:
                 type: string
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml

--- a/specs/029-global-stats-utc/checklists/requirements.md
+++ b/specs/029-global-stats-utc/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 ## PR1 (Spec) gate — must be ✅ before merging
 
-- [x] `spec.md` covers FR-001..FR-005 with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` covers FR-001..FR-006 with no `[NEEDS CLARIFICATION]` markers.
 - [x] `spec.md` records the decision (Option 1 UTC-fix) and why rate-limiting is not needed.
 - [x] `plan.md` Constitution Check has all five principles marked PASS.
 - [x] `research.md` documents the 4 decisions (option choice, param removal, no rate-limit, per-user untouched).
@@ -10,8 +10,8 @@
 - [x] `quickstart.md` enumerates scenarios A–E.
 - [x] `tasks.md` separates PR1 from PR2.
 - [x] `contracts/openapi-diff.md` documents the `timezone` param removal.
-- [x] `global-stats.yaml` drops the `timezone` param and updates the description.
-- [x] `npm run generate` sets `getGlobalStats` query params to `never`; `npm run typecheck` passes.
+- [x] `global-stats.yaml` drops the `timezone` param, updates the description, and declares the invalid-range `400`.
+- [x] `npm run generate` sets `getGlobalStats` query params to `never`, includes the `400` response; `npm run typecheck` passes.
 - [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
 - [x] PR1 references issue #29.
 

--- a/specs/029-global-stats-utc/checklists/requirements.md
+++ b/specs/029-global-stats-utc/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Acceptance Checklist: Global Stats Always Aggregate in UTC
+
+## PR1 (Spec) gate — must be ✅ before merging
+
+- [x] `spec.md` covers FR-001..FR-005 with no `[NEEDS CLARIFICATION]` markers.
+- [x] `spec.md` records the decision (Option 1 UTC-fix) and why rate-limiting is not needed.
+- [x] `plan.md` Constitution Check has all five principles marked PASS.
+- [x] `research.md` documents the 4 decisions (option choice, param removal, no rate-limit, per-user untouched).
+- [x] `data-model.md` confirms no schema change and documents the UTC range + single cache key.
+- [x] `quickstart.md` enumerates scenarios A–E.
+- [x] `tasks.md` separates PR1 from PR2.
+- [x] `contracts/openapi-diff.md` documents the `timezone` param removal.
+- [x] `global-stats.yaml` drops the `timezone` param and updates the description.
+- [x] `npm run generate` sets `getGlobalStats` query params to `never`; `npm run typecheck` passes.
+- [x] PR1 contains no runtime code under `src/` (only regenerated `src/types/generated.ts`).
+- [x] PR1 references issue #29.
+
+## PR2 (Implementation) gate — must be ✅ before merging
+
+### Code
+
+- [ ] `src/routes/meta.ts` global-stats handler: resolve range in UTC (`resolveStatsRange(range)`), cache key `global-stats:{range}`, `range.timezone = "UTC"`; remove the `timezone` query read + `isValidTimezone` validation (and the now-unused import if applicable).
+- [ ] The authenticated `src/routes/stats.ts` per-user handler is **unchanged**.
+- [ ] `npm run typecheck` passes; no hand-edited generated types.
+
+### Behaviour (per `quickstart.md`)
+
+- [ ] A: `?timezone=…` ignored; `range.timezone` always `"UTC"`; identical payload.
+- [ ] B: same `range` with different timezones hits one cache entry.
+- [ ] C: invalid timezone → 200 (ignored), not 400.
+- [ ] D: invalid range → 400 (unchanged).
+- [ ] E: authenticated per-user stats still honour timezone.
+
+### Tests
+
+- [ ] `tests/integration/global-stats.test.ts` (or extend meta tests): timezone ignored (same data + `range.timezone` UTC across tz values), invalid timezone not rejected, invalid range 400.
+- [ ] `npm test` stays green.
+
+## Post-deployment gate
+
+- [ ] Confirm `GET /stats/{range}?timezone=…` returns UTC and does not multiply cache entries.
+- [ ] Confirm per-user `GET /users/current/stats/{range}` is unaffected.

--- a/specs/029-global-stats-utc/contracts/openapi-diff.md
+++ b/specs/029-global-stats-utc/contracts/openapi-diff.md
@@ -1,0 +1,38 @@
+# OpenAPI Diff
+
+`getGlobalStats` loses its `timezone` query parameter and its description is
+rewritten to state the endpoint always aggregates in UTC. No response-body
+change.
+
+## Files touched
+
+1. `schemas/paths/meta/global-stats.yaml`
+   - Remove the `timezone` query parameter.
+   - Rewrite the operation `description`: unauthenticated, always UTC; explains
+     the cache-stability and cross-user-ambiguity rationale (#29).
+
+No schema component changes; `GlobalStats` is unchanged (its `range.timezone`
+is now always `"UTC"` at runtime, but the field shape is the same).
+
+## Contract
+
+`GET /api/v1/stats/{range}` (unauthenticated):
+- Parameters: `range` (path) only. **No `timezone`.**
+- `200` → `{ data: GlobalStats }`; `202` → still-calculating; `400` → bad range.
+
+## Generated-types impact
+
+`npm run generate` sets `operations["getGlobalStats"]["parameters"]["query"]`
+to `never` (the `timezone` query param is gone). No other change; no body
+shapes affected.
+
+## Backward compatibility
+
+Non-breaking at runtime: clients still sending `?timezone=` are unaffected
+(the value is ignored; Hono does not reject unknown query params).
+
+## SDD compliance note
+
+PR1 lands SpecKit + the parameter removal + regenerated types. PR2 lands the
+`meta.ts` handler change (ignore timezone, single cache key, `range.timezone =
+"UTC"`) and a test. No runtime code in PR1.

--- a/specs/029-global-stats-utc/contracts/openapi-diff.md
+++ b/specs/029-global-stats-utc/contracts/openapi-diff.md
@@ -1,8 +1,8 @@
 # OpenAPI Diff
 
 `getGlobalStats` loses its `timezone` query parameter and its description is
-rewritten to state the endpoint always aggregates in UTC. No response-body
-change.
+rewritten to state the endpoint always aggregates in UTC. The existing bad
+range behavior is also documented with an explicit `400` response.
 
 ## Files touched
 
@@ -10,6 +10,7 @@ change.
    - Remove the `timezone` query parameter.
    - Rewrite the operation `description`: unauthenticated, always UTC; explains
      the cache-stability and cross-user-ambiguity rationale (#29).
+   - Declare `400` with the shared `BadRequest` response for invalid ranges.
 
 No schema component changes; `GlobalStats` is unchanged (its `range.timezone`
 is now always `"UTC"` at runtime, but the field shape is the same).
@@ -23,8 +24,8 @@ is now always `"UTC"` at runtime, but the field shape is the same).
 ## Generated-types impact
 
 `npm run generate` sets `operations["getGlobalStats"]["parameters"]["query"]`
-to `never` (the `timezone` query param is gone). No other change; no body
-shapes affected.
+to `never` (the `timezone` query param is gone) and includes the `400`
+BadRequest response for invalid ranges. No success body shapes are affected.
 
 ## Backward compatibility
 

--- a/specs/029-global-stats-utc/data-model.md
+++ b/specs/029-global-stats-utc/data-model.md
@@ -1,0 +1,40 @@
+# Data Model: Global Stats Always Aggregate in UTC
+
+No schema changes. Reads the existing `summaries` table; only the global
+endpoint's range/cache handling changes.
+
+## `summaries` (existing, unchanged)
+
+`summaries.date` is `YYYY-MM-DD` bucketed in **each user's profile timezone**
+by the cron aggregator (#32). That is correct for per-user views.
+
+For the **global** endpoint, the requested range is resolved to UTC date
+bounds and applied directly to `date`:
+
+```sql
+-- range bounds resolved in UTC (no client timezone)
+SELECT COALESCE(SUM(total_seconds), 0) AS total_seconds, MIN(date) AS min_date
+  FROM summaries WHERE date >= ? AND date <= ?;
+-- + GROUP BY category / language / editor / operating_system (unchanged)
+```
+
+This treats every user's local `date` as if it were a UTC date for the
+purpose of the global rollup. It is an approximation (a user near a day
+boundary in a far-from-UTC timezone may land in an adjacent global day), but
+it is single-valued and cache-stable — the right trade-off for an aggregate,
+unauthenticated view. Exact per-timezone global aggregation would require a
+separate UTC date column (issue Option 4), which is deferred.
+
+## KV cache key
+
+- **Before**: `global-stats:{range}:{tz}` — fragmented per timezone.
+- **After**: `global-stats:{range}` — one entry per range; 5-minute TTL
+  unchanged. Old keys age out.
+
+## Response
+
+`GlobalStats.range.timezone` is always `"UTC"`. All other fields unchanged.
+
+## No writes / migration
+
+Read-only endpoint. No D1 migration, no new column, no new binding.

--- a/specs/029-global-stats-utc/plan.md
+++ b/specs/029-global-stats-utc/plan.md
@@ -64,7 +64,7 @@ The `timezone` query read, the `isValidTimezone` validation, and the tz in the c
 
 ### OpenAPI surface
 
-`getGlobalStats` loses its `timezone` query parameter — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No response-body change.
+`getGlobalStats` loses its `timezone` query parameter and explicitly declares the existing invalid-range `400` response — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No success response-body change.
 
 ## Phase 2 — Implementation Tasks
 

--- a/specs/029-global-stats-utc/plan.md
+++ b/specs/029-global-stats-utc/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Global Stats Always Aggregate in UTC
+
+**Branch**: `029-global-stats-utc` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/029-global-stats-utc/spec.md`
+
+## Summary
+
+Make the unauthenticated `GET /api/v1/stats/{range}` global endpoint ignore any client `timezone`: resolve the range in UTC, key the cache on `global-stats:{range}`, and report `range.timezone = "UTC"`. This removes the cache-fragmentation/bypass vector and the cross-user date ambiguity (#29).
+
+PR1 (this PR): SpecKit artifacts + OpenAPI (drop the `timezone` query param from `getGlobalStats`) + regenerated types. PR2: the small `src/routes/meta.ts` change + a test.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`summaries`, read) + KV (cache)
+**Testing**: Vitest + workers pool — global-stats handler test (timezone ignored, single cache key, range.timezone UTC)
+**Performance Goals**: unchanged; in fact fewer recomputations (cache no longer fragmentable)
+**Constraints**: none new
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI updated first (drop `timezone`); `npm run generate` removes the param from `getGlobalStats`. Handler change lands in PR2. |
+| II. Cloudflare-Native | PASS | Pure D1 read + KV cache; no new bindings. |
+| III. Type Safety | PASS | Handler uses `components["schemas"]["GlobalStats"]`. No hand-edited types. |
+| IV. Legal/Trademark | PASS | No source/asset borrowing. |
+| V. Simplicity First | PASS | Removes code (timezone read/validate/cache-key) rather than adding. Rate-limiting deliberately not added. |
+
+## Project Structure
+
+```text
+specs/029-global-stats-utc/   # this feature's SpecKit docs
+src/routes/meta.ts            # EDIT in PR2: drop timezone handling for global stats
+```
+
+**Structure Decision**: The only code change is in the existing `meta.ts` global-stats handler. The authenticated per-user stats handler (`src/routes/stats.ts`) is untouched.
+
+## Phase 0 — Research Outputs
+
+See [research.md](./research.md). Key decisions:
+1. **Option 1 (UTC-fix)** over normalize-tz / rate-limit / UTC-column / keep-as-is — it resolves both concerns with the least code.
+2. **Drop the `timezone` param from the contract** (honest: it no longer does anything) rather than accept-but-ignore-silently in the spec.
+3. **No rate-limiting** needed for the cache concern once the key is un-fragmentable.
+
+## Phase 1 — Design Outputs
+
+### Handler change sketch (PR2, `meta.ts`)
+
+```ts
+meta.get("/stats/:range", async (c) => {
+  const rangeParam = c.req.param("range");
+  const resolved = resolveStatsRange(rangeParam);          // UTC; no tz
+  if (!resolved) return c.json({ error: "Invalid range. …" }, 400);
+
+  const cacheKey = `global-stats:${rangeParam}`;            // no tz component
+  // … unchanged aggregation …
+  range: { start: `${resolved.start}T00:00:00Z`, end: `${resolved.end}T23:59:59Z`, text: resolved.text, timezone: "UTC" },
+});
+```
+
+The `timezone` query read, the `isValidTimezone` validation, and the tz in the cache key / response are removed. The `isValidTimezone` import is dropped from `meta.ts` if it becomes unused.
+
+### OpenAPI surface
+
+`getGlobalStats` loses its `timezone` query parameter — see [contracts/openapi-diff.md](./contracts/openapi-diff.md). No response-body change.
+
+## Phase 2 — Implementation Tasks
+
+See [tasks.md](./tasks.md).
+
+## Complexity Tracking
+
+Net negative complexity — the change removes branching and a cache-key dimension.

--- a/specs/029-global-stats-utc/quickstart.md
+++ b/specs/029-global-stats-utc/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Global Stats Always Aggregate in UTC
+
+Manual verification once PR2 (implementation) is deployed. The global stats
+endpoint is unauthenticated.
+
+## Prerequisites
+
+```bash
+export BASE=https://cloudtime.example.dev/api/v1
+```
+
+## Scenario A — Timezone is ignored
+
+```bash
+curl -s "$BASE/stats/last_7_days" | jq '.data.range.timezone'
+curl -s "$BASE/stats/last_7_days?timezone=Asia/Tokyo" | jq '.data.range.timezone'
+```
+
+**Expected**: both print `"UTC"`, and the two `data` payloads are identical.
+
+## Scenario B — Single cache entry per range
+
+```bash
+curl -s "$BASE/stats/last_30_days?timezone=America/New_York" >/dev/null
+curl -s "$BASE/stats/last_30_days?timezone=Europe/Paris"     >/dev/null
+curl -s "$BASE/stats/last_30_days"                            >/dev/null
+```
+
+**Expected**: all three are served from one cache entry (`global-stats:last_30_days`); varying the timezone does not create new entries or force recomputation (observable as stable latency / no extra D1 aggregation in logs).
+
+## Scenario C — Invalid timezone does not error
+
+```bash
+curl -si "$BASE/stats/last_7_days?timezone=Not/AZone" | head -1
+```
+
+**Expected**: `200` (the timezone is ignored, not validated). Contrast with the **authenticated** per-user endpoint, which still 400s on an invalid timezone.
+
+## Scenario D — Invalid range still 400s
+
+```bash
+curl -si "$BASE/stats/since_forever" | head -1
+```
+
+**Expected**: `400` (range validation is unchanged).
+
+## Scenario E — Per-user stats unaffected
+
+```bash
+curl -s "$BASE/users/current/stats/last_7_days?timezone=Asia/Tokyo" -H "Authorization: Bearer $API_KEY" | jq '.data.range.timezone'
+```
+
+**Expected**: `"Asia/Tokyo"` (or the user's profile timezone) — the authenticated endpoint still honours timezone; only the global endpoint is fixed to UTC.
+
+## Reverting / cleanup
+
+Pure handler change. Reverting restores the previous timezone-aware global
+behaviour; no data or schema impact. Old cache keys expire within 5 minutes.

--- a/specs/029-global-stats-utc/research.md
+++ b/specs/029-global-stats-utc/research.md
@@ -1,0 +1,47 @@
+# Research: Global Stats Always Aggregate in UTC
+
+## Decision 1: Option 1 (UTC-fix) over the alternatives
+
+**Decision**: Always aggregate global stats in UTC and drop the `timezone` parameter, rather than normalising timezones to a fixed set, rate-limiting, adding a UTC date column, or keeping the current behaviour.
+
+**Rationale** (the issue listed five options):
+- **(1) UTC-fix — chosen.** One small change resolves *both* concerns: the cache key stops varying by timezone (no fragmentation/bypass), and a single UTC boundary removes cross-user date ambiguity. Least code, no new infra, no schema change.
+- **(2) Normalise tz to whole-hour offsets** — shrinks but does not eliminate cache-key space, and still leaves cross-user date ambiguity. Half a fix.
+- **(3) Per-IP rate-limit** — addresses only the abuse symptom, not the ambiguity, and adds a rate-limit binding + tuning. Unnecessary for the cache concern once the key is un-fragmentable (see Decision 3).
+- **(4) UTC date column in `summaries`** — enables true per-tz global aggregation but is a schema migration + aggregator change; over-engineered for an unauthenticated global view. Deferred.
+- **(5) Keep as-is** — fine for single-user, but the issue is about hardening before multi-user; we are addressing it now.
+
+**Trade-off accepted**: a client cannot get global stats anchored to their own timezone. For an aggregate-across-all-users view this is acceptable (and arguably more correct) — UTC is a single, well-defined reference. Per-user, timezone-correct stats remain available on the authenticated `GET /users/current/stats/{range}`.
+
+---
+
+## Decision 2: Drop the parameter from the contract (don't silently accept-and-ignore in the spec)
+
+**Decision**: Remove the `timezone` query parameter from the `getGlobalStats` OpenAPI operation. The handler ignores any value still sent.
+
+**Rationale**:
+- A declared parameter that no longer affects the response is misleading. Removing it makes the contract honest.
+- Removal is non-breaking at runtime: Hono does not 400 on unknown query params, so existing callers passing `?timezone=` keep working (the value is ignored).
+
+**Alternative considered**: keep the param documented as "ignored". Rejected — clutter and confusion; the honest contract is no param.
+
+---
+
+## Decision 3: No rate-limiting needed for this concern
+
+**Decision**: Do not add per-IP rate limiting as part of this fix.
+
+**Rationale**:
+- The abuse vector in concern #1 was *cache bypass via timezone fragmentation*. Once the cache key is `global-stats:{range}` (a small, fixed key space — the handful of valid ranges), an attacker cannot force unique cache misses by varying a parameter; repeated requests hit the cache. The 5-minute TTL bounds recomputation regardless.
+- Rate-limiting unauthenticated endpoints can still be worthwhile as general defense-in-depth, but it is a separate, optional hardening and out of scope here.
+
+**Alternative considered**: add rate-limiting too. Deferred — not required to close the issue's concerns, and avoids new bindings/tuning.
+
+---
+
+## Decision 4: Authenticated per-user stats unchanged
+
+**Decision**: This change touches only the global `GET /api/v1/stats/{range}` (in `meta.ts`). The authenticated `GET /api/v1/users/current/stats/{range}` keeps using the user's profile timezone.
+
+**Rationale**:
+- Per-user stats are scoped to one user whose `summaries.date` is bucketed in their own timezone — a timezone-aware view is correct and unambiguous there. The cross-user ambiguity only arises when aggregating across users.

--- a/specs/029-global-stats-utc/spec.md
+++ b/specs/029-global-stats-utc/spec.md
@@ -60,6 +60,7 @@ As an operator, I want global stats to be cheap and consistent regardless of cli
 - **FR-003**: The response `range.timezone` MUST be `"UTC"`.
 - **FR-004**: A supplied `timezone` MUST NOT cause a 400; it is ignored. Range validation (400 on bad `range`) is unchanged.
 - **FR-005**: The OpenAPI operation MUST NOT declare a `timezone` parameter.
+- **FR-006**: The OpenAPI operation MUST declare the existing `400` BadRequest response for invalid `range` values.
 
 ### Non-Functional Requirements
 
@@ -76,6 +77,7 @@ Reads the existing `summaries` table. No new columns. `summaries.date` remains p
 - **SC-002**: `range.timezone` is always `"UTC"` on global stats.
 - **SC-003**: The OpenAPI no longer advertises a `timezone` param for `getGlobalStats`.
 - **SC-004**: The authenticated per-user stats endpoint is unchanged.
+- **SC-005**: The OpenAPI explicitly documents the invalid-range `400` response.
 
 ## Out of Scope
 

--- a/specs/029-global-stats-utc/spec.md
+++ b/specs/029-global-stats-utc/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Global Stats Always Aggregate in UTC
+
+**Feature Branch**: `029-global-stats-utc`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: Issue #29 — the unauthenticated global stats endpoint (`GET /api/v1/stats/{range}`) accepts a `timezone` query parameter that is folded into the KV cache key and the date-range resolution. This fragments the cache and makes cross-user date aggregation ambiguous once `summaries.date` is bucketed per user timezone (#32).
+
+## Background
+
+`GET /api/v1/stats/{range}` aggregates activity across **all** users and is **unauthenticated** (`security: []`), served from a 5-minute KV cache. Today it:
+
+- reads a `timezone` query param, validates it, and uses it to resolve the date range, and
+- includes the timezone in the cache key (`global-stats:{range}:{tz}`) and the response `range.timezone`.
+
+Two problems, both multi-user-relevant (harmless in single-user but worth fixing before `INSTANCE_MODE=multi`):
+
+1. **Cache fragmentation / bypass** — each distinct `timezone` value creates a separate cache entry. On an unauthenticated endpoint an attacker can cycle timezones to bypass the cache and force repeated full aggregations.
+2. **Cross-user date ambiguity** — `summaries.date` is bucketed in each user's local timezone (#32). A global aggregation `WHERE date BETWEEN …` mixes rows whose `date` means different absolute day boundaries per user, so a client-supplied timezone cannot give a coherent global answer.
+
+## Decision
+
+**Option 1 — global stats always aggregate in UTC.** The endpoint no longer accepts a `timezone`:
+
+- The date range is resolved in UTC.
+- The cache key is `global-stats:{range}` (one entry per range) — no longer fragmentable.
+- The response `range.timezone` is always `"UTC"`.
+
+This single change resolves **both** concerns. With the cache no longer fragmentable, per-IP rate-limiting (issue Option 3) is not required for this purpose and is left as optional future defense-in-depth.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stable, cacheable global stats (Priority: P2)
+
+As an operator, I want global stats to be cheap and consistent regardless of client-supplied timezones, so the unauthenticated endpoint can't be abused to bypass the cache.
+
+**Independent Test**: Seed summaries. `GET /stats/last_7_days` and `GET /stats/last_7_days?timezone=Asia/Tokyo` return the **same** data, both report `range.timezone = "UTC"`, and both are served from the same cache entry (the second is a cache hit of the first).
+
+**Acceptance Scenarios**:
+1. **Given** any `timezone` query value, **When** requesting global stats, **Then** the result is identical to omitting it and `range.timezone` is `"UTC"`.
+2. **Given** two requests for the same `range` with different `timezone` values, **When** served, **Then** they hit a single cache entry (`global-stats:{range}`).
+3. **Given** an invalid `timezone` value, **When** requesting, **Then** the request still succeeds in UTC (the param is ignored, not validated) — no 400 for the timezone.
+4. **Given** an invalid `range`, **When** requesting, **Then** 400 (unchanged).
+
+---
+
+### Edge Cases
+
+- **Existing clients sending `?timezone=`**: the param is silently ignored (Hono does not 400 on unknown query params); responses are UTC.
+- **`all_time`**: unchanged — UTC bounds, with the daily-average denominator still anchored to the first data date.
+- **Cache entries from the old key format**: the old `global-stats:{range}:{tz}` entries simply age out (5-min TTL); the new key is `global-stats:{range}`.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `GET /api/v1/stats/{range}` MUST resolve the range and aggregate in UTC, ignoring any `timezone` query parameter.
+- **FR-002**: The KV cache key MUST be `global-stats:{range}` (no timezone component).
+- **FR-003**: The response `range.timezone` MUST be `"UTC"`.
+- **FR-004**: A supplied `timezone` MUST NOT cause a 400; it is ignored. Range validation (400 on bad `range`) is unchanged.
+- **FR-005**: The OpenAPI operation MUST NOT declare a `timezone` parameter.
+
+### Non-Functional Requirements
+
+- **NFR-001**: No behavioural change to the authenticated per-user `GET /users/current/stats/{range}` (which legitimately uses the user's timezone).
+- **NFR-002**: No D1 schema change; no new binding. (Issue Option 4 — a UTC date column — is **not** adopted; UTC range bounds over the existing per-user `date` is the pragmatic global view for now.)
+
+### Key Entities *(no schema change)*
+
+Reads the existing `summaries` table. No new columns. `summaries.date` remains per-user-local; the global endpoint simply treats the requested range bounds as UTC dates.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `?timezone=…` no longer changes the response or creates a new cache entry.
+- **SC-002**: `range.timezone` is always `"UTC"` on global stats.
+- **SC-003**: The OpenAPI no longer advertises a `timezone` param for `getGlobalStats`.
+- **SC-004**: The authenticated per-user stats endpoint is unchanged.
+
+## Out of Scope
+
+- **Per-IP rate limiting** of the endpoint (Option 3) — unnecessary once the cache is un-fragmentable; optional future hardening.
+- **A separate UTC date column** in `summaries` (Option 4) — deferred; revisit if true per-user-timezone global aggregation is needed in multi-user mode.
+- **The authenticated per-user stats** endpoint and its timezone handling.

--- a/specs/029-global-stats-utc/tasks.md
+++ b/specs/029-global-stats-utc/tasks.md
@@ -13,8 +13,8 @@
 - [x] **T-005**: Author `quickstart.md` (scenarios A–E).
 - [x] **T-006**: Author `contracts/openapi-diff.md`.
 - [x] **T-007**: Author `checklists/requirements.md`.
-- [x] **T-008**: Remove the `timezone` query param from `global-stats.yaml`; rewrite the description (UTC, rationale).
-- [x] **T-009**: Run `npm run generate` (getGlobalStats query → never); run `npm run typecheck`.
+- [x] **T-008**: Remove the `timezone` query param from `global-stats.yaml`; rewrite the description (UTC, rationale); declare the invalid-range `400`.
+- [x] **T-009**: Run `npm run generate` (getGlobalStats query → never; `400` response present); run `npm run typecheck`.
 - [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
 
 ## PR2 — Implementation (after PR1 merges)

--- a/specs/029-global-stats-utc/tasks.md
+++ b/specs/029-global-stats-utc/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Global Stats Always Aggregate in UTC
+
+**Branch**: `029-global-stats-utc`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-05-29
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (problem, Option 1 decision, FR-001..FR-005, scenarios).
+- [x] **T-002**: Author `plan.md` (Constitution Check, handler sketch).
+- [x] **T-003**: Author `research.md` (4 documented decisions).
+- [x] **T-004**: Author `data-model.md` (no schema change; UTC range + single cache key).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–E).
+- [x] **T-006**: Author `contracts/openapi-diff.md`.
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Remove the `timezone` query param from `global-stats.yaml`; rewrite the description (UTC, rationale).
+- [x] **T-009**: Run `npm run generate` (getGlobalStats query → never); run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (spec+schema, then types), push, open PR against `develop`.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Handler
+
+- [ ] **T-101**: `src/routes/meta.ts` — resolve range in UTC (`resolveStatsRange(rangeParam)`), set cache key `global-stats:${rangeParam}`, `range.timezone = "UTC"`; remove the `timezone` query read + `isValidTimezone` validation; drop the `isValidTimezone` import if unused.
+
+### Tests
+
+- [ ] **T-102**: `tests/integration/global-stats.test.ts` — timezone ignored (same data + `range.timezone` UTC across tz values; single cache entry), invalid timezone not rejected (200), invalid range 400; assert per-user stats unaffected (smoke).
+
+### Verification
+
+- [ ] **T-103**: `npm run typecheck` — zero errors.
+- [ ] **T-104**: `npm test` — full suite green incl. the new test.
+- [ ] **T-105**: Manual `quickstart.md` A / B / C against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-106**: Commit with `fix:` prefix, push, open PR against `develop` referencing PR1 and issue #29.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010            (PR1)
+T-010 → T-101 → T-102 → T-103 → T-104 → T-105 → T-106   (PR2)
+```
+
+## Out of scope
+
+- Per-IP rate limiting (Option 3); a UTC date column in `summaries` (Option 4);
+  the authenticated per-user stats endpoint.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -1174,7 +1174,7 @@ export interface paths {
         };
         /**
          * Aggregate stats of all users
-         * @description Summary data is bucketed by each user's profile timezone at aggregation time. In single-user mode, the query timezone and bucketing timezone align when the user's profile timezone matches. Cross-user timezone aggregation is a known limitation deferred to multi-user support.
+         * @description Aggregates activity across all users over the requested range. This endpoint is unauthenticated and **always aggregates in UTC** — it does not accept a timezone. Fixing UTC keeps the response cacheable under a single key per range (a client-supplied timezone would otherwise fragment the cache on an unauthenticated endpoint) and avoids ambiguous cross-user date boundaries when `summaries.date` is bucketed per user timezone (#29).
          */
         get: operations["getGlobalStats"];
         put?: never;
@@ -3634,10 +3634,7 @@ export interface operations {
     };
     getGlobalStats: {
         parameters: {
-            query?: {
-                /** @description IANA timezone (e.g. Asia/Tokyo). Shifts the date anchor used for range resolution. Defaults to UTC when omitted. See endpoint description for timezone bucketing notes. */
-                timezone?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 range: string;

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -3666,6 +3666,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
         };
     };
 }


### PR DESCRIPTION
## Summary

Spec-first PR1 for issue #29 — harden the unauthenticated global stats endpoint (`GET /api/v1/stats/{range}`) by **always aggregating in UTC** and dropping the `timezone` query parameter. **No implementation code** — the `meta.ts` handler change lands in PR2.

## Problem (from #29)

The global endpoint is unauthenticated and folded a client `timezone` into both the KV cache key (`global-stats:{range}:{tz}`) and the date-range resolution. That causes:
1. **Cache fragmentation / bypass** — cycling timezones forces unique cache misses on an unauthenticated endpoint.
2. **Cross-user date ambiguity** — `summaries.date` is bucketed per user timezone (#32), so a client timezone can't give a coherent global answer.

## Decision: Option 1 (UTC-fix)

Global stats always aggregate in UTC; the endpoint no longer accepts `timezone`:
- range resolved in UTC, cache key `global-stats:{range}` (one entry per range), `range.timezone` always `"UTC"`.

This single change resolves **both** concerns. With the cache key un-fragmentable, per-IP rate-limiting (issue Option 3) isn't needed for this purpose; a UTC date column (Option 4) is deferred. The **authenticated per-user** stats endpoint is untouched.

## What's in this PR

- **OpenAPI** — remove the `timezone` query param from `getGlobalStats`; rewrite the description (UTC + rationale).
- **Generated types** — `getGlobalStats` query params become `never`; no body change.
- **SpecKit artifacts** under `specs/029-global-stats-utc/`.

## Backward compatibility

Non-breaking at runtime: clients still sending `?timezone=` are unaffected (Hono ignores unknown query params; the value is simply not used).

## No schema change

Read-only endpoint; no D1 migration, no new binding.

## Test plan

- [x] `npm run generate` → `getGlobalStats` query `never`
- [x] `npm run typecheck` passes
- [x] OpenAPI bundles cleanly
- [ ] PR2: `meta.ts` handler (ignore timezone, single cache key, UTC) + test