### PR TITLE
spec: add hours-of-day insight type (PR1/2) #134

### DIFF
--- a/schemas/components/schemas/Insight.yaml
+++ b/schemas/components/schemas/Insight.yaml
@@ -36,6 +36,20 @@ properties:
         format: double
       text:
         type: string
+  hours:
+    type: array
+    items:
+      type: object
+      properties:
+        hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        total_seconds:
+          type: number
+          format: double
+        text:
+          type: string
   items:
     type: array
     items:

--- a/schemas/paths/insights/insights.yaml
+++ b/schemas/paths/insights/insights.yaml
@@ -4,11 +4,10 @@ get:
     - insights
   summary: Coding activity insights
   description: |
-    Derives an insight of the requested `insight_type` over `range` from the
-    pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
-    insight types ship in the first cut; an `hours`-of-day insight is
-    intentionally absent because `summaries` has day granularity only (it
-    would require an hourly aggregate - a future addition).
+    Derives an insight of the requested `insight_type` over `range`. Most types
+    read from the pre-aggregated `summaries` table (day granularity, no
+    raw-heartbeat scan); the `hours`-of-day type reads from the `hourly_summaries`
+    aggregate, which the same hourly cron maintains at hour-of-day granularity.
 
     `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
     `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
@@ -20,6 +19,10 @@ get:
       single weekday when the `weekday` query parameter is set).
     - `best_day` -> `best_day` (the single highest-total day).
     - `daily_average` -> `daily_average` (mean seconds per active day).
+    - `hours` -> `hours[]`, one bucket per hour of day (0-23, computed in the
+      user's profile timezone), `total_seconds` = mean coding time in that hour
+      across the active days in the range, ordered by hour ascending. Always 24
+      buckets; hours with no activity report `total_seconds` 0.
     - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
       `total_seconds` = mean for that weekday, ordered most-active first.
     - `projects` / `languages` / `editors` / `categories` / `machines` /
@@ -43,6 +46,7 @@ get:
           - days
           - best_day
           - daily_average
+          - hours
           - projects
           - languages
           - editors

--- a/specs/134-insights-hours-of-day/checklists/requirements.md
+++ b/specs/134-insights-hours-of-day/checklists/requirements.md
@@ -31,4 +31,4 @@ Quality gate for the spec before implementation. Each item is verifiable against
 - [x] No raw-heartbeat scan at request time (Cloudflare-Native) — FR-006, SC-004.
 - [x] One new narrow table; generated-types impact assessed (additive) in contracts/openapi-diff.md.
 - [x] Semantics derived from our own model; no third-party source consulted (Legal/Trademark) — research D-1/D-3.
-- [x] schema.sql-in-PR1 exception is documented and issue-directed (plan.md).
+- [x] DB schema changes are deferred to PR2 per the project PR1/PR2 workflow (plan.md, tasks.md).

--- a/specs/134-insights-hours-of-day/checklists/requirements.md
+++ b/specs/134-insights-hours-of-day/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Requirements Checklist: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day` | **Spec**: [spec.md](../spec.md)
+
+Quality gate for the spec before implementation. Each item is verifiable against `spec.md`.
+
+## Completeness
+
+- [x] Every functional requirement (FR-001…FR-010) maps to at least one acceptance scenario or success criterion.
+- [x] Aggregation strategy fixed and justified ((a) per-hour table; (b) query-time scan rejected) — research D-1.
+- [x] Bucket count and ordering specified (24 buckets, ascending `0…23`) — FR-002, SC-001.
+- [x] Average semantics + denominator fixed (mean per distinct active day) — FR-004, research D-3.
+- [x] Empty-range behavior specified (24 zero buckets) — spec Edge Cases, SC-001.
+- [x] Response field shape enumerated (`hour`, `total_seconds`, `text`) — FR-003.
+
+## Consistency
+
+- [x] Hour bucketing basis matches `summaries.date` (user-profile timezone at aggregation time) — FR-005, research D-7.
+- [x] Sums-to-`daily_average` invariant stated and testable — SC-002, data-model.
+- [x] Same cron pass + single cursor as `summaries` (incremental constraint) — FR-008, research D-2.
+- [x] Out-of-scope items named: `timeout`/`writes_only`/`weekday`, backfill, interval splitting (FR-010, research D-4/D-6).
+
+## Testability
+
+- [x] Each user story has an Independent Test.
+- [x] Success criteria are measurable (SC-001…SC-005).
+- [x] Quickstart scenarios A–H cover profile, daily_average equality, empty, range vocabulary, 400, 401, timezone, reserved-params.
+
+## Compliance
+
+- [x] No raw-heartbeat scan at request time (Cloudflare-Native) — FR-006, SC-004.
+- [x] One new narrow table; generated-types impact assessed (additive) in contracts/openapi-diff.md.
+- [x] Semantics derived from our own model; no third-party source consulted (Legal/Trademark) — research D-1/D-3.
+- [x] schema.sql-in-PR1 exception is documented and issue-directed (plan.md).

--- a/specs/134-insights-hours-of-day/contracts/openapi-diff.md
+++ b/specs/134-insights-hours-of-day/contracts/openapi-diff.md
@@ -1,0 +1,121 @@
+# OpenAPI Contract Diff: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day`
+**Files**: `schemas/paths/insights/insights.yaml` (operation `getInsight`), `schemas/components/schemas/Insight.yaml`
+
+This PR1 change is **additive**: a new enum value, a new response field, and clarified operation prose. `npm run generate` produces a new `hours` literal in the `insight_type` parameter union and an additive `hours?: …` field on the `Insight` schema in `src/types/generated.ts`. No existing field or type is removed or changed.
+
+## 1. `insight_type` enum — add `hours`
+
+**Before**
+```yaml
+        enum:
+          - weekday
+          - days
+          - best_day
+          - daily_average
+          - projects
+          - languages
+          - editors
+          - categories
+          - machines
+          - operating_systems
+```
+
+**After**
+```yaml
+        enum:
+          - weekday
+          - days
+          - best_day
+          - daily_average
+          - hours
+          - projects
+          - languages
+          - editors
+          - categories
+          - machines
+          - operating_systems
+```
+
+## 2. Operation description — data source + the `hours` field mapping
+
+**Before** (opening paragraph)
+```
+Derives an insight of the requested `insight_type` over `range` from the
+pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
+insight types ship in the first cut; an `hours`-of-day insight is
+intentionally absent because `summaries` has day granularity only (it
+would require an hourly aggregate - a future addition).
+```
+
+**After**
+```
+Derives an insight of the requested `insight_type` over `range`. Most types
+read from the pre-aggregated `summaries` table (day granularity, no
+raw-heartbeat scan); the `hours`-of-day type reads from the `hourly_summaries`
+aggregate, which the same hourly cron maintains at hour-of-day granularity.
+```
+
+**Field mapping** — add one bullet (placed with the temporal types, before the dimension types):
+```
+- `hours` -> `hours[]`, one bucket per hour of day (0-23, computed in the
+  user's profile timezone), `total_seconds` = mean coding time in that hour
+  across the active days in the range, ordered by hour ascending. Always 24
+  buckets; hours with no activity report `total_seconds` 0.
+```
+
+The `weekday`, `timeout`, and `writes_only` paragraphs are unchanged.
+
+## 3. `Insight` schema — add the `hours[]` field
+
+**Before** (`schemas/components/schemas/Insight.yaml`, after `daily_average`)
+```yaml
+  daily_average:
+    type: object
+    properties:
+      seconds:
+        type: number
+        format: double
+      text:
+        type: string
+  items:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+```
+
+**After**
+```yaml
+  daily_average:
+    type: object
+    properties:
+      seconds:
+        type: number
+        format: double
+      text:
+        type: string
+  hours:
+    type: array
+    items:
+      type: object
+      properties:
+        hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        total_seconds:
+          type: number
+          format: double
+        text:
+          type: string
+  items:
+    type: array
+    items:
+      $ref: ./SummaryItem.yaml
+```
+
+## Generated types impact
+
+- `src/types/generated.ts`: the `getInsight` `insight_type` path parameter union gains the `"hours"` literal; the `Insight` schema gains an additive optional `hours?: { hour?: number; total_seconds?: number; text?: string }[]`. No existing member changes.
+- Verified by `npm run generate` followed by reviewing the `git diff` of `src/types/generated.ts` (expected: the new enum literal + the additive field + the updated operation JSDoc).

--- a/specs/134-insights-hours-of-day/data-model.md
+++ b/specs/134-insights-hours-of-day/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day` | **Date**: 2026-06-05
+
+## New table: `hourly_summaries` (PR1, `src/db/schema.sql`)
+
+Hour-of-day pre-aggregate. One row per (`user_id`, local `date`, local `hour`), with an accumulating `total_seconds`. Maintained by the same hourly cron pass as `summaries`.
+
+```sql
+CREATE TABLE IF NOT EXISTS hourly_summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,          -- YYYY-MM-DD, user-profile-timezone calendar date
+  hour INTEGER NOT NULL,       -- 0..23, user-profile-timezone hour-of-day
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
+  ON hourly_summaries(user_id, date, hour);
+```
+
+Mirrors the `summaries` shape (AUTOINCREMENT id + a unique index that backs the cron's `ON CONFLICT … DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds` UPSERT). The unique key also serves the read query's `WHERE user_id = ? AND date BETWEEN ? AND ?` prefix.
+
+**Granularity note**: at most 24 rows per active day per user — equal to or below `summaries`, which stores one row per dimension tuple (project/language/editor/…) per day. Acceptable for D1 at single-user scale.
+
+## Write path (PR2 — cron, same pass as `summaries`)
+
+The existing `computeDurations` walk in `src/cron/aggregate.ts` already attributes each interval `[prev, curr)` to the owning heartbeat `prev` and computes `date = getDateForTimestamp(prev.time, tz)`. PR2 additionally computes `hour = getHourForTimestamp(prev.time, tz)` (0–23) and accumulates a second map keyed by `${userId}|${date}|${hour}`. Both maps are flushed in the **same** `db.batch()` and the **same** `last_aggregated_at` cursor advance, so a single heartbeat scan feeds both aggregates (FR-008).
+
+```sql
+INSERT INTO hourly_summaries (user_id, date, hour, total_seconds)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id, date, hour)
+DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds
+```
+
+## Read path (PR2 — `hours` insight)
+
+For `insight_type === "hours"`, the route issues a single read against the new aggregate (no `heartbeats` scan, FR-006):
+
+```sql
+SELECT date, hour, total_seconds
+  FROM hourly_summaries
+ WHERE user_id = ? AND date BETWEEN ? AND ?
+```
+
+`date` / `hour` are already the user-profile-timezone calendar date and hour as bucketed by the cron.
+
+## Derived in memory (PR2 — pure builder)
+
+| Concept | Source | Notes |
+|---|---|---|
+| Per-hour sum | fold rows by `hour` | `Map<hour, Σ total_seconds>` over the range. |
+| Active days | `new Set(rows.map(r => r.date)).size` | distinct dates with any activity → the mean denominator (FR-004). |
+| Bucket mean | `sum[h] / activeDays` (0 when `activeDays === 0`) | one value per hour. |
+| `hours[]` | hours `0…23` | 24 entries, ascending; `{ hour, total_seconds: mean, text: formatHumanReadable(round(mean)) }`. Zero-activity hours → `total_seconds: 0`. |
+
+**Invariant** (SC-002): `Σ_{h=0..23} hours[h].total_seconds === daily_average.seconds` for the same range, because both equal `grandTotal / activeDays`.
+
+## Response shape (PR1 — `Insight` schema)
+
+Additive: a new optional `hours` array on `components/schemas/Insight.yaml`. No existing field changes.
+
+```yaml
+hours:
+  type: array
+  items:
+    type: object
+    properties:
+      hour:          { type: integer, minimum: 0, maximum: 23 }
+      total_seconds: { type: number, format: double }
+      text:          { type: string }
+```

--- a/specs/134-insights-hours-of-day/data-model.md
+++ b/specs/134-insights-hours-of-day/data-model.md
@@ -2,7 +2,7 @@
 
 **Branch**: `134-insights-hours-of-day` | **Date**: 2026-06-05
 
-## New table: `hourly_summaries` (PR1, `src/db/schema.sql`)
+## New table: `hourly_summaries` (PR2, `src/db/schema.sql`)
 
 Hour-of-day pre-aggregate. One row per (`user_id`, local `date`, local `hour`), with an accumulating `total_seconds`. Maintained by the same hourly cron pass as `summaries`.
 
@@ -24,7 +24,7 @@ Mirrors the `summaries` shape (AUTOINCREMENT id + a unique index that backs the 
 
 **Granularity note**: at most 24 rows per active day per user — equal to or below `summaries`, which stores one row per dimension tuple (project/language/editor/…) per day. Acceptable for D1 at single-user scale.
 
-## Write path (PR2 — cron, same pass as `summaries`)
+## Write path (PR2 — schema + cron, same pass as `summaries`)
 
 The existing `computeDurations` walk in `src/cron/aggregate.ts` already attributes each interval `[prev, curr)` to the owning heartbeat `prev` and computes `date = getDateForTimestamp(prev.time, tz)`. PR2 additionally computes `hour = getHourForTimestamp(prev.time, tz)` (0–23) and accumulates a second map keyed by `${userId}|${date}|${hour}`. Both maps are flushed in the **same** `db.batch()` and the **same** `last_aggregated_at` cursor advance, so a single heartbeat scan feeds both aggregates (FR-008).
 

--- a/specs/134-insights-hours-of-day/plan.md
+++ b/specs/134-insights-hours-of-day/plan.md
@@ -7,11 +7,9 @@
 
 Add the `hours`-of-day insight type, backed by a new `hourly_summaries` pre-aggregate maintained by the existing hourly cron (same pass, same `last_aggregated_at` cursor as `summaries`). The insight reports a stable 24-bucket profile of mean coding time per hour-of-day, computed in the user's profile timezone. Strategy (a) from #134 (a per-hour aggregate table) is chosen over scanning raw heartbeats at query time, which is rejected for large ranges under the Workers 10ms CPU budget.
 
-**PR1 (this PR)**: SpecKit artifacts + OpenAPI changes (`hours` enum value, operation prose, new `Insight.hours[]` field) + the `hourly_summaries` table in `src/db/schema.sql` + regenerated types. **No cron or route/business logic.**
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI changes (`hours` enum value, operation prose, new `Insight.hours[]` field) + regenerated types. **No DB schema, cron, route, or business logic changes.**
 
-**PR2 (after PR1 merges)**: extend the cron to populate `hourly_summaries` in the same pass; add the `hours` read path + builder; unit + integration tests.
-
-> **Why `schema.sql` lands in PR1**: Issue #134 explicitly scopes "add the hourly aggregate table to `src/db/schema.sql`" to PR1. The table is part of the data-model contract that PR2's cron and read path depend on; it contains no business logic. This is a deliberate, issue-directed exception to the "schemas only" shorthand for PR1 — it stays SDD-compliant (data model defined before the code that uses it).
+**PR2 (after PR1 merges)**: add the `hourly_summaries` table to `src/db/schema.sql`; extend the cron to populate it in the same pass; add the `hours` read path + builder; unit + integration tests.
 
 ## Technical Context
 
@@ -26,7 +24,7 @@ Add the `hours`-of-day insight type, backed by a new `hourly_summaries` pre-aggr
 
 | Principle | Status | Notes |
 |-----------|--------|-------|
-| I. SDD | PASS | Spec + OpenAPI + data model (schema.sql) land first (PR1); cron/route/builder follow in PR2. Types regenerated, never hand-edited. |
+| I. SDD | PASS | Spec + OpenAPI land first (PR1); DB schema, cron, route, and builder follow in PR2. Types regenerated, never hand-edited. |
 | II. Cloudflare-Native | PASS | Reuses the single hourly cron pass and one cursor for both aggregates (no second scan); request reads one pre-aggregate. D1 batch UPSERT for the new table (PR2). |
 | III. Type Safety | PASS | Handler will use `components["schemas"]["Insight"]`; the new `hours[]` field is generated, not hand-written. |
 | IV. Legal/Trademark | PASS | Semantics derived from our own `summaries`/`daily_average` model; no third-party source consulted. |
@@ -56,10 +54,10 @@ specs/134-insights-hours-of-day/
 # PR1
 schemas/paths/insights/insights.yaml      # CHANGE: add `hours` to enum; update operation prose + field mapping
 schemas/components/schemas/Insight.yaml   # CHANGE: add `hours[]` field
-src/db/schema.sql                         # CHANGE: add `hourly_summaries` table + unique index
 src/types/generated.ts                    # REGENERATED (npm run generate)
 
 # PR2 (after PR1 merges)
+src/db/schema.sql                         # CHANGE: add `hourly_summaries` table + unique index
 src/utils/time-format.ts                  # CHANGE: add getHourForTimestamp(epoch, tz) -> 0..23
 src/cron/aggregate.ts                      # CHANGE: also bucket each duration into (user, date, hour); batch-UPSERT hourly_summaries in the same pass
 src/utils/insights.ts                      # CHANGE: add the `hours` builder branch (24-bucket mean profile)
@@ -70,8 +68,8 @@ src/routes/insights.ts                     # CHANGE: for insight_type === "hours
 
 ## Phases
 
-- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add `hours` to the enum and the `Insight.hours[]` field; document the operation prose; add `hourly_summaries` to `schema.sql`; `npm run generate`; `npm run typecheck`.
-- **PR2 — Implementation**: `getHourForTimestamp` helper + cron hour bucketing + `hours` builder + route read path + unit/aggregation/integration tests; `npm test` green; open PR referencing #134 and PR1.
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add `hours` to the enum and the `Insight.hours[]` field; document the operation prose; `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: `hourly_summaries` DDL in `schema.sql` + `getHourForTimestamp` helper + cron hour bucketing + `hours` builder + route read path + unit/aggregation/integration tests; `npm test` green; open PR referencing #134 and PR1.
 
 ## Risks & Mitigations
 

--- a/specs/134-insights-hours-of-day/plan.md
+++ b/specs/134-insights-hours-of-day/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day` | **Date**: 2026-06-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/134-insights-hours-of-day/spec.md`
+
+## Summary
+
+Add the `hours`-of-day insight type, backed by a new `hourly_summaries` pre-aggregate maintained by the existing hourly cron (same pass, same `last_aggregated_at` cursor as `summaries`). The insight reports a stable 24-bucket profile of mean coding time per hour-of-day, computed in the user's profile timezone. Strategy (a) from #134 (a per-hour aggregate table) is chosen over scanning raw heartbeats at query time, which is rejected for large ranges under the Workers 10ms CPU budget.
+
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI changes (`hours` enum value, operation prose, new `Insight.hours[]` field) + the `hourly_summaries` table in `src/db/schema.sql` + regenerated types. **No cron or route/business logic.**
+
+**PR2 (after PR1 merges)**: extend the cron to populate `hourly_summaries` in the same pass; add the `hours` read path + builder; unit + integration tests.
+
+> **Why `schema.sql` lands in PR1**: Issue #134 explicitly scopes "add the hourly aggregate table to `src/db/schema.sql`" to PR1. The table is part of the data-model contract that PR2's cron and read path depend on; it contains no business logic. This is a deliberate, issue-directed exception to the "schemas only" shorthand for PR1 — it stays SDD-compliant (data model defined before the code that uses it).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: D1 — adds `hourly_summaries` (new table); reads it for the insight. `summaries` unchanged.
+**Testing**: Vitest + workers pool — unit tests for the pure `hours` builder; aggregation tests for the cron's hour bucketing; integration tests for the endpoint (24-bucket shape, mean math, empty range, timezone, 400/401).
+**Performance Goals**: <10ms CPU — one read of `hourly_summaries` per request + an O(active rows) in-memory fold; the cron gains hour bucketing inside the existing single heartbeat scan (no extra scan).
+**Constraints**: incremental cron (process only data since `last_aggregated_at`); no raw-heartbeat scan at request time.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Spec + OpenAPI + data model (schema.sql) land first (PR1); cron/route/builder follow in PR2. Types regenerated, never hand-edited. |
+| II. Cloudflare-Native | PASS | Reuses the single hourly cron pass and one cursor for both aggregates (no second scan); request reads one pre-aggregate. D1 batch UPSERT for the new table (PR2). |
+| III. Type Safety | PASS | Handler will use `components["schemas"]["Insight"]`; the new `hours[]` field is generated, not hand-written. |
+| IV. Legal/Trademark | PASS | Semantics derived from our own `summaries`/`daily_average` model; no third-party source consulted. |
+| V. Simplicity First | PASS | One new narrow table (4 columns), one new enum value, one new builder branch. Reuses the existing cron walk and timezone helpers. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/134-insights-hours-of-day/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/paths/insights/insights.yaml      # CHANGE: add `hours` to enum; update operation prose + field mapping
+schemas/components/schemas/Insight.yaml   # CHANGE: add `hours[]` field
+src/db/schema.sql                         # CHANGE: add `hourly_summaries` table + unique index
+src/types/generated.ts                    # REGENERATED (npm run generate)
+
+# PR2 (after PR1 merges)
+src/utils/time-format.ts                  # CHANGE: add getHourForTimestamp(epoch, tz) -> 0..23
+src/cron/aggregate.ts                      # CHANGE: also bucket each duration into (user, date, hour); batch-UPSERT hourly_summaries in the same pass
+src/utils/insights.ts                      # CHANGE: add the `hours` builder branch (24-bucket mean profile)
+src/routes/insights.ts                     # CHANGE: for insight_type === "hours", read hourly_summaries instead of summaries
+```
+
+**Structure Decision**: Keep the per-request read path thin and the math pure. The cron change is additive — the existing `computeDurations` walk already determines each interval's owning heartbeat and `date`; PR2 also derives that heartbeat's `hour` and accumulates a second map keyed by `(userId, date, hour)`, then batch-UPSERTs it alongside the daily summaries in the same `db.batch()`. The route, for `insight_type === "hours"`, issues a single `SELECT date, hour, total_seconds FROM hourly_summaries WHERE user_id = ? AND date BETWEEN ? AND ?` and hands the rows to a pure builder that folds them into the 24-bucket mean profile (distinct dates → active-day denominator). No other insight branch is touched.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add `hours` to the enum and the `Insight.hours[]` field; document the operation prose; add `hourly_summaries` to `schema.sql`; `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: `getHourForTimestamp` helper + cron hour bucketing + `hours` builder + route read path + unit/aggregation/integration tests; `npm test` green; open PR referencing #134 and PR1.
+
+## Risks & Mitigations
+
+- **Forward-only data on existing instances** (the new table starts empty) → documented as a known limitation (spec Edge Cases, research D-6); a bounded backfill from still-retained `heartbeats` is an optional, separate follow-up — the contract is correct for all data aggregated after introduction.
+- **Storage growth** (up to 24 rows/active-day/user) → comparable to or below `summaries` (which stores one row per dimension tuple per day); acceptable for D1 at single-user scale. Noted in data-model.
+- **Hour-boundary attribution skew** → bounded by the session timeout (≤ 60 min) and consistent with the existing `date` attribution; documented (FR-009, research D-4).
+- **Type drift** → the `hours[]` field is generated from the OpenAPI schema; the generate diff is reviewed to confirm only the additive `Insight` change + the new enum value.

--- a/specs/134-insights-hours-of-day/quickstart.md
+++ b/specs/134-insights-hours-of-day/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day`
+
+Manual verification scenarios (run against a worker with seeded `hourly_summaries`). These also map directly to the PR2 integration tests. Auth via API key (Bearer) per project test helpers.
+
+Assume a user (profile timezone `UTC` for the baseline) whose `hourly_summaries` contain, across **two active days** `2026-06-01` and `2026-06-02`:
+
+| date       | hour | total_seconds |
+|------------|------|---------------|
+| 2026-06-01 | 9    | 3600          |
+| 2026-06-01 | 10   | 1800          |
+| 2026-06-02 | 9    | 1800          |
+| 2026-06-02 | 14   | 600           |
+
+Active days = 2. Expected means: hour 9 → (3600+1800)/2 = 2700; hour 10 → 1800/2 = 900; hour 14 → 600/2 = 300; every other hour → 0.
+
+## A. Basic profile
+
+```
+GET /api/v1/users/current/insights/hours/last_30_days
+```
+Expect `data.type === "hours"` and `data.hours` with **24 entries** ordered `0…23`. Bucket `hour:9` → `total_seconds:2700`, `hour:10` → `900`, `hour:14` → `300`, all others → `0`.
+
+## B. Sums to daily_average
+
+```
+GET /api/v1/users/current/insights/daily_average/last_30_days
+```
+Expect `data.daily_average.seconds === 3900` (= 2700+900+300), i.e. the sum of all 24 `hours[]` buckets from A.
+
+## C. Empty range → 24 zeros
+
+```
+GET /api/v1/users/current/insights/hours/2099
+```
+Expect HTTP 200 with `data.hours` still 24 entries, every `total_seconds === 0`.
+
+## D. Range vocabulary + year/month
+
+```
+GET /api/v1/users/current/insights/hours/2026-06
+GET /api/v1/users/current/insights/hours/last_7_days
+```
+Expect HTTP 200, `type:"hours"`, 24 buckets, for both.
+
+## E. Invalid range → 400
+
+```
+GET /api/v1/users/current/insights/hours/not_a_range
+```
+Expect HTTP 400.
+
+## F. Unauthenticated → 401
+
+```
+GET /api/v1/users/current/insights/hours/last_30_days   (no/invalid Bearer)
+```
+Expect HTTP 401.
+
+## G. Timezone basis
+
+Seed a user with profile timezone `America/New_York` and heartbeats whose UTC hour differs from the local hour; re-run the cron. Expect the bucket to land on the **local** hour (e.g. 14:00 UTC → 09:00 or 10:00 New York depending on DST), matching the date bucketed into `summaries` for the same activity.
+
+## H. Reserved params ignored
+
+```
+GET /api/v1/users/current/insights/hours/last_30_days?weekday=monday&timeout=30&writes_only=true
+```
+Expect a response identical to A — `weekday`, `timeout`, `writes_only` have no effect on `hours`.

--- a/specs/134-insights-hours-of-day/research.md
+++ b/specs/134-insights-hours-of-day/research.md
@@ -1,0 +1,66 @@
+# Research & Decisions: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day` | **Date**: 2026-06-05
+
+Documented decisions that shape the contract. Each records the choice, the alternatives, and why.
+
+## D-1: Aggregation strategy — a per-hour pre-aggregate table
+
+**Decision**: Add a `hourly_summaries` table at (`user_id`, local `date`, local `hour`) granularity, populated by the hourly cron. Serve the insight from it.
+
+**Why**: `summaries` is day-granular and cannot answer an hour-of-day question. The two candidates in #134 are (a) an hourly aggregate table, or (b) scanning raw `heartbeats` at query time. (b) is rejected: an `all_time` / `last_year` `hours` request would scan an unbounded number of heartbeats inside a single request, blowing the Workers 10ms CPU budget, and `heartbeats` may already be purged past the retention window. (a) keeps the request to one indexed read of a small aggregate, consistent with how every other insight is served.
+
+**Alternatives rejected**: query-time heartbeat scan (b) — unbounded request cost, breaks under retention purging. Reusing `summaries` with a synthetic hour column — would require re-aggregating raw data anyway and bloats the daily table.
+
+## D-2: Populate in the same cron pass, off the same cursor
+
+**Decision**: Bucket each duration into both `summaries` (by `date`) and `hourly_summaries` (by `date`+`hour`) in the **same** `computeDurations` walk, batch-UPSERT both in the same `db.batch()`, and advance the single existing `last_aggregated_at` cursor for both.
+
+**Why**: The cron already performs exactly one heartbeat scan per run and already computes each interval's owning heartbeat. Deriving that heartbeat's hour is a constant-time addition; no second scan, no second cursor, no risk of the two aggregates drifting out of sync. This honours the incremental-cron constraint (process only data since `last_aggregated_at`).
+
+**Alternatives rejected**: a separate `last_hourly_aggregated_at` cursor + independent pass — doubles the heartbeat scan cost and invites skew between the daily and hourly views for no benefit at our scale.
+
+## D-3: Mean per active day (denominator = distinct active dates in range)
+
+**Decision**: `hours[h].total_seconds = (sum of seconds bucketed to hour h across the range) / (count of distinct dates with any activity in the range)`.
+
+**Why**: This yields a "typical active day" profile and has a clean, testable property: the 24 buckets sum to the `daily_average` insight's `seconds` (both divide the same grand total by the same active-day count). It mirrors how `daily_average` already defines an average over active days, so the two insights agree.
+
+**Alternatives rejected**:
+- *Per-hour active-day denominator* (divide each hour by the number of days that had activity **in that hour**, the way the `weekday` insight averages per weekday): inflates sparse hours and breaks the "sums to daily_average" property; less intuitive as a daily profile.
+- *Raw totals (no averaging)*: the insight is defined as an average ("mean coding time per hour"); totals would just duplicate what a summed query already shows and scale with range length.
+- *Denominator = all calendar days in range* (including zero-activity days): drags the profile toward zero for sparse users and diverges from `daily_average`'s active-day basis.
+
+## D-4: Hour-boundary attribution follows the existing `date` rule
+
+**Decision**: Attribute a whole duration interval `[prev, curr)` to the hour-of-day of `prev` (its starting heartbeat), exactly as aggregation already attributes the interval to `prev`'s `date`.
+
+**Why**: Consistency with the daily aggregation and simplicity. An interval is at most one session timeout (≤ 60 min, `MAX_USER_TIMEOUT`), so attributing it wholly to the starting hour displaces at most that much time into the neighbouring hour — a bounded, well-understood approximation. Splitting an interval across hour boundaries would add complexity (and a date-rollover case) for negligible accuracy gain at our granularity.
+
+**Alternatives rejected**: proportional split across hour boundaries — more code, a midnight-rollover edge, and no meaningful change to a coarse hour-of-day profile.
+
+## D-5: Response shape — a dedicated `hours[]` field, always 24 buckets
+
+**Decision**: Add a top-level `hours[]` array to the `Insight` schema, each entry `{hour: 0–23, total_seconds, text}`, always 24 entries ordered ascending by `hour` (zero-activity hours included as `total_seconds: 0`).
+
+**Why**: A dedicated field parallels the existing `days[]` / `best_day` / `daily_average` modeling (insight_type `days` → field `days`, so `hours` → field `hours`), and a self-describing integer `hour` reads better than overloading `SummaryItem.name` with an hour string (the `items[]` route used by dimension/`weekday` insights). A fixed 24-bucket shape lets a client render an hour-of-day chart unconditionally, with no gaps to fill in. The field is additive — existing insight responses are unchanged.
+
+**Alternatives rejected**:
+- *Reuse `items[]` (`SummaryItem`)* like the `weekday` insight — would put the hour into `name` as a string and carry irrelevant fields (`percent`, `digital`, `hours`/`minutes`/`seconds`); a typed `hour` integer is cleaner. (Note `SummaryItem.hours` is the integer hour component of a duration — unrelated to this array; no real collision.)
+- *Sparse, activity-sorted array* like `weekday` — convenient for a leaderboard but awkward for a 24-hour profile chart; the stable 24-bucket order is more useful here.
+
+## D-6: Forward-only population; backfill is an optional follow-up
+
+**Decision**: `hourly_summaries` is filled by the cron going forward from when the table is introduced. The `hours` insight is correct for all activity aggregated on or after that point. A one-time backfill is **not** part of this feature.
+
+**Why**: The daily `summaries` were themselves built incrementally and have already discarded the hour, so the hourly table cannot be reconstructed from `summaries`. It could only be backfilled from raw `heartbeats` that are still within the retention window — a bounded, instance-specific one-off (e.g. a `wrangler d1 execute` migration or a throttled cron task) that does not belong in this contract. Calling this out keeps the limitation explicit rather than implying historical hour data appears retroactively.
+
+**Alternatives rejected**: forcing a full backfill in PR2 — impossible where heartbeats are purged, and a request-time backfill would violate the CPU budget; reset of `last_aggregated_at` to re-aggregate — would double-count the daily `summaries` UPSERTs.
+
+## D-7: `hour` numbering and timezone basis
+
+**Decision**: `hour` is an integer `0–23` on a 24-hour clock (`h23`), computed in the user's profile timezone, on the same basis aggregation uses for `summaries.date`.
+
+**Why**: Aligns with the daily `date` bucketing (user-profile timezone at aggregation time) so the two aggregates describe the same local calendar. The 24-hour clock is unambiguous and locale-independent. PR2 adds a `getHourForTimestamp(epoch, tz)` helper mirroring the existing `getDateForTimestamp`, reusing the same `Intl.DateTimeFormat(... hourCycle: "h23")` machinery already present in `time-format.ts`.
+
+**Alternatives rejected**: 12-hour clock / AM-PM strings — locale-dependent and harder to sort/aggregate; UTC hours — would disagree with the user's local `date` bucketing.

--- a/specs/134-insights-hours-of-day/spec.md
+++ b/specs/134-insights-hours-of-day/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Add the `hours`-of-day insight type
+
+**Feature Branch**: `134-insights-hours-of-day`
+**Created**: 2026-06-05
+**Status**: Draft
+**Input**: The `getInsight` operation documents that an `hours`-of-day insight is "intentionally absent because `summaries` has day granularity only" (`schemas/paths/insights/insights.yaml`). `hours` is not in the `insight_type` enum, so a request for it returns 400. Issue #134.
+
+## Background
+
+The Insights endpoint (`GET /api/v1/users/current/insights/{insight_type}/{range}`, shipped in #103) derives an insight from the pre-aggregated `summaries` table. `summaries` is bucketed at **day** granularity, so it cannot answer "how is my coding distributed across the hours of a typical day?". That hour-of-day breakdown was deferred at first cut precisely because the data was not aggregated at that resolution.
+
+This feature adds the `hours`-of-day insight. It reports, for each hour `0–23` (computed in the user's profile timezone), the **mean coding time in that hour across the active days in the range** — the shape of a typical coding day.
+
+To answer it within the Workers CPU budget without scanning raw heartbeats at query time, this feature introduces a second pre-aggregate, `hourly_summaries`, maintained by the **same hourly cron pass** that already maintains `summaries`, off the **same `last_aggregated_at` cursor**. The hour is bucketed in the user's timezone at aggregation time, exactly as the daily `date` already is, so the two aggregates stay internally consistent.
+
+The sibling `timeout` and `writes_only` query parameters remain reserved/unapplied and are **out of scope** here, as is the `weekday` filter (it applies only to the `days` type, #133).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See the shape of a typical coding day (Priority: P1)
+
+As an authenticated user, I want to see how my coding time is distributed across the hours of the day so I can understand when I am most active.
+
+**Why this priority**: This is the entire feature. Without it the hour-of-day breakdown does not exist.
+
+**Independent Test**: Seed `hourly_summaries` for a user across several dates with activity in known hours. `GET /insights/hours/last_30_days` returns `{data:{type:"hours", hours:[…]}}` with exactly 24 buckets, one per hour `0–23` in ascending order, each bucket's `total_seconds` equal to that hour's summed seconds divided by the number of distinct active days in the range.
+
+**Acceptance Scenarios**:
+
+1. **Given** activity bucketed into a few hours across multiple dates, **When** requesting `hours` for a range covering them, **Then** `hours[]` has 24 entries ordered `0…23`, hours with no activity have `total_seconds = 0`, and each active hour's `total_seconds` is its summed seconds across the range divided by the count of distinct active days.
+2. **Given** the same data, **When** summing `total_seconds` across all 24 buckets, **Then** the total equals the `daily_average` insight's `seconds` for the same range (both divide the same grand total by the same active-day count).
+3. **Given** a range with no activity, **When** requesting `hours`, **Then** `hours[]` still has 24 entries, all with `total_seconds = 0`, HTTP 200.
+4. **Given** a user whose profile timezone differs from UTC, **When** requesting `hours`, **Then** each bucket reflects the hour as bucketed in that timezone at aggregation time (the same basis as `summaries.date`).
+
+---
+
+### User Story 2 - `hours` is a first-class `insight_type` (Priority: P2)
+
+As an API client author, I want `hours` accepted by the same operation, range vocabulary, and error contract as every other insight type so I do not have to special-case it.
+
+**Why this priority**: Consistency with the existing insights contract; small but required for a clean client experience.
+
+**Independent Test**: `GET /insights/hours/last_7_days` and `GET /insights/hours/2026-05` both return 200 with `type:"hours"`; `GET /insights/hours/not_a_range` returns 400; an unauthenticated request returns 401.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid range name or `YYYY` / `YYYY-MM`, **When** requesting `hours`, **Then** HTTP 200 with `data.type === "hours"` and `data.range` populated as for every other insight type.
+2. **Given** an unrecognised range, **When** requesting `hours`, **Then** HTTP 400 (same as other types).
+3. **Given** no/invalid credentials, **When** requesting `hours`, **Then** HTTP 401.
+
+---
+
+### Edge Cases
+
+- **Range with no data**: a stable 24-bucket response with all zeros (not an empty array), so clients can render a 24-bar profile unconditionally.
+- **Duration spanning an hour boundary**: a duration interval is attributed entirely to the hour of its starting heartbeat — the same approximation aggregation already uses for the `date` bucket. The interval is at most one session timeout (≤ 60 min), so the displacement is bounded.
+- **Timezone changes after the fact**: hour buckets reflect the timezone in effect at aggregation time and are not retroactively re-bucketed if the user later changes timezone — identical to the existing behavior of `summaries.date`.
+- **Forward-only population**: `hourly_summaries` is filled by the cron going forward from the moment the table exists; activity already aggregated into `summaries` before that is not present unless a backfill is run (see research D-6). The contract is correct for all data aggregated on or after introduction.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST add `hours` to the `insight_type` enum so `GET /insights/hours/{range}` is a valid request.
+- **FR-002**: The `hours` insight MUST return a `hours[]` array of exactly 24 entries, one per hour `0–23`, ordered ascending by `hour`, regardless of how many hours had activity.
+- **FR-003**: Each `hours[]` entry MUST contain `hour` (integer `0–23`), `total_seconds` (number), and `text` (human-readable formatting of `total_seconds`).
+- **FR-004**: `total_seconds` for hour *h* MUST equal the sum of seconds bucketed to hour *h* across the range divided by the number of distinct active days (dates with any activity) in the range; when there are no active days it MUST be `0`.
+- **FR-005**: The hour of each duration MUST be computed in the user's profile timezone, on the same basis aggregation uses for the daily `date` (FR-009), so the two aggregates agree.
+- **FR-006**: The system MUST serve the `hours` insight from a pre-aggregate (`hourly_summaries`) — it MUST NOT scan raw `heartbeats` at request time.
+- **FR-007**: The `hours` insight MUST accept the same `range` vocabulary (`last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `all_time`, `YYYY`, `YYYY-MM`) and return 400 for an unrecognised range and 401 when unauthenticated, identical to the other insight types.
+- **FR-008**: The system MUST populate `hourly_summaries` in the same hourly cron pass and off the same `last_aggregated_at` cursor as `summaries`, so a single heartbeat scan feeds both aggregates and they advance together.
+- **FR-009**: A duration interval MUST be attributed entirely to the hour-of-day of its starting heartbeat (matching how aggregation attributes the interval to that heartbeat's `date`).
+- **FR-010**: The `timeout`, `writes_only`, and `weekday` query parameters MUST behave unchanged for the `hours` type — ignored, as they are for every type other than `days` (`weekday`) / every type (`timeout`, `writes_only`).
+
+### Key Entities
+
+- **`hourly_summaries`** (new): hour-of-day pre-aggregate. One row per (`user_id`, local `date`, local `hour` `0–23`) with an accumulating `total_seconds`. Maintained by the hourly cron; read by the `hours` insight. See `data-model.md`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A `hours` request always returns exactly 24 buckets ordered `0…23`, for any dataset including an empty range.
+- **SC-002**: For any seeded dataset, the sum of all 24 buckets' `total_seconds` equals the `daily_average` insight's `seconds` for the same range (to within rounding).
+- **SC-003**: For any seeded dataset, each bucket's `total_seconds` equals (summed seconds in that hour) / (distinct active days), verifiable against the seed.
+- **SC-004**: A `hours` request issues no query against the `heartbeats` table (served entirely from `hourly_summaries`), staying within the existing single-aggregate-read CPU budget.
+- **SC-005**: The hourly aggregation runs in the same cron invocation as the daily aggregation with no additional heartbeat scan, and both aggregates reflect the same `last_aggregated_at` cursor after a run.

--- a/specs/134-insights-hours-of-day/tasks.md
+++ b/specs/134-insights-hours-of-day/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: `hours`-of-day insight
+
+**Branch**: `134-insights-hours-of-day`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-06-05 · **Issue**: #134
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (US1 profile, US2 first-class type; FR-001..FR-010; edge cases; SC-001..SC-005).
+- [x] **T-002**: Author `plan.md` (Constitution Check; same-pass cron design; note schema.sql in PR1 per #134).
+- [x] **T-003**: Author `research.md` (D-1 aggregate-table strategy, D-2 same-pass/cursor, D-3 mean-per-active-day, D-4 hour-boundary attribution, D-5 response shape, D-6 forward-only/backfill, D-7 numbering/timezone).
+- [x] **T-004**: Author `data-model.md` (`hourly_summaries` DDL; write/read paths; in-memory fold; daily_average invariant).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–H).
+- [x] **T-006**: Author `contracts/openapi-diff.md` (enum value + `Insight.hours[]` + prose; additive generate diff).
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Update `schemas/paths/insights/insights.yaml` — add `hours` to the enum; rewrite the data-source paragraph; add the `hours` field-mapping bullet.
+- [x] **T-009**: Update `schemas/components/schemas/Insight.yaml` — add the `hours[]` field.
+- [x] **T-010**: Add `hourly_summaries` table + unique index to `src/db/schema.sql`.
+- [x] **T-011**: Run `npm run generate` (expect additive enum literal + `Insight.hours[]` in `src/types/generated.ts`); run `npm run typecheck`.
+- [ ] **T-012**: Commit PR1 in SDD order (spec/schemas + schema.sql, then regenerated types), push, open PR against `develop` referencing #134.
+
+## PR2 — Implementation (after PR1 merges)
+
+### Timezone helper
+- [ ] **T-101**: `src/utils/time-format.ts` — add `getHourForTimestamp(epochSeconds, tz?) -> 0..23` mirroring `getDateForTimestamp` (reuse `Intl.DateTimeFormat` with `hourCycle: "h23"`; UTC fast path).
+- [ ] **T-102**: Unit tests for `getHourForTimestamp` (UTC, a +/- offset zone, a DST boundary).
+
+### Cron (same pass as summaries)
+- [ ] **T-103**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
+- [ ] **T-104**: Aggregation tests `tests/aggregation/` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
+
+### Builder + route
+- [ ] **T-105**: `src/utils/insights.ts` — add the `hours` branch: fold per-`(date,hour)` rows into 24 buckets, mean = sum/distinct-active-days, ascending by hour; add `hours` to `INSIGHT_TYPES`.
+- [ ] **T-106**: `src/routes/insights.ts` — for `insight_type === "hours"`, issue the `hourly_summaries` SELECT and pass its rows to the builder; other types unchanged.
+- [ ] **T-107**: Unit tests `tests/aggregation/insights.test.ts` (extend) — 24-bucket shape, mean math, empty → 24 zeros, sums-to-daily_average invariant.
+
+### Integration + verification
+- [ ] **T-108**: `tests/integration/insights.test.ts` (extend) — quickstart A–H: profile, daily_average equality, empty range, year/month + range names, 400, 401, timezone, reserved-params ignored, cross-user isolation.
+- [ ] **T-109**: `npm run typecheck` — zero errors.
+- [ ] **T-110**: `npm test` — full suite green incl. new/extended unit + aggregation + integration.
+- [ ] **T-111**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #134.
+
+## Dependencies
+
+```
+T-001 .. T-011 → T-012                  (PR1)
+T-012 → T-101 .. T-111                   (PR2 after PR1 merge)
+T-101 → T-102
+T-101 → T-103 → T-104
+T-105 → T-106 → T-107 → T-108
+T-104 / T-108 → T-109 → T-110 → T-111
+```
+
+## Out of scope
+
+- Backfilling `hourly_summaries` from historical heartbeats (research D-6) — optional ops follow-up.
+- Applying `timeout` / `writes_only` / `weekday` to `hours` (they stay ignored).
+- Splitting a duration across hour boundaries (research D-4).
+- Any change to the daily `summaries` shape or the other insight types.

--- a/specs/134-insights-hours-of-day/tasks.md
+++ b/specs/134-insights-hours-of-day/tasks.md
@@ -7,7 +7,7 @@
 ## PR1 — Spec + Design
 
 - [x] **T-001**: Author `spec.md` (US1 profile, US2 first-class type; FR-001..FR-010; edge cases; SC-001..SC-005).
-- [x] **T-002**: Author `plan.md` (Constitution Check; same-pass cron design; note schema.sql in PR1 per #134).
+- [x] **T-002**: Author `plan.md` (Constitution Check; same-pass cron design; schema.sql deferred to PR2 per project workflow).
 - [x] **T-003**: Author `research.md` (D-1 aggregate-table strategy, D-2 same-pass/cursor, D-3 mean-per-active-day, D-4 hour-boundary attribution, D-5 response shape, D-6 forward-only/backfill, D-7 numbering/timezone).
 - [x] **T-004**: Author `data-model.md` (`hourly_summaries` DDL; write/read paths; in-memory fold; daily_average invariant).
 - [x] **T-005**: Author `quickstart.md` (scenarios A–H).
@@ -15,9 +15,8 @@
 - [x] **T-007**: Author `checklists/requirements.md`.
 - [x] **T-008**: Update `schemas/paths/insights/insights.yaml` — add `hours` to the enum; rewrite the data-source paragraph; add the `hours` field-mapping bullet.
 - [x] **T-009**: Update `schemas/components/schemas/Insight.yaml` — add the `hours[]` field.
-- [x] **T-010**: Add `hourly_summaries` table + unique index to `src/db/schema.sql`.
-- [x] **T-011**: Run `npm run generate` (expect additive enum literal + `Insight.hours[]` in `src/types/generated.ts`); run `npm run typecheck`.
-- [ ] **T-012**: Commit PR1 in SDD order (spec/schemas + schema.sql, then regenerated types), push, open PR against `develop` referencing #134.
+- [x] **T-010**: Run `npm run generate` (expect additive enum literal + `Insight.hours[]` in `src/types/generated.ts`); run `npm run typecheck`.
+- [x] **T-011**: Commit PR1 in SDD order (spec/schemas, then regenerated types), push, open PR against `develop` referencing #134.
 
 ## PR2 — Implementation (after PR1 merges)
 
@@ -26,29 +25,30 @@
 - [ ] **T-102**: Unit tests for `getHourForTimestamp` (UTC, a +/- offset zone, a DST boundary).
 
 ### Cron (same pass as summaries)
-- [ ] **T-103**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
-- [ ] **T-104**: Aggregation tests `tests/aggregation/` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
+- [ ] **T-103**: `src/db/schema.sql` — add the `hourly_summaries` table + unique index.
+- [ ] **T-104**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
+- [ ] **T-105**: Aggregation tests `tests/aggregation/` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
 
 ### Builder + route
-- [ ] **T-105**: `src/utils/insights.ts` — add the `hours` branch: fold per-`(date,hour)` rows into 24 buckets, mean = sum/distinct-active-days, ascending by hour; add `hours` to `INSIGHT_TYPES`.
-- [ ] **T-106**: `src/routes/insights.ts` — for `insight_type === "hours"`, issue the `hourly_summaries` SELECT and pass its rows to the builder; other types unchanged.
-- [ ] **T-107**: Unit tests `tests/aggregation/insights.test.ts` (extend) — 24-bucket shape, mean math, empty → 24 zeros, sums-to-daily_average invariant.
+- [ ] **T-106**: `src/utils/insights.ts` — add the `hours` branch: fold per-`(date,hour)` rows into 24 buckets, mean = sum/distinct-active-days, ascending by hour; add `hours` to `INSIGHT_TYPES`.
+- [ ] **T-107**: `src/routes/insights.ts` — for `insight_type === "hours"`, issue the `hourly_summaries` SELECT and pass its rows to the builder; other types unchanged.
+- [ ] **T-108**: Unit tests `tests/aggregation/insights.test.ts` (extend) — 24-bucket shape, mean math, empty → 24 zeros, sums-to-daily_average invariant.
 
 ### Integration + verification
-- [ ] **T-108**: `tests/integration/insights.test.ts` (extend) — quickstart A–H: profile, daily_average equality, empty range, year/month + range names, 400, 401, timezone, reserved-params ignored, cross-user isolation.
-- [ ] **T-109**: `npm run typecheck` — zero errors.
-- [ ] **T-110**: `npm test` — full suite green incl. new/extended unit + aggregation + integration.
-- [ ] **T-111**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #134.
+- [ ] **T-109**: `tests/integration/insights.test.ts` (extend) — quickstart A–H: profile, daily_average equality, empty range, year/month + range names, 400, 401, timezone, reserved-params ignored, cross-user isolation.
+- [ ] **T-110**: `npm run typecheck` — zero errors.
+- [ ] **T-111**: `npm test` — full suite green incl. new/extended unit + aggregation + integration.
+- [ ] **T-112**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #134.
 
 ## Dependencies
 
 ```
-T-001 .. T-011 → T-012                  (PR1)
-T-012 → T-101 .. T-111                   (PR2 after PR1 merge)
+T-001 .. T-010 → T-011                  (PR1)
+T-011 → T-101 .. T-112                   (PR2 after PR1 merge)
 T-101 → T-102
-T-101 → T-103 → T-104
-T-105 → T-106 → T-107 → T-108
-T-104 / T-108 → T-109 → T-110 → T-111
+T-101 → T-103 → T-104 → T-105
+T-106 → T-107 → T-108 → T-109
+T-105 / T-109 → T-110 → T-111 → T-112
 ```
 
 ## Out of scope

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -151,24 +151,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_summaries_unique
   ON summaries(user_id, date, project, language, editor, operating_system, category, branch, machine);
 
 -- ============================================================
--- Hourly Summaries (hour-of-day aggregated, populated by cron)
--- Backs the `hours`-of-day insight (Issue #134). Maintained by the same hourly
--- cron pass as `summaries`, off the same last_aggregated_at cursor. One row per
--- (user, local date, local hour 0-23); total_seconds accumulates via UPSERT.
--- ============================================================
-CREATE TABLE IF NOT EXISTS hourly_summaries (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id TEXT NOT NULL,
-  date TEXT NOT NULL,
-  hour INTEGER NOT NULL,
-  total_seconds REAL NOT NULL DEFAULT 0,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
-  ON hourly_summaries(user_id, date, hour);
-
--- ============================================================
 -- Goals
 -- ============================================================
 CREATE TABLE IF NOT EXISTS goals (

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -151,6 +151,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_summaries_unique
   ON summaries(user_id, date, project, language, editor, operating_system, category, branch, machine);
 
 -- ============================================================
+-- Hourly Summaries (hour-of-day aggregated, populated by cron)
+-- Backs the `hours`-of-day insight (Issue #134). Maintained by the same hourly
+-- cron pass as `summaries`, off the same last_aggregated_at cursor. One row per
+-- (user, local date, local hour 0-23); total_seconds accumulates via UPSERT.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS hourly_summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  hour INTEGER NOT NULL,
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
+  ON hourly_summaries(user_id, date, hour);
+
+-- ============================================================
 -- Goals
 -- ============================================================
 CREATE TABLE IF NOT EXISTS goals (

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -770,11 +770,10 @@ export interface paths {
         };
         /**
          * Coding activity insights
-         * @description Derives an insight of the requested `insight_type` over `range` from the
-         *     pre-aggregated `summaries` table (no raw-heartbeat scan). All listed
-         *     insight types ship in the first cut; an `hours`-of-day insight is
-         *     intentionally absent because `summaries` has day granularity only (it
-         *     would require an hourly aggregate - a future addition).
+         * @description Derives an insight of the requested `insight_type` over `range`. Most types
+         *     read from the pre-aggregated `summaries` table (day granularity, no
+         *     raw-heartbeat scan); the `hours`-of-day type reads from the `hourly_summaries`
+         *     aggregate, which the same hourly cron maintains at hour-of-day granularity.
          *
          *     `range` accepts `last_7_days`, `last_30_days`, `last_6_months`,
          *     `last_year`, `all_time`, or `YYYY` / `YYYY-MM`, interpreted in the user's
@@ -786,6 +785,10 @@ export interface paths {
          *       single weekday when the `weekday` query parameter is set).
          *     - `best_day` -> `best_day` (the single highest-total day).
          *     - `daily_average` -> `daily_average` (mean seconds per active day).
+         *     - `hours` -> `hours[]`, one bucket per hour of day (0-23, computed in the
+         *       user's profile timezone), `total_seconds` = mean coding time in that hour
+         *       across the active days in the range, ordered by hour ascending. Always 24
+         *       buckets; hours with no activity report `total_seconds` 0.
          *     - `weekday` -> `items[]`, one per weekday (`name` = Monday-Sunday),
          *       `total_seconds` = mean for that weekday, ordered most-active first.
          *     - `projects` / `languages` / `editors` / `categories` / `machines` /
@@ -1670,6 +1673,12 @@ export interface components {
                 seconds?: number;
                 text?: string;
             };
+            hours?: {
+                hour?: number;
+                /** Format: double */
+                total_seconds?: number;
+                text?: string;
+            }[];
             items?: components["schemas"]["SummaryItem"][];
         };
         CustomRule: {
@@ -3119,7 +3128,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                insight_type: "weekday" | "days" | "best_day" | "daily_average" | "projects" | "languages" | "editors" | "categories" | "machines" | "operating_systems";
+                insight_type: "weekday" | "days" | "best_day" | "daily_average" | "hours" | "projects" | "languages" | "editors" | "categories" | "machines" | "operating_systems";
                 range: string;
             };
             cookie?: never;


### PR DESCRIPTION
## Summary

PR1 of 2 for #134 — **spec + design only, no DB schema, cron, route, or business logic** (per the SpecKit 2-PR workflow). Adds the contract for the `hours`-of-day insight: a stable 24-bucket profile of mean coding time per hour-of-day, computed in the user's profile timezone.

### What lands here
- **OpenAPI**: add `hours` to the `insight_type` enum; add the additive `Insight.hours[]` field (`{ hour 0-23, total_seconds, text }`); rewrite the data-source paragraph and add the `hours` field-mapping bullet (`schemas/paths/insights/insights.yaml`, `schemas/components/schemas/Insight.yaml`).
- **Generated types**: `npm run generate` — additive `"hours"` union literal + `Insight.hours[]` + JSDoc only.
- **SpecKit artifacts**: `specs/134-insights-hours-of-day/` (spec, plan, research, data-model, quickstart, tasks, contracts, checklist).

### Key design decisions (see `research.md`)
- **Strategy (a)**: per-hour aggregate table, not a query-time `heartbeats` scan (rejected for unbounded CPU cost / retention purging).
- **Mean per active day**: `hours[h].total_seconds = sum(seconds in hour h) / distinct active days`. The 24 buckets sum to the `daily_average` insight's `seconds` — a clean, testable invariant.
- **Always 24 buckets** ordered `0...23` (zero-activity hours included) so clients render an hour-of-day chart unconditionally.
- **Forward-only population**: the new table fills going forward once PR2 adds the DDL and cron write path; historical backfill is an optional, out-of-scope follow-up (documented).

### Verification
- `npm run generate` — additive diff only (confirmed).
- `npm run typecheck` — passes.
- `npm test` — passes.
- `npm run lint:api` — passes.

### Out of scope (PR2)
`src/db/schema.sql` DDL for `hourly_summaries`, `getHourForTimestamp` helper, cron hour bucketing, the `hours` builder branch + route read path, and unit/aggregation/integration tests.

Tracks #134.
