### PR TITLE
spec: apply weekday filter to days insight (PR1/2) #133

### DIFF
--- a/schemas/paths/insights/insights.yaml
+++ b/schemas/paths/insights/insights.yaml
@@ -16,7 +16,8 @@ get:
     invalid `insight_type` or unrecognised range returns 400.
 
     Which `Insight` field is populated depends on `insight_type`:
-    - `days` -> `days[]` (per-day totals across the range).
+    - `days` -> `days[]` (per-day totals across the range; restricted to a
+      single weekday when the `weekday` query parameter is set).
     - `best_day` -> `best_day` (the single highest-total day).
     - `daily_average` -> `daily_average` (mean seconds per active day).
     - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
@@ -25,10 +26,12 @@ get:
       `operating_systems` -> `items[]`, top values of that dimension by
       `total_seconds` (with `percent` of the range total).
 
-    The `timeout`, `writes_only`, and `weekday` query parameters are accepted
-    for forward-compatibility but are not applied in the first cut: insights
-    read from `summaries`, which already bake in each user's session timeout
-    and do not retain per-heartbeat write flags or weekday filters.
+    The `weekday` query parameter filters the `days` insight type to a single
+    day of the week (see the parameter definition for accepted values); it is
+    ignored by every other insight type. The `timeout` and `writes_only` query
+    parameters remain accepted for forward-compatibility but are not applied:
+    insights read from `summaries`, which already bake in each user's session
+    timeout and do not retain per-heartbeat write flags.
   parameters:
     - name: insight_type
       in: path
@@ -65,8 +68,10 @@ get:
     - name: weekday
       in: query
       description: >-
-        Reserved for future filtering of the days insight type (0-6 or
-        monday-sunday). Accepted but not applied in the first cut.
+        Restricts the `days` insight type to a single day of the week. Accepts an
+        integer 0-6 (0=Sunday ... 6=Saturday) or a case-insensitive English weekday
+        name (sunday ... saturday). Ignored by all other insight types. For the
+        `days` type, an out-of-range integer or unrecognised name returns 400.
       schema:
         type: string
   responses:

--- a/specs/133-insights-weekday-filter/checklists/requirements.md
+++ b/specs/133-insights-weekday-filter/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Requirements Checklist: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter` | **Spec**: [spec.md](../spec.md)
+
+Quality gate for the spec before implementation. Each item is verifiable against `spec.md`.
+
+## Completeness
+
+- [x] Every functional requirement (FR-001…FR-009) maps to at least one acceptance scenario.
+- [x] Numbering convention (0=Sunday) is fixed and justified (research D-1).
+- [x] Accepted input forms enumerated: integer 0–6 and case-insensitive full names (FR-002/FR-003).
+- [x] Omitted-parameter behavior specified (FR-005).
+- [x] Invalid-input behavior specified per insight type (FR-006 days → 400; FR-007 others → ignore).
+
+## Consistency
+
+- [x] Filtering basis matches the existing `weekday` insight (FR-008, research D-4).
+- [x] `days[]` ordering and entry shape preserved (FR-004).
+- [x] Out-of-scope items named: `timeout`, `writes_only` (FR-009), no schema change (data-model).
+
+## Testability
+
+- [x] Each user story has an Independent Test.
+- [x] Success criteria are measurable (SC-001…SC-005).
+- [x] Quickstart scenarios A–H cover filter, equivalence, empty, 400, ignore, and cross-insight consistency.
+
+## Compliance
+
+- [x] No new D1 table / migration (Cloudflare-Native, Simplicity).
+- [x] Generated-types impact assessed (JSDoc-only) in contracts/openapi-diff.md.
+- [x] Convention chosen for internal consistency; no WakaTime source consulted (Legal/Trademark).

--- a/specs/133-insights-weekday-filter/checklists/requirements.md
+++ b/specs/133-insights-weekday-filter/checklists/requirements.md
@@ -28,4 +28,4 @@ Quality gate for the spec before implementation. Each item is verifiable against
 
 - [x] No new D1 table / migration (Cloudflare-Native, Simplicity).
 - [x] Generated-types impact assessed (JSDoc-only) in contracts/openapi-diff.md.
-- [x] Convention chosen for internal consistency; no WakaTime source consulted (Legal/Trademark).
+- [x] Convention chosen for internal consistency; no third-party source consulted (Legal/Trademark).

--- a/specs/133-insights-weekday-filter/contracts/openapi-diff.md
+++ b/specs/133-insights-weekday-filter/contracts/openapi-diff.md
@@ -1,0 +1,70 @@
+# OpenAPI Contract Diff: `weekday` filter
+
+**Branch**: `133-insights-weekday-filter`
+**File**: `schemas/paths/insights/insights.yaml` (operation `getInsight`)
+
+This PR1 change is **descriptive only** — no request parameter is added/removed and no response schema changes. The `weekday` parameter already exists as `type: string`. We sharpen its description (reserved → applied) and update the operation prose. `npm run generate` therefore produces a JSDoc-only diff in `src/types/generated.ts`.
+
+## 1. Operation description (the `days` field mapping)
+
+**Before**
+```
+- `days` -> `days[]` (per-day totals across the range).
+```
+
+**After**
+```
+- `days` -> `days[]` (per-day totals across the range; restricted to a
+  single weekday when the `weekday` query parameter is set).
+```
+
+## 2. Operation description (reserved-params paragraph)
+
+**Before**
+```
+The `timeout`, `writes_only`, and `weekday` query parameters are accepted
+for forward-compatibility but are not applied in the first cut: insights
+read from `summaries`, which already bake in each user's session timeout
+and do not retain per-heartbeat write flags or weekday filters.
+```
+
+**After**
+```
+The `weekday` query parameter filters the `days` insight type to a single
+day of the week (see the parameter definition for accepted values); it is
+ignored by every other insight type. The `timeout` and `writes_only` query
+parameters remain accepted for forward-compatibility but are not applied:
+insights read from `summaries`, which already bake in each user's session
+timeout and do not retain per-heartbeat write flags.
+```
+
+## 3. The `weekday` parameter definition
+
+**Before**
+```yaml
+- name: weekday
+  in: query
+  description: >-
+    Reserved for future filtering of the days insight type (0-6 or
+    monday-sunday). Accepted but not applied in the first cut.
+  schema:
+    type: string
+```
+
+**After**
+```yaml
+- name: weekday
+  in: query
+  description: >-
+    Restricts the `days` insight type to a single day of the week. Accepts an
+    integer 0-6 (0=Sunday ... 6=Saturday) or a case-insensitive English weekday
+    name (sunday ... saturday). Ignored by all other insight types. For the
+    `days` type, an out-of-range integer or unrecognised name returns 400.
+  schema:
+    type: string
+```
+
+## Generated types impact
+
+- `src/types/generated.ts`: `getInsight` parameter `weekday?: string` is unchanged in type; only its JSDoc comment updates. No `Insight` / response change.
+- Verified by `npm run generate` followed by reviewing the `git diff` of `src/types/generated.ts` (expected: comment lines only).

--- a/specs/133-insights-weekday-filter/data-model.md
+++ b/specs/133-insights-weekday-filter/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter` | **Date**: 2026-06-04
+
+## Storage
+
+**No schema change.** No new table, column, index, or migration. The feature reads only the existing `summaries` rows the endpoint already queries.
+
+## Read path (unchanged from #103)
+
+The route issues the same single grouped SELECT introduced in #103:
+
+```sql
+SELECT date, project, language, editor, operating_system, category, branch, machine,
+       SUM(total_seconds) AS total_seconds
+  FROM summaries
+ WHERE user_id = ? AND date BETWEEN ? AND ?
+ GROUP BY date, project, language, editor, operating_system, category, branch, machine
+```
+
+`date` is the user-profile-timezone calendar date as bucketed by the hourly aggregation cron.
+
+## Derived in memory
+
+| Concept | Source | Notes |
+|---|---|---|
+| Per-date totals | `dailyTotals(rows)` (existing) | `Map<date, total_seconds>` summed across dimensions. |
+| Weekday of a date | `weekdayOf(date)` (existing) | `new Date(\`${date}T00:00:00Z\`).getUTCDay()` → 0=Sunday … 6=Saturday. |
+| **`weekday` filter** (new) | normalised request value `0–6 \| null` | When non-null and `insight_type==="days"`, keep only dates with `weekdayOf(date) === filter`. |
+
+## Request parameter normalisation (new, PR2)
+
+| Input form | Examples | Normalised |
+|---|---|---|
+| Omitted | (no `weekday`) | `null` (no filter) |
+| Integer 0–6 | `0`, `6` | that integer |
+| Full name (case-insensitive, trimmed) | `monday`, `MONDAY`, ` monday ` | 0–6 via name→index map |
+| Invalid (only enforced for `days`) | `7`, `-1`, `funday`, `` (blank) | → 400 for `days`; ignored (treated as `null`) for other types |
+
+## Response shape
+
+Unchanged. `days[]` entries keep `{date, total_seconds, text}` and ascending-by-date order; filtering only removes non-matching entries (possibly yielding `[]`).

--- a/specs/133-insights-weekday-filter/plan.md
+++ b/specs/133-insights-weekday-filter/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter` | **Date**: 2026-06-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/133-insights-weekday-filter/spec.md`
+
+## Summary
+
+Graduate the already-declared `weekday` query parameter from *reserved* to *applied*, for the `days` insight type only. When set, `days[]` is restricted to dates whose day-of-week matches; for every other insight type the parameter stays ignored. Reuse the existing weekday derivation (0=Sunday … 6=Saturday) so `days` filtering and the `weekday` insight agree. No new table, no schema migration, no raw-heartbeat scan.
+
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI description updates (operation prose + the `weekday` parameter description) + regenerated types. No request/response *shape* change — the parameter already exists as `string` — so `npm run generate` is JSDoc-only.
+
+**PR2 (after PR1 merges)**: parse + validate `weekday` in the route, thread it into `buildInsight`, filter the `days` branch, add unit + integration tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 (`summaries`, existing) — read-only, no change
+**Testing**: Vitest + workers pool — unit tests for the pure filter in `buildInsight`; integration tests for the endpoint (filtered/unfiltered, name/int equivalence, 400s, non-`days` ignore)
+**Performance Goals**: <10ms CPU — unchanged single grouped SELECT + an O(active-days) in-memory filter
+**Constraints**: summaries day-granularity; reuse existing `weekdayOf` (no new timezone logic)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Parameter already declared; PR1 clarifies its description (reserved → applied) and regenerates; PR2 implements. `npm run generate` is JSDoc-only. |
+| II. Cloudflare-Native | PASS | No new SELECT, no new table/binding; in-memory filter over already-materialised per-date totals. Stays within the existing CPU budget. |
+| III. Type Safety | PASS | Handler keeps using `components["schemas"]["Insight"]`; parameter remains `string` in generated types. No hand-edited types. |
+| IV. Legal/Trademark | PASS | Convention chosen for internal consistency with our own `weekday` insight; no WakaTime source consulted. |
+| V. Simplicity First | PASS | One parameter activated, one branch of one pure builder touched. `timeout`/`writes_only` deliberately left out of scope. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/133-insights-weekday-filter/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root) — landed in PR2
+
+```text
+src/
+├── routes/
+│   └── insights.ts   # CHANGE: read & validate `weekday` query (only enforced for `days`); pass into buildInsight
+└── utils/
+    └── insights.ts   # CHANGE: buildInsight accepts an optional weekday filter; applied in the `days` branch via the existing weekdayOf()
+```
+
+**Structure Decision**: Keep the route thin — it parses `weekday` into a normalised `0–6 | null`, returns 400 only when `insight_type === "days"` and the value is present-but-invalid, and passes the resolved filter to `buildInsight`. The pure builder applies the filter inside the `days` branch using the existing `weekdayOf` helper, so it stays unit-testable without D1. No other insight branch reads the filter.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; update `schemas/paths/insights/insights.yaml` (operation description + `weekday` parameter description); `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: route parse/validate + builder filter + unit & integration tests; `npm test` green; open PR referencing #133 and PR1.
+
+## Risks & Mitigations
+
+- **Convention mismatch with clients expecting ISO weekdays** → documented explicitly in the parameter description and `research.md` D-1; accepting names sidesteps integer-convention confusion for most callers.
+- **Regression for clients already sending `weekday` on non-`days` types** → FR-007 + US3 lock in "ignore where unused"; integration test asserts identical payloads.
+- **Type drift** → parameter intentionally stays `string`; `npm run generate` diff reviewed to confirm it is JSDoc-only.

--- a/specs/133-insights-weekday-filter/plan.md
+++ b/specs/133-insights-weekday-filter/plan.md
@@ -27,7 +27,7 @@ Graduate the already-declared `weekday` query parameter from *reserved* to *appl
 | I. SDD | PASS | Parameter already declared; PR1 clarifies its description (reserved → applied) and regenerates; PR2 implements. `npm run generate` is JSDoc-only. |
 | II. Cloudflare-Native | PASS | No new SELECT, no new table/binding; in-memory filter over already-materialised per-date totals. Stays within the existing CPU budget. |
 | III. Type Safety | PASS | Handler keeps using `components["schemas"]["Insight"]`; parameter remains `string` in generated types. No hand-edited types. |
-| IV. Legal/Trademark | PASS | Convention chosen for internal consistency with our own `weekday` insight; no WakaTime source consulted. |
+| IV. Legal/Trademark | PASS | Convention chosen for internal consistency with our own `weekday` insight; no third-party source consulted. |
 | V. Simplicity First | PASS | One parameter activated, one branch of one pure builder touched. `timeout`/`writes_only` deliberately left out of scope. |
 
 ## Project Structure

--- a/specs/133-insights-weekday-filter/quickstart.md
+++ b/specs/133-insights-weekday-filter/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter`
+
+Manual verification scenarios (run against a worker with seeded `summaries`). These also map directly to the PR2 integration tests. Auth via API key (Bearer) per project test helpers.
+
+Assume a user whose `summaries` contain activity on a spread of dates, e.g.
+`2026-06-01` (Mon), `2026-06-02` (Tue), `2026-06-08` (Mon), `2026-06-09` (Tue).
+
+## A. Unfiltered baseline
+
+```
+GET /api/v1/users/current/insights/days/last_30_days
+```
+Expect `data.days[]` with all four dates, ascending.
+
+## B. Filter by name
+
+```
+GET /api/v1/users/current/insights/days/last_30_days?weekday=monday
+```
+Expect `data.days[]` = only `2026-06-01` and `2026-06-08`, ascending; no Tuesdays.
+
+## C. Filter by integer (equivalence)
+
+```
+GET /api/v1/users/current/insights/days/last_30_days?weekday=1
+```
+Expect a response byte-identical to B (1 = Monday).
+
+## D. Case-insensitivity
+
+```
+GET /api/v1/users/current/insights/days/last_30_days?weekday=MONDAY
+```
+Expect a response identical to B.
+
+## E. No matches → empty
+
+```
+GET /api/v1/users/current/insights/days/last_30_days?weekday=saturday
+```
+Expect `data.days` = `[]`, HTTP 200.
+
+## F. Invalid value → 400
+
+```
+GET /api/v1/users/current/insights/days/last_30_days?weekday=funday
+GET /api/v1/users/current/insights/days/last_30_days?weekday=7
+```
+Expect HTTP 400 for both.
+
+## G. Ignored by non-`days` types
+
+```
+GET /api/v1/users/current/insights/languages/last_30_days?weekday=monday
+```
+Expect the same payload as without `weekday` (HTTP 200), even for an invalid value:
+
+```
+GET /api/v1/users/current/insights/languages/last_30_days?weekday=funday
+```
+Expect HTTP 200, unfiltered languages payload.
+
+## H. Consistency with the `weekday` insight
+
+The dates returned by B must be exactly the dates the `weekday` insight counts under "Monday":
+
+```
+GET /api/v1/users/current/insights/weekday/last_30_days
+```
+Cross-check that the Monday average in this response is the mean of the `total_seconds` from B.

--- a/specs/133-insights-weekday-filter/research.md
+++ b/specs/133-insights-weekday-filter/research.md
@@ -1,0 +1,55 @@
+# Research & Decisions: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter` | **Date**: 2026-06-04
+
+Documented decisions that shape the contract. Each records the choice, the alternatives, and why.
+
+## D-1: Weekday numbering convention (0=Sunday … 6=Saturday)
+
+**Decision**: `weekday=0` is Sunday, `1` Monday … `6` Saturday.
+
+**Why**: The existing `weekday` insight already maps weekdays this way — `src/utils/insights.ts` derives the day via `new Date(\`${date}T00:00:00Z\`).getUTCDay()` (0=Sunday) and indexes `WEEKDAY_NAMES = ["Sunday", …, "Saturday"]`. Reusing the same convention keeps the two insight types internally consistent: filtering `days` by `weekday=1` selects exactly the dates the `weekday` insight labels "Monday". Inventing a different (e.g. ISO 0=Monday) convention for the filter would make the two disagree.
+
+**Alternatives rejected**: ISO-8601 (1=Monday…7=Sunday) — clean externally but inconsistent with our shipped `weekday` insight, and we do not read WakaTime source to mirror their exact integer mapping (trademark hygiene). Internal consistency is the deciding factor.
+
+## D-2: Accept both integer and full weekday name
+
+**Decision**: Accept integer `0`–`6` **or** a case-insensitive full English name (`sunday`…`saturday`). They are equivalent.
+
+**Why**: The pre-existing parameter description already hinted "(0-6 or monday-sunday)", so both forms were anticipated. Names are self-documenting for humans; integers are convenient for programmatic clients.
+
+**Alternatives rejected**: Abbreviations (`mon`, `tue`) — adds ambiguity (e.g. locale variants) for little benefit; excluded to keep the accepted set small and unambiguous. Can be added later additively if a client needs it.
+
+## D-3: Validation scope — only when the value is used
+
+**Decision**: Validate `weekday` (→ 400 on bad input) **only** for `insight_type=days`. For all other insight types the value is ignored entirely, including invalid values (200).
+
+**Why**: Forward-compatibility. Clients may already attach `weekday` to every insights request (it was inert before this change). Rejecting it on, say, a `languages` request would be a regression. The principle: validate a parameter where it has meaning; ignore it where it has none.
+
+**Alternatives rejected**: Global validation regardless of type — cleaner-looking but breaks existing clients that blanket-attach the param. Silently ignoring a *malformed* value on `days` — hides client bugs; we 400 instead so authors get feedback.
+
+## D-4: Timezone basis reuses the existing helper
+
+**Decision**: Compute each date's weekday with the same `weekdayOf(date)` logic the `weekday` insight uses — `getUTCDay()` over the `YYYY-MM-DD` string (which is already the user-profile-timezone calendar date produced by aggregation).
+
+**Why**: `summaries.date` is already bucketed in the user's timezone by the hourly cron. The local calendar date *is* the correct unit; interpreting it at UTC midnight and taking `getUTCDay()` yields its weekday without any further conversion. This is exactly what the `weekday` insight already does, so no new timezone code is introduced and the two stay aligned (FR-008).
+
+## D-5: Filter location — pure builder, not SQL
+
+**Decision**: Apply the filter in-memory inside the pure `buildInsight` path (PR2), not via a SQL `WHERE`.
+
+**Why**: SQLite/D1 has no portable timezone-aware day-of-week extraction over our stored local-date strings, and the per-date totals are already materialised in memory after the single `GROUP BY`. Filtering an O(active-days) array is trivial and keeps the one-SELECT, <10ms-CPU shape from #103 (Cloudflare-Native principle). It also keeps the builder unit-testable without D1.
+
+**Alternatives rejected**: `WHERE strftime('%w', date) = ?` — couples to SQLite date functions, risks edge mismatches with our TZ-bucketed strings, and offers no measurable benefit at our data volume.
+
+## D-6: Type surface stays `string`
+
+**Decision**: Keep the OpenAPI `weekday` parameter as `type: string` (with a precise description); do not model it as an enum.
+
+**Why**: The accepted set mixes integers and case-insensitive names, which a single clean JSON-Schema enum cannot express (case-insensitivity, int|string union). A `string` with a descriptive contract plus route-level validation is the pragmatic fit. Consequence: `npm run generate` produces only a JSDoc/description diff for this parameter, not a TypeScript type change — acceptable and expected for this PR1.
+
+## D-7: Scope limited to `weekday`
+
+**Decision**: `timeout` and `writes_only` remain accepted-but-unapplied; this feature only activates `weekday`.
+
+**Why**: Those two cannot be honoured from `summaries` (which already bakes in the session timeout and drops per-heartbeat write flags). Activating them would require a different data path and belongs to separate issues, not this one. Keeping scope to `weekday` matches the "one feature per PR" principle.

--- a/specs/133-insights-weekday-filter/research.md
+++ b/specs/133-insights-weekday-filter/research.md
@@ -10,7 +10,7 @@ Documented decisions that shape the contract. Each records the choice, the alter
 
 **Why**: The existing `weekday` insight already maps weekdays this way — `src/utils/insights.ts` derives the day via `new Date(\`${date}T00:00:00Z\`).getUTCDay()` (0=Sunday) and indexes `WEEKDAY_NAMES = ["Sunday", …, "Saturday"]`. Reusing the same convention keeps the two insight types internally consistent: filtering `days` by `weekday=1` selects exactly the dates the `weekday` insight labels "Monday". Inventing a different (e.g. ISO 0=Monday) convention for the filter would make the two disagree.
 
-**Alternatives rejected**: ISO-8601 (1=Monday…7=Sunday) — clean externally but inconsistent with our shipped `weekday` insight, and we do not read WakaTime source to mirror their exact integer mapping (trademark hygiene). Internal consistency is the deciding factor.
+**Alternatives rejected**: ISO-8601 (1=Monday…7=Sunday) — clean externally but inconsistent with our shipped `weekday` insight, and we do not inspect third-party source code to mirror external integer mappings (trademark hygiene). Internal consistency is the deciding factor.
 
 ## D-2: Accept both integer and full weekday name
 

--- a/specs/133-insights-weekday-filter/spec.md
+++ b/specs/133-insights-weekday-filter/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Apply the `weekday` filter to the `days` insight type
+
+**Feature Branch**: `133-insights-weekday-filter`
+**Created**: 2026-06-04
+**Status**: Draft
+**Input**: The `getInsight` operation already accepts a `weekday` query parameter, but it is declared "accepted but not applied in the first cut" (`schemas/paths/insights/insights.yaml`). Clients can pass `weekday=monday` / `weekday=0`, but it has no effect — the full `days[]` series is always returned. Issue #133.
+
+## Background
+
+The Insights endpoint (`GET /api/v1/users/current/insights/{insight_type}/{range}`, shipped in #103) derives an insight from the pre-aggregated `summaries` table. The `days` insight type returns `days[]` — one entry per active date in the range, each `{date, total_seconds, text}`.
+
+WakaTime-compatible clients expose a "filter by day of week" control on the days view (e.g. "show only my Mondays"). The contract already reserves a `weekday` query parameter for this, but the first cut accepts it without applying it. This feature graduates `weekday` from *reserved* to *applied* for the `days` insight type only.
+
+No new table, no raw-heartbeat scan, no schema migration: the filter is a pure post-grouping restriction of the per-date totals the endpoint already computes. The weekday of each date is derived exactly as the existing `weekday` insight already derives it (0=Sunday … 6=Saturday), so the two insight types stay internally consistent.
+
+The sibling `timeout` and `writes_only` query parameters remain reserved/unapplied and are **out of scope** here.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter the days view to a single weekday (Priority: P1)
+
+As an authenticated user looking at my per-day coding totals, I want to restrict the `days` insight to a single day of the week so I can compare, say, all my Mondays over the range.
+
+**Why this priority**: This is the entire feature. Without it the parameter is inert.
+
+**Independent Test**: Seed `summaries` across dates spanning multiple weeks. `GET /insights/days/last_30_days?weekday=monday` returns `{data:{type:"days", days:[…]}}` where every entry's `date` falls on a Monday (in the user's profile timezone), and no non-Monday dates appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** summaries on dates that fall on several different weekdays, **When** requesting `days` with `weekday=monday`, **Then** `days[]` contains only the dates that are Mondays, still ordered ascending by date, each `{date, total_seconds, text}` unchanged.
+2. **Given** the same data, **When** requesting `days` with `weekday=1`, **Then** the result is identical to `weekday=monday` (1 = Monday under the 0=Sunday convention).
+3. **Given** the same data, **When** requesting `days` with `weekday=MONDAY` (any letter case), **Then** the result is identical to `weekday=monday`.
+4. **Given** summaries with no activity on the requested weekday in range, **When** requesting `days` with that `weekday`, **Then** `days` is `[]` with HTTP 200.
+5. **Given** the `weekday` parameter is omitted, **When** requesting `days`, **Then** the full unfiltered `days[]` is returned (unchanged behavior).
+
+---
+
+### User Story 2 - Invalid weekday values are rejected (Priority: P2)
+
+As an API client author, I want a clear error when I pass a malformed `weekday` so I can fix my request rather than silently receive unfiltered data.
+
+**Why this priority**: Prevents silent contract violations; small but important for compatibility correctness.
+
+**Independent Test**: `GET /insights/days/last_30_days?weekday=funday` returns HTTP 400 with an error message; `?weekday=7` and `?weekday=-1` also return 400.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unrecognised weekday name, **When** requesting `days` with `weekday=funday`, **Then** HTTP 400.
+2. **Given** an out-of-range integer, **When** requesting `days` with `weekday=7` (or `-1`), **Then** HTTP 400.
+3. **Given** an empty value, **When** requesting `days` with `weekday=` (present but blank), **Then** HTTP 400 (a present-but-unparseable value is an error, distinct from omission).
+
+---
+
+### User Story 3 - `weekday` is ignored by non-`days` insight types (Priority: P3)
+
+As a client that attaches `weekday` to every insights request, I want non-`days` insight types to keep working unchanged so I don't have to special-case my query building.
+
+**Why this priority**: Preserves forward-compatibility for clients already sending the (previously inert) parameter.
+
+**Independent Test**: `GET /insights/languages/last_30_days?weekday=monday` returns the same payload as without the parameter.
+
+**Acceptance Scenarios**:
+
+1. **Given** any non-`days` insight type (`languages`, `weekday`, `best_day`, …), **When** a `weekday` query value is present, **Then** it is ignored and the response is identical to the request without it.
+2. **Given** a non-`days` insight type with a syntactically **invalid** `weekday` (e.g. `weekday=funday`), **When** requested, **Then** the value is ignored and 200 is returned (validation applies only where the value is used — see FR-007).
+
+### Edge Cases
+
+- **Timezone**: the weekday is computed from the date as already bucketed into the user's profile timezone by aggregation (the same basis as the existing `weekday` insight). No additional timezone conversion is introduced.
+- **All-time / yearly ranges**: filtering composes with any `range`; it operates on whatever dates the range produced.
+- **Numeric vs name equivalence**: `0`==`sunday`, `1`==`monday`, … `6`==`saturday`.
+- **Leading/trailing whitespace** in the value: trimmed before parsing (e.g. `weekday=%20monday` → `monday`).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST apply the `weekday` query parameter as a filter on the `days` insight type, returning only the per-date entries whose date falls on the requested day of the week.
+- **FR-002**: The system MUST accept `weekday` as an integer `0`–`6` where **0=Sunday, 1=Monday, … 6=Saturday**, matching the convention used by the existing `weekday` insight.
+- **FR-003**: The system MUST accept `weekday` as a case-insensitive full English weekday name (`sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`), equivalent to the corresponding integer.
+- **FR-004**: The system MUST preserve the existing `days[]` ordering (ascending by date) and per-entry shape (`date`, `total_seconds`, `text`) after filtering.
+- **FR-005**: When `weekday` is omitted, the system MUST return the full unfiltered `days[]` (no behavior change).
+- **FR-006**: For the `days` insight type, the system MUST return HTTP 400 when `weekday` is present but is neither a valid integer `0`–`6` nor a recognised weekday name.
+- **FR-007**: For insight types other than `days`, the system MUST ignore the `weekday` parameter (including syntactically invalid values) and return the same response as if it were absent.
+- **FR-008**: The system MUST compute each date's weekday on the same basis as the existing `weekday` insight (user-profile-timezone date as bucketed in `summaries`), so `days` filtering and the `weekday` insight agree on which dates are e.g. Mondays.
+- **FR-009**: The `timeout` and `writes_only` query parameters MUST remain accepted-but-unapplied (no change); only `weekday` graduates to applied.
+
+### Key Entities
+
+- No new entities. Operates on the existing `summaries` per-date totals already produced by the endpoint.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A `days` request with `weekday=monday` returns 100% Monday-dated entries and 0% other-weekday entries for any seeded dataset.
+- **SC-002**: `weekday=<n>` and `weekday=<name>` produce byte-identical responses for every equivalent pair (0/sunday … 6/saturday).
+- **SC-003**: Every malformed `weekday` on a `days` request yields HTTP 400; no malformed value ever returns partial or unfiltered data as if valid.
+- **SC-004**: Non-`days` insight responses are unchanged whether or not `weekday` is present (regression-free for existing clients).
+- **SC-005**: No new D1 table, no schema migration, and request latency stays within the existing single-`GROUP BY` budget (filtering is in-memory, O(active days)).

--- a/specs/133-insights-weekday-filter/tasks.md
+++ b/specs/133-insights-weekday-filter/tasks.md
@@ -15,7 +15,7 @@
 - [x] **T-007**: Author `checklists/requirements.md`.
 - [x] **T-008**: Update `schemas/paths/insights/insights.yaml` — `days` field mapping note, reserved-params paragraph, and the `weekday` parameter description. No parameter add/remove, no 200/response shape change.
 - [x] **T-009**: Run `npm run generate` (expect JSDoc-only diff in `src/types/generated.ts`); run `npm run typecheck`.
-- [ ] **T-010**: Commit PR1 (artifacts + schema, then regenerated types), push, open PR against `develop` referencing #133.
+- [x] **T-010**: Commit PR1 (artifacts + schema, then regenerated types), push, open PR against `develop` referencing #133.
 
 ## PR2 — Implementation (after PR1 merges)
 

--- a/specs/133-insights-weekday-filter/tasks.md
+++ b/specs/133-insights-weekday-filter/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: `weekday` filter for the `days` insight
+
+**Branch**: `133-insights-weekday-filter`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-06-04 · **Issue**: #133
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (US1 filter, US2 invalid→400, US3 ignore on non-days; FR-001..FR-009; edge cases; SC-001..SC-005).
+- [x] **T-002**: Author `plan.md` (Constitution Check, thin-route + pure-builder structure).
+- [x] **T-003**: Author `research.md` (D-1..D-7: numbering, accepted forms, validation scope, timezone basis, filter location, type surface, scope).
+- [x] **T-004**: Author `data-model.md` (no schema change; in-memory filter over existing per-date totals).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–H).
+- [x] **T-006**: Author `contracts/openapi-diff.md` (descriptive-only change; JSDoc-only generate diff).
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Update `schemas/paths/insights/insights.yaml` — `days` field mapping note, reserved-params paragraph, and the `weekday` parameter description. No parameter add/remove, no 200/response shape change.
+- [x] **T-009**: Run `npm run generate` (expect JSDoc-only diff in `src/types/generated.ts`); run `npm run typecheck`.
+- [ ] **T-010**: Commit PR1 (artifacts + schema, then regenerated types), push, open PR against `develop` referencing #133.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Builder
+
+- [ ] **T-101**: `src/utils/insights.ts` — extend `buildInsight` to accept an optional resolved weekday filter (`0–6 | null`); in the `days` branch, keep only dates with `weekdayOf(date) === filter` when non-null. Reuse the existing `weekdayOf` helper. No other branch reads the filter.
+- [ ] **T-102**: Unit tests `tests/aggregation/insights.test.ts` (extend) — filtered `days` for a known fixture; int/name equivalence at the builder level; empty result; non-`days` types unaffected when a filter is passed.
+
+### Route
+
+- [ ] **T-103**: `src/routes/insights.ts` — parse `weekday` query → normalised `0–6 | null` (trim, accept int 0–6 and case-insensitive name). For `insight_type === "days"`, return 400 when present-but-invalid; for other types, ignore (treat as `null`). Pass the resolved filter into `buildInsight`.
+
+### Tests
+
+- [ ] **T-104**: `tests/integration/insights.test.ts` (extend) — quickstart A–H: unfiltered baseline, name filter, int equivalence, case-insensitivity, empty, 400s (`funday`, `7`, blank), non-`days` ignore (valid + invalid), cross-user isolation, 401.
+
+### Verification
+
+- [ ] **T-105**: `npm run typecheck` — zero errors.
+- [ ] **T-106**: `npm test` — full suite green incl. new/extended unit + integration.
+- [ ] **T-107**: Manual run of `quickstart.md` B / C / E / F / G against a staging worker.
+
+### PR2 submission
+
+- [ ] **T-108**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #133.
+
+## Dependencies
+
+```
+T-001 .. T-009 → T-010                 (PR1)
+T-010 → T-101 .. T-108                  (PR2 after PR1 merge)
+T-101 → T-102
+T-101 → T-103 → T-104
+T-102 / T-104 → T-105 → T-106 → T-107 → T-108
+```
+
+## Out of scope
+
+- Applying `timeout` / `writes_only` (summaries can't honour them).
+- Weekday abbreviations (`mon`, `tue`) — additive later if needed.
+- SQL-side filtering / any schema change.
+- The `hours` insight type (#134) and other insight work.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -782,7 +782,8 @@ export interface paths {
          *     invalid `insight_type` or unrecognised range returns 400.
          *
          *     Which `Insight` field is populated depends on `insight_type`:
-         *     - `days` -> `days[]` (per-day totals across the range).
+         *     - `days` -> `days[]` (per-day totals across the range; restricted to a
+         *       single weekday when the `weekday` query parameter is set).
          *     - `best_day` -> `best_day` (the single highest-total day).
          *     - `daily_average` -> `daily_average` (mean seconds per active day).
          *     - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
@@ -791,10 +792,12 @@ export interface paths {
          *       `operating_systems` -> `items[]`, top values of that dimension by
          *       `total_seconds` (with `percent` of the range total).
          *
-         *     The `timeout`, `writes_only`, and `weekday` query parameters are accepted
-         *     for forward-compatibility but are not applied in the first cut: insights
-         *     read from `summaries`, which already bake in each user's session timeout
-         *     and do not retain per-heartbeat write flags or weekday filters.
+         *     The `weekday` query parameter filters the `days` insight type to a single
+         *     day of the week (see the parameter definition for accepted values); it is
+         *     ignored by every other insight type. The `timeout` and `writes_only` query
+         *     parameters remain accepted for forward-compatibility but are not applied:
+         *     insights read from `summaries`, which already bake in each user's session
+         *     timeout and do not retain per-heartbeat write flags.
          */
         get: operations["getInsight"];
         put?: never;
@@ -3111,7 +3114,7 @@ export interface operations {
             query?: {
                 timeout?: number;
                 writes_only?: boolean;
-                /** @description Reserved for future filtering of the days insight type (0-6 or monday-sunday). Accepted but not applied in the first cut. */
+                /** @description Restricts the `days` insight type to a single day of the week. Accepts an integer 0-6 (0=Sunday ... 6=Saturday) or a case-insensitive English weekday name (sunday ... saturday). Ignored by all other insight types. For the `days` type, an out-of-range integer or unrecognised name returns 400. */
                 weekday?: string;
             };
             header?: never;


### PR DESCRIPTION
## Summary

PR1 (spec + design) of the SpecKit 2-PR workflow for #133.

Graduates the existing `getInsight` `weekday` query parameter from **reserved** to **applied**, for the `days` insight type only. When set, `days[]` is restricted to the dates whose day-of-week matches; every other insight type keeps ignoring the parameter. No new table, no schema migration, no raw-heartbeat scan.

This PR contains **spec + design only** — no implementation code (per the 2-PR workflow). Implementation lands in PR2 after this merges.

## What changed

- **SpecKit artifacts** under `specs/133-insights-weekday-filter/`: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`, `contracts/openapi-diff.md`, `checklists/requirements.md`.
- **OpenAPI** (`schemas/paths/insights/insights.yaml`): updated the `getInsight` operation prose (`days` field mapping + reserved-params paragraph) and the `weekday` parameter description (reserved → applied, with accepted values + 400 behavior).
- **Generated types** (`src/types/generated.ts`): regenerated via `npm run generate`. JSDoc-only diff — the parameter stays `weekday?: string`; no request/response shape change.

## Key design decisions (see `research.md`)

- **Numbering**: `0=Sunday … 6=Saturday`, matching the existing `weekday` insight (`weekdayOf` → `getUTCDay`) so the two insight types agree on which dates are e.g. Mondays.
- **Accepted forms**: integer `0–6` or case-insensitive full weekday name (`sunday`…`saturday`).
- **Validation scope**: 400 only for `insight_type=days` with a present-but-invalid value; other types ignore it entirely (forward-compat for clients already attaching the previously-inert param).
- **Out of scope**: `timeout` / `writes_only` stay reserved/unapplied; no schema change.

## Verification

- `npm run generate` — JSDoc-only diff in `src/types/generated.ts` (verified).
- `npm run typecheck` — clean.

## Follow-up

PR2 (implementation): route parse/validate + `buildInsight` filter + unit/integration tests, referencing this PR.

Part of #133 (the issue is closed by PR2; this PR1 establishes the contract).
