### PR TITLE
feat: apply weekday filter to days insight (PR2/2) #133

### DIFF
--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -9,7 +9,7 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import { authMiddleware, getUserTimezone } from "../middleware/auth";
 import { resolveStatsRange } from "../utils/stats-range";
-import { buildInsight, INSIGHT_TYPES, type InsightType } from "../utils/insights";
+import { buildInsight, INSIGHT_TYPES, parseWeekday, type InsightType } from "../utils/insights";
 import type { SummaryRow } from "../utils/summary-builder";
 
 const VALID_INSIGHT_TYPES = new Set<string>(INSIGHT_TYPES);
@@ -36,6 +36,20 @@ insights.get("/insights/:insight_type/:range", async (c) => {
     );
   }
 
+  // `weekday` filters the `days` insight only; other types ignore it (incl.
+  // invalid values). For `days`, a present-but-unparseable value is a 400.
+  let weekdayFilter: number | null = null;
+  const weekdayRaw = c.req.query("weekday");
+  if (weekdayRaw !== undefined && insightType === "days") {
+    weekdayFilter = parseWeekday(weekdayRaw);
+    if (weekdayFilter === null) {
+      return c.json(
+        { error: "Invalid weekday. Use 0-6 (0=Sunday) or a weekday name (sunday-saturday)." },
+        400,
+      );
+    }
+  }
+
   const userId = c.get("userId");
   try {
     const { results } = await c.env.DB.prepare(
@@ -48,7 +62,7 @@ insights.get("/insights/:insight_type/:range", async (c) => {
       .bind(userId, resolved.start, resolved.end)
       .all<SummaryRow>();
 
-    return c.json({ data: buildInsight(insightType as InsightType, results, resolved, tz) });
+    return c.json({ data: buildInsight(insightType as InsightType, results, resolved, tz, weekdayFilter) });
   } catch (err) {
     console.error("GET /insights error:", err);
     return c.json({ error: "Internal server error" }, 500);

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -41,6 +41,22 @@ const WEEKDAY_NAMES = [
   "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
 ];
 
+/** Lowercase weekday name -> index (0=Sunday), derived from WEEKDAY_NAMES. */
+const WEEKDAY_INDEX: Record<string, number> = Object.fromEntries(
+  WEEKDAY_NAMES.map((name, i) => [name.toLowerCase(), i]),
+);
+
+/**
+ * Parse a `weekday` query value to a day index (0=Sunday … 6=Saturday), or
+ * `null` if it is neither an integer 0-6 nor a case-insensitive English weekday
+ * name. Used to filter the `days` insight; the same convention as `weekdayOf`.
+ */
+export function parseWeekday(raw: string): number | null {
+  const v = raw.trim().toLowerCase();
+  if (/^[0-6]$/.test(v)) return Number(v);
+  return v in WEEKDAY_INDEX ? WEEKDAY_INDEX[v] : null;
+}
+
 export interface ResolvedRange {
   start: string;
   end: string;
@@ -79,6 +95,7 @@ export function buildInsight(
   rows: SummaryRow[],
   range: ResolvedRange,
   tz: string,
+  weekdayFilter: number | null = null,
 ): Insight {
   const grandTotal = rows.reduce((sum, r) => sum + r.total_seconds, 0);
   const base: Insight = {
@@ -101,6 +118,7 @@ export function buildInsight(
   switch (type) {
     case "days": {
       const days = Array.from(totals.entries())
+        .filter(([date]) => weekdayFilter === null || weekdayOf(date) === weekdayFilter)
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([date, total_seconds]) => ({
           date,

--- a/tests/aggregation/insights.test.ts
+++ b/tests/aggregation/insights.test.ts
@@ -3,7 +3,7 @@
  * (specs/103-insights/). No D1, no KV.
  */
 import { describe, expect, it } from "vitest";
-import { buildInsight, type ResolvedRange } from "../../src/utils/insights";
+import { buildInsight, parseWeekday, type ResolvedRange } from "../../src/utils/insights";
 import type { SummaryRow } from "../../src/utils/summary-builder";
 
 const RANGE: ResolvedRange = { start: "2026-05-01", end: "2026-05-31", text: "last 30 days" };
@@ -98,5 +98,49 @@ describe("buildInsight - temporal types", () => {
     expect(buildInsight("best_day", [], RANGE, "UTC").best_day?.total_seconds).toBe(0);
     expect(buildInsight("daily_average", [], RANGE, "UTC").daily_average?.seconds).toBe(0);
     expect(buildInsight("weekday", [], RANGE, "UTC").items).toEqual([]);
+  });
+
+  it("days: weekday filter keeps only matching dates, preserving order/shape", () => {
+    // Monday filter (1) -> the two Mondays only.
+    const mon = buildInsight("days", rows, RANGE, "UTC", 1);
+    expect(mon.days?.map((d) => d.date)).toEqual(["2026-05-04", "2026-05-11"]);
+    expect(mon.days?.[1].total_seconds).toBe(5400);
+    // Tuesday filter (2) -> the single Tuesday.
+    expect(buildInsight("days", rows, RANGE, "UTC", 2).days?.map((d) => d.date)).toEqual(["2026-05-05"]);
+    // Sunday filter (0) -> no matches.
+    expect(buildInsight("days", rows, RANGE, "UTC", 0).days).toEqual([]);
+    // null filter -> unchanged (all active days).
+    expect(buildInsight("days", rows, RANGE, "UTC", null).days?.map((d) => d.date)).toEqual([
+      "2026-05-04",
+      "2026-05-05",
+      "2026-05-11",
+    ]);
+  });
+
+  it("weekday filter only affects the `days` type", () => {
+    // A non-null filter passed to a non-`days` type is ignored.
+    const wd = buildInsight("weekday", rows, RANGE, "UTC", 1);
+    expect(wd.items?.map((i) => i.name)).toEqual(["Monday", "Tuesday"]);
+  });
+});
+
+describe("parseWeekday", () => {
+  it("parses integers 0-6", () => {
+    expect(parseWeekday("0")).toBe(0);
+    expect(parseWeekday("6")).toBe(6);
+  });
+
+  it("parses case-insensitive weekday names, trimming whitespace", () => {
+    expect(parseWeekday("sunday")).toBe(0);
+    expect(parseWeekday("MONDAY")).toBe(1);
+    expect(parseWeekday("  saturday  ")).toBe(6);
+  });
+
+  it("returns null for out-of-range, unknown, or empty input", () => {
+    expect(parseWeekday("7")).toBeNull();
+    expect(parseWeekday("-1")).toBeNull();
+    expect(parseWeekday("funday")).toBeNull();
+    expect(parseWeekday("")).toBeNull();
+    expect(parseWeekday("01")).toBeNull();
   });
 });

--- a/tests/integration/insights.test.ts
+++ b/tests/integration/insights.test.ts
@@ -132,3 +132,66 @@ describe("GET /insights/:insight_type/:range", () => {
     await env.KV.delete(`apikey:${bob.apiKeyHash}`);
   });
 });
+
+describe("GET /insights/days/:range?weekday= (filter)", () => {
+  // 2026-03-02 & 2026-03-09 are Mondays; 2026-03-03 is a Tuesday.
+  async function seedDaysFixture(): Promise<void> {
+    await seedSummary({ userId: user.userId, date: "2026-03-02", project: "p", totalSeconds: 3600 }); // Mon
+    await seedSummary({ userId: user.userId, date: "2026-03-09", project: "p", totalSeconds: 5400 }); // Mon
+    await seedSummary({ userId: user.userId, date: "2026-03-03", project: "p", totalSeconds: 1800 }); // Tue
+  }
+
+  async function dayDates(query: string): Promise<{ status: number; dates: string[] }> {
+    const res = await call(`${INSIGHTS}/days/${YEAR}${query}`, { headers: bearer(user.apiKey) });
+    if (res.status !== 200) return { status: res.status, dates: [] };
+    const { data } = (await res.json()) as { data: { days: { date: string }[] } };
+    return { status: res.status, dates: data.days.map((d) => d.date) };
+  }
+
+  it("filters by weekday name", async () => {
+    await seedDaysFixture();
+    expect((await dayDates("?weekday=monday")).dates).toEqual(["2026-03-02", "2026-03-09"]);
+  });
+
+  it("integer and name are equivalent, case-insensitively", async () => {
+    await seedDaysFixture();
+    const byInt = await dayDates("?weekday=1");
+    const byName = await dayDates("?weekday=monday");
+    const byCaps = await dayDates("?weekday=MONDAY");
+    expect(byInt.dates).toEqual(["2026-03-02", "2026-03-09"]);
+    expect(byName.dates).toEqual(byInt.dates);
+    expect(byCaps.dates).toEqual(byInt.dates);
+  });
+
+  it("returns a single matching day, and empty when none match", async () => {
+    await seedDaysFixture();
+    expect((await dayDates("?weekday=tuesday")).dates).toEqual(["2026-03-03"]);
+    expect((await dayDates("?weekday=saturday")).dates).toEqual([]);
+  });
+
+  it("400s on an invalid weekday for the days type", async () => {
+    await seedDaysFixture();
+    expect((await dayDates("?weekday=funday")).status).toBe(400);
+    expect((await dayDates("?weekday=7")).status).toBe(400);
+    expect((await dayDates("?weekday=")).status).toBe(400);
+  });
+
+  it("is ignored by non-`days` insight types (valid or invalid value)", async () => {
+    await seedSummary({ userId: user.userId, date: "2026-03-02", language: "TypeScript", totalSeconds: 3600 }); // Mon
+    await seedSummary({ userId: user.userId, date: "2026-03-03", language: "Go", totalSeconds: 1800 }); // Tue
+
+    const names = async (path: string): Promise<{ status: number; names: string[] }> => {
+      const r = await call(path, { headers: bearer(user.apiKey) });
+      const body = (await r.json()) as { data: { items: { name: string }[] } };
+      return { status: r.status, names: body.data.items.map((i) => i.name) };
+    };
+
+    const plain = await names(`${INSIGHTS}/languages/${YEAR}`);
+    const filtered = await names(`${INSIGHTS}/languages/${YEAR}?weekday=monday`);
+    const bogus = await names(`${INSIGHTS}/languages/${YEAR}?weekday=funday`);
+    expect(filtered.status).toBe(200);
+    expect(bogus.status).toBe(200);
+    expect(filtered.names).toEqual(plain.names);
+    expect(bogus.names).toEqual(plain.names);
+  });
+});


### PR DESCRIPTION
## Summary

PR2 (implementation) of the SpecKit 2-PR workflow for #133. Builds on the contract established in PR1 #138 (merged).

Activates the `getInsight` `weekday` query parameter for the **`days`** insight type: `days[]` is restricted to the dates whose day-of-week matches. Every other insight type continues to ignore the parameter.

## What changed

- **`src/utils/insights.ts`**
  - `parseWeekday(raw)` — pure parser: integer `0–6` or case-insensitive English weekday name (trimmed) → day index (`0=Sunday … 6=Saturday`, derived from the existing `WEEKDAY_NAMES`); `null` for anything else.
  - `buildInsight(..., weekdayFilter = null)` — optional filter applied **only** in the `days` branch, via the existing `weekdayOf()` helper, preserving ascending order and entry shape.
- **`src/routes/insights.ts`** — reads `weekday`; for `insight_type=days` a present-but-invalid value returns **400**; for all other types the parameter is ignored entirely (including invalid values). Threads the resolved filter into `buildInsight`.
- **Tests** — unit (`days` filter incl. empty, `parseWeekday` valid/invalid/whitespace, filter ignored for non-`days`); integration (name filter, int/name/case equivalence, single-match & empty, 400s for `funday`/`7`/blank, non-`days` ignore for valid + invalid).

## Design (per `specs/133-insights-weekday-filter/`)

- **0=Sunday … 6=Saturday**, matching the existing `weekday` insight so the two agree on which dates are e.g. Mondays (research D-1).
- **Validate where used**: 400 only on `days`; ignore on other types to stay forward-compatible with clients that already attach the previously-inert param (research D-3, FR-007).
- In-memory filter over the already-materialised per-date totals — no new SELECT, table, or schema change (research D-5).

## Verification

- `npm run typecheck` — clean.
- `npm test` — **290 passed** (was 280; +10 new unit/integration).
- No request/response shape change; no `schemas/` or generated-types change in this PR (contract landed in PR1).

Closes #133.

Refs PR1 #138.
