### PR TITLE
fix: global stats always aggregate in UTC (PR2/2) #29

### DIFF
--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -4,7 +4,7 @@ import type { components } from "../types/generated";
 import { EDITORS } from "../data/editors";
 import { LANGUAGES } from "../data/languages";
 import { resolveStatsRange } from "../utils/stats-range";
-import { formatDigital, formatHumanReadable, isValidTimezone } from "../utils/time-format";
+import { formatDigital, formatHumanReadable } from "../utils/time-format";
 import { checkUpToDate } from "../utils/aggregation-status";
 
 type GlobalStats = components["schemas"]["GlobalStats"];
@@ -40,17 +40,16 @@ meta.get("/program_languages", (c) => {
 
 meta.get("/stats/:range", async (c) => {
   const rangeParam = c.req.param("range");
-  const tz = c.req.query("timezone");
-  if (tz && !isValidTimezone(tz)) {
-    return c.json({ error: "Invalid timezone. Use IANA format (e.g. Asia/Tokyo)" }, 400);
-  }
-  const resolved = resolveStatsRange(rangeParam, tz);
+  // Global stats always aggregate in UTC (Issue #29): no timezone is accepted.
+  // This keeps the cache key un-fragmentable on this unauthenticated endpoint
+  // and avoids ambiguous cross-user date boundaries.
+  const resolved = resolveStatsRange(rangeParam);
   if (!resolved) {
     return c.json({ error: "Invalid range. Use: last_7_days, last_30_days, last_6_months, last_year, all_time, YYYY, or YYYY-MM" }, 400);
   }
 
   // Check KV cache (5 min TTL)
-  const cacheKey = `global-stats:${rangeParam}:${tz ?? "UTC"}`;
+  const cacheKey = `global-stats:${rangeParam}`;
   const cached = await c.env.KV.get(cacheKey, "json") as { data: GlobalStats; status: number } | null;
   if (cached) {
     if (cached.status === 202) {
@@ -121,7 +120,7 @@ meta.get("/stats/:range", async (c) => {
         start: `${resolved.start}T00:00:00Z`,
         end: `${resolved.end}T23:59:59Z`,
         text: resolved.text,
-        timezone: tz ?? "UTC",
+        timezone: "UTC",
       },
     };
 

--- a/tests/integration/global-stats.test.ts
+++ b/tests/integration/global-stats.test.ts
@@ -13,8 +13,20 @@ import worker from "../../src/index";
 import { truncate } from "../helpers/fixtures";
 
 const BASE = "https://test.cloudtime.dev";
+const CACHE_KEYS = [
+  "global-stats:last_7_days",
+  "global-stats:last_7_days:UTC",
+  "global-stats:last_7_days:Asia/Tokyo",
+  "global-stats:last_30_days",
+  "global-stats:last_30_days:Not/AZone",
+];
+
+async function clearGlobalStatsCache(): Promise<void> {
+  await Promise.all(CACHE_KEYS.map((key) => env.KV.delete(key)));
+}
 
 beforeEach(async () => {
+  await clearGlobalStatsCache();
   // Mark aggregation recent so the endpoint returns 200 (not 202).
   await env.DB.prepare(
     "INSERT INTO meta (key, value) VALUES ('last_aggregated_at', ?) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
@@ -25,8 +37,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await truncate("meta");
-  await env.KV.delete("global-stats:last_7_days");
-  await env.KV.delete("global-stats:last_30_days");
+  await clearGlobalStatsCache();
 });
 
 async function call(path: string): Promise<Response> {
@@ -55,12 +66,17 @@ describe("GET /api/v1/stats/:range (global, UTC)", () => {
     expect(b.data.range.timezone).toBe("UTC");
     // Different timezones resolve to the same cache key, so the payloads match.
     expect(b.data).toEqual(a.data);
+    expect(await env.KV.get("global-stats:last_7_days", "json")).not.toBeNull();
+    expect(await env.KV.get("global-stats:last_7_days:UTC", "json")).toBeNull();
+    expect(await env.KV.get("global-stats:last_7_days:Asia/Tokyo", "json")).toBeNull();
   });
 
   it("does not reject an invalid timezone (it is ignored)", async () => {
     const res = await call("/api/v1/stats/last_30_days?timezone=Not/AZone");
     expect(res.status).toBe(200);
     expect(((await res.json()) as GlobalStatsBody).data.range.timezone).toBe("UTC");
+    expect(await env.KV.get("global-stats:last_30_days", "json")).not.toBeNull();
+    expect(await env.KV.get("global-stats:last_30_days:Not/AZone", "json")).toBeNull();
   });
 
   it("still 400s on an invalid range", async () => {

--- a/tests/integration/global-stats.test.ts
+++ b/tests/integration/global-stats.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration tests for the unauthenticated global stats endpoint
+ * (specs/029-global-stats-utc/): it always aggregates in UTC and ignores any
+ * client `timezone`, so the cache key cannot be fragmented (#29).
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { truncate } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+
+beforeEach(async () => {
+  // Mark aggregation recent so the endpoint returns 200 (not 202).
+  await env.DB.prepare(
+    "INSERT INTO meta (key, value) VALUES ('last_aggregated_at', ?) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+  )
+    .bind(String(Math.floor(Date.now() / 1000)))
+    .run();
+});
+
+afterEach(async () => {
+  await truncate("meta");
+  await env.KV.delete("global-stats:last_7_days");
+  await env.KV.delete("global-stats:last_30_days");
+});
+
+async function call(path: string): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, {}), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+interface GlobalStatsBody {
+  data: { range: { timezone: string }; total_seconds: number };
+}
+
+describe("GET /api/v1/stats/:range (global, UTC)", () => {
+  it("is unauthenticated and reports range.timezone = UTC", async () => {
+    const res = await call("/api/v1/stats/last_7_days");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GlobalStatsBody;
+    expect(body.data.range.timezone).toBe("UTC");
+  });
+
+  it("ignores a client timezone (same payload, still UTC)", async () => {
+    const a = (await (await call("/api/v1/stats/last_7_days")).json()) as GlobalStatsBody;
+    const b = (await (await call("/api/v1/stats/last_7_days?timezone=Asia/Tokyo")).json()) as GlobalStatsBody;
+    expect(a.data.range.timezone).toBe("UTC");
+    expect(b.data.range.timezone).toBe("UTC");
+    // Different timezones resolve to the same cache key, so the payloads match.
+    expect(b.data).toEqual(a.data);
+  });
+
+  it("does not reject an invalid timezone (it is ignored)", async () => {
+    const res = await call("/api/v1/stats/last_30_days?timezone=Not/AZone");
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as GlobalStatsBody).data.range.timezone).toBe("UTC");
+  });
+
+  it("still 400s on an invalid range", async () => {
+    const res = await call("/api/v1/stats/since_forever");
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Implementation PR2 for issue #29, completing the contract from #131 (merged). The unauthenticated `GET /api/v1/stats/{range}` now **always aggregates in UTC** and ignores any client `timezone`.

## What changed (`src/routes/meta.ts`)

- Remove the `timezone` query read + `isValidTimezone` validation (and the now-unused import).
- Resolve the range in UTC (`resolveStatsRange(rangeParam)`).
- KV cache key is `global-stats:{range}` — one entry per range, no longer fragmentable by timezone.
- `range.timezone` is always `"UTC"`.
- The authenticated per-user `GET /users/current/stats/{range}` is **untouched** (it still honours the user's timezone).

## Why

Closes both #29 concerns: cache fragmentation / bypass on an unauthenticated endpoint, and cross-user date ambiguity (`summaries.date` is bucketed per user timezone). With the cache key un-fragmentable, rate-limiting isn't needed for this purpose.

## Tests

`tests/integration/global-stats.test.ts`: reports UTC, ignores a client timezone (identical payload across tz values), does not reject an invalid timezone (200), still 400s on an invalid range.

## Backward compatibility

Non-breaking: clients still sending `?timezone=` are unaffected (the value is ignored).

## No schema / type change

OpenAPI + generated types landed in PR1 (#131). Implementation + test only.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 280 passing (276 prior + 4 new)