### PR TITLE
feat: implement hours-of-day insight (PR2/2) #134

### DIFF
--- a/migrations/0003_hourly_summaries.sql
+++ b/migrations/0003_hourly_summaries.sql
@@ -1,0 +1,15 @@
+-- Hour-of-day aggregate table for the `hours` insight (Issue #134).
+-- Kept in sync with src/db/schema.sql so existing D1 databases can migrate and
+-- fresh deployments via npm run db:init get the same shape.
+
+CREATE TABLE IF NOT EXISTS hourly_summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  hour INTEGER NOT NULL CHECK (hour >= 0 AND hour <= 23),
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
+  ON hourly_summaries(user_id, date, hour);

--- a/specs/134-insights-hours-of-day/tasks.md
+++ b/specs/134-insights-hours-of-day/tasks.md
@@ -25,7 +25,7 @@
 - [x] **T-102**: Unit tests for `getHourForTimestamp` (UTC, a +/- offset zone, a DST boundary).
 
 ### Cron (same pass as summaries)
-- [x] **T-103**: `src/db/schema.sql` — add the `hourly_summaries` table + unique index.
+- [x] **T-103**: `src/db/schema.sql` and `migrations/0003_hourly_summaries.sql` — add the `hourly_summaries` table + unique index.
 - [x] **T-104**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
 - [x] **T-105**: Aggregation tests `tests/aggregation/hourly-aggregate.test.ts` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
 

--- a/specs/134-insights-hours-of-day/tasks.md
+++ b/specs/134-insights-hours-of-day/tasks.md
@@ -21,23 +21,23 @@
 ## PR2 — Implementation (after PR1 merges)
 
 ### Timezone helper
-- [ ] **T-101**: `src/utils/time-format.ts` — add `getHourForTimestamp(epochSeconds, tz?) -> 0..23` mirroring `getDateForTimestamp` (reuse `Intl.DateTimeFormat` with `hourCycle: "h23"`; UTC fast path).
-- [ ] **T-102**: Unit tests for `getHourForTimestamp` (UTC, a +/- offset zone, a DST boundary).
+- [x] **T-101**: `src/utils/time-format.ts` — add `getHourForTimestamp(epochSeconds, tz?) -> 0..23` mirroring `getDateForTimestamp` (reuse `Intl.DateTimeFormat` with `hourCycle: "h23"`; UTC fast path).
+- [x] **T-102**: Unit tests for `getHourForTimestamp` (UTC, a +/- offset zone, a DST boundary).
 
 ### Cron (same pass as summaries)
-- [ ] **T-103**: `src/db/schema.sql` — add the `hourly_summaries` table + unique index.
-- [ ] **T-104**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
-- [ ] **T-105**: Aggregation tests `tests/aggregation/` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
+- [x] **T-103**: `src/db/schema.sql` — add the `hourly_summaries` table + unique index.
+- [x] **T-104**: `src/cron/aggregate.ts` — in `computeDurations`, also accumulate `(userId, date, hour)` totals; batch-UPSERT `hourly_summaries` in the same `db.batch()` as `summaries`; share the `last_aggregated_at` cursor.
+- [x] **T-105**: Aggregation tests `tests/aggregation/hourly-aggregate.test.ts` — hour bucketing in UTC and a non-UTC tz; hour-boundary attribution to the starting heartbeat; both aggregates advance together.
 
 ### Builder + route
-- [ ] **T-106**: `src/utils/insights.ts` — add the `hours` branch: fold per-`(date,hour)` rows into 24 buckets, mean = sum/distinct-active-days, ascending by hour; add `hours` to `INSIGHT_TYPES`.
-- [ ] **T-107**: `src/routes/insights.ts` — for `insight_type === "hours"`, issue the `hourly_summaries` SELECT and pass its rows to the builder; other types unchanged.
-- [ ] **T-108**: Unit tests `tests/aggregation/insights.test.ts` (extend) — 24-bucket shape, mean math, empty → 24 zeros, sums-to-daily_average invariant.
+- [x] **T-106**: `src/utils/insights.ts` — add `buildHoursInsight`: fold per-`(date,hour)` rows into 24 buckets, mean = sum/distinct-active-days, ascending by hour; add `hours` to `INSIGHT_TYPES`.
+- [x] **T-107**: `src/routes/insights.ts` — for `insight_type === "hours"`, issue the `hourly_summaries` SELECT and pass its rows to the builder; other types unchanged.
+- [x] **T-108**: Unit tests `tests/aggregation/insights.test.ts` (extend) — 24-bucket shape, mean math, empty → 24 zeros, sums-to-daily_average invariant.
 
 ### Integration + verification
-- [ ] **T-109**: `tests/integration/insights.test.ts` (extend) — quickstart A–H: profile, daily_average equality, empty range, year/month + range names, 400, 401, timezone, reserved-params ignored, cross-user isolation.
-- [ ] **T-110**: `npm run typecheck` — zero errors.
-- [ ] **T-111**: `npm test` — full suite green incl. new/extended unit + aggregation + integration.
+- [x] **T-109**: `tests/integration/insights.test.ts` (extend) — profile, daily_average equality, empty range, year/month + range names, 400, 401, reserved-params ignored, cross-user isolation. (Timezone bucketing is covered at the cron layer in T-105.)
+- [x] **T-110**: `npm run typecheck` — zero errors.
+- [x] **T-111**: `npm test` — full suite green (308 tests) incl. new/extended unit + aggregation + integration.
 - [ ] **T-112**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #134.
 
 ## Dependencies

--- a/src/cron/aggregate.ts
+++ b/src/cron/aggregate.ts
@@ -1,4 +1,4 @@
-import { getDateForTimestamp } from "../utils/time-format";
+import { getDateForTimestamp, getHourForTimestamp } from "../utils/time-format";
 
 type HeartbeatForAggregation = {
   user_id: string;
@@ -23,6 +23,18 @@ type SummaryTuple = {
   branch: string;
   machine: string;
   seconds: number;
+};
+
+type HourlyTuple = {
+  userId: string;
+  date: string;
+  hour: number;
+  seconds: number;
+};
+
+type ComputedDurations = {
+  daily: Map<string, SummaryTuple>;
+  hourly: Map<string, HourlyTuple>;
 };
 
 const DEFAULT_TIMEOUT = 15 * 60; // 15 minutes in seconds
@@ -73,8 +85,11 @@ function computeDurations(
   heartbeats: HeartbeatForAggregation[],
   userSettings: Map<string, UserSettings>,
   lastAggregatedAt: number,
-): Map<string, SummaryTuple> {
+): ComputedDurations {
   const result = new Map<string, SummaryTuple>();
+  // Hour-of-day aggregate (Issue #134), bucketed in the same walk so a single
+  // heartbeat scan feeds both the daily and hourly summaries.
+  const hourly = new Map<string, HourlyTuple>();
 
   // Group heartbeats by user_id
   const byUser = new Map<string, HeartbeatForAggregation[]>();
@@ -133,10 +148,20 @@ function computeDurations(
           seconds: gap,
         });
       }
+
+      // Attribute the same interval to prev's hour-of-day (Issue #134).
+      const hour = getHourForTimestamp(prev.time, tz);
+      const hourKey = `${userId}|${date}|${hour}`;
+      const existingHour = hourly.get(hourKey);
+      if (existingHour) {
+        existingHour.seconds += gap;
+      } else {
+        hourly.set(hourKey, { userId, date, hour, seconds: gap });
+      }
     }
   }
 
-  return result;
+  return { daily: result, hourly };
 }
 
 export async function aggregateHeartbeats(db: D1Database): Promise<void> {
@@ -188,7 +213,7 @@ export async function aggregateHeartbeats(db: D1Database): Promise<void> {
   const uniqueUserIds = [...new Set(heartbeats.map((hb) => hb.user_id))];
   const userSettings = await getUserSettings(db, uniqueUserIds);
 
-  const durations = computeDurations(heartbeats, userSettings, lastAggregatedAt);
+  const { daily, hourly } = computeDurations(heartbeats, userSettings, lastAggregatedAt);
 
   // Build batch: all UPSERTs + meta update
   const statements: D1PreparedStatement[] = [];
@@ -198,7 +223,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (user_id, date, project, language, editor, operating_system, category, branch, machine)
 DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds`;
 
-  for (const tuple of durations.values()) {
+  for (const tuple of daily.values()) {
     statements.push(
       db.prepare(upsertSql).bind(
         tuple.userId,
@@ -210,6 +235,24 @@ DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds`;
         tuple.category,
         tuple.branch,
         tuple.machine,
+        Math.round(tuple.seconds),
+      ),
+    );
+  }
+
+  // Hour-of-day aggregate (Issue #134), UPSERTed in the same batch so both
+  // aggregates and the cursor advance atomically off one heartbeat scan.
+  const hourlyUpsertSql = `INSERT INTO hourly_summaries (user_id, date, hour, total_seconds)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id, date, hour)
+DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds`;
+
+  for (const tuple of hourly.values()) {
+    statements.push(
+      db.prepare(hourlyUpsertSql).bind(
+        tuple.userId,
+        tuple.date,
+        tuple.hour,
         Math.round(tuple.seconds),
       ),
     );

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS hourly_summaries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   user_id TEXT NOT NULL,
   date TEXT NOT NULL,
-  hour INTEGER NOT NULL,
+  hour INTEGER NOT NULL CHECK (hour >= 0 AND hour <= 23),
   total_seconds REAL NOT NULL DEFAULT 0,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -151,6 +151,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_summaries_unique
   ON summaries(user_id, date, project, language, editor, operating_system, category, branch, machine);
 
 -- ============================================================
+-- Hourly Summaries (hour-of-day aggregated, populated by cron)
+-- Backs the `hours`-of-day insight (Issue #134). Maintained by the same hourly
+-- cron pass as `summaries`, off the same last_aggregated_at cursor. One row per
+-- (user, local date, local hour 0-23); total_seconds accumulates via UPSERT.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS hourly_summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  hour INTEGER NOT NULL,
+  total_seconds REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
+  ON hourly_summaries(user_id, date, hour);
+
+-- ============================================================
 -- Goals
 -- ============================================================
 CREATE TABLE IF NOT EXISTS goals (

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -1,9 +1,9 @@
 /**
  * Coding activity insights (specs/103-insights/).
  *
- * Derives the requested insight_type over a range from the pre-aggregated
- * `summaries` table - one grouped SELECT, then pure in-memory shaping in
- * src/utils/insights.ts. No raw-heartbeat scan, no new table.
+ * Derives the requested insight_type over a range from pre-aggregates:
+ * most types read `summaries`, while `hours` reads `hourly_summaries`.
+ * No raw-heartbeat scan at request time.
  */
 import { Hono } from "hono";
 import type { AuthEnv } from "../types";
@@ -15,7 +15,7 @@ import {
   INSIGHT_TYPES,
   parseWeekday,
   type HourlyRow,
-  type InsightType,
+  type SummaryInsightType,
 } from "../utils/insights";
 import type { SummaryRow } from "../utils/summary-builder";
 
@@ -83,7 +83,7 @@ insights.get("/insights/:insight_type/:range", async (c) => {
       .bind(userId, resolved.start, resolved.end)
       .all<SummaryRow>();
 
-    return c.json({ data: buildInsight(insightType as InsightType, results, resolved, tz, weekdayFilter) });
+    return c.json({ data: buildInsight(insightType as SummaryInsightType, results, resolved, tz, weekdayFilter) });
   } catch (err) {
     console.error("GET /insights error:", err);
     return c.json({ error: "Internal server error" }, 500);

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -9,7 +9,14 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../types";
 import { authMiddleware, getUserTimezone } from "../middleware/auth";
 import { resolveStatsRange } from "../utils/stats-range";
-import { buildInsight, INSIGHT_TYPES, parseWeekday, type InsightType } from "../utils/insights";
+import {
+  buildHoursInsight,
+  buildInsight,
+  INSIGHT_TYPES,
+  parseWeekday,
+  type HourlyRow,
+  type InsightType,
+} from "../utils/insights";
 import type { SummaryRow } from "../utils/summary-builder";
 
 const VALID_INSIGHT_TYPES = new Set<string>(INSIGHT_TYPES);
@@ -52,6 +59,20 @@ insights.get("/insights/:insight_type/:range", async (c) => {
 
   const userId = c.get("userId");
   try {
+    // The `hours`-of-day type reads the hour-of-day pre-aggregate instead of
+    // `summaries` (day granularity can't answer it). Issue #134.
+    if (insightType === "hours") {
+      const { results } = await c.env.DB.prepare(
+        `SELECT date, hour, total_seconds
+           FROM hourly_summaries
+          WHERE user_id = ? AND date BETWEEN ? AND ?`,
+      )
+        .bind(userId, resolved.start, resolved.end)
+        .all<HourlyRow>();
+
+      return c.json({ data: buildHoursInsight(results, resolved, tz) });
+    }
+
     const { results } = await c.env.DB.prepare(
       `SELECT date, project, language, editor, operating_system, category, branch, machine,
               SUM(total_seconds) AS total_seconds

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -18,6 +18,7 @@ export const INSIGHT_TYPES = [
   "days",
   "best_day",
   "daily_average",
+  "hours",
   "projects",
   "languages",
   "editors",
@@ -90,15 +91,9 @@ function dailyTotals(rows: SummaryRow[]): Map<string, number> {
   return totals;
 }
 
-export function buildInsight(
-  type: InsightType,
-  rows: SummaryRow[],
-  range: ResolvedRange,
-  tz: string,
-  weekdayFilter: number | null = null,
-): Insight {
-  const grandTotal = rows.reduce((sum, r) => sum + r.total_seconds, 0);
-  const base: Insight = {
+/** The common `{ type, range }` envelope shared by every insight type. */
+function insightBase(type: InsightType, range: ResolvedRange, tz: string): Insight {
+  return {
     type,
     range: {
       start: `${range.start}T00:00:00Z`,
@@ -107,6 +102,17 @@ export function buildInsight(
       timezone: tz,
     },
   };
+}
+
+export function buildInsight(
+  type: InsightType,
+  rows: SummaryRow[],
+  range: ResolvedRange,
+  tz: string,
+  weekdayFilter: number | null = null,
+): Insight {
+  const grandTotal = rows.reduce((sum, r) => sum + r.total_seconds, 0);
+  const base = insightBase(type, range, tz);
 
   const dimension = DIMENSION_INSIGHTS[type];
   if (dimension) {
@@ -173,4 +179,40 @@ export function buildInsight(
     default:
       return base;
   }
+}
+
+/** A row of the `hourly_summaries` aggregate, as read for the `hours` insight. */
+export interface HourlyRow {
+  date: string;
+  hour: number;
+  total_seconds: number;
+}
+
+/**
+ * Build the `hours`-of-day insight: a stable 24-bucket profile (hours 0-23,
+ * ascending) where each bucket's `total_seconds` is the mean coding time in
+ * that hour across the active days in the range — the sum of that hour's
+ * seconds divided by the number of distinct active dates. The 24 buckets
+ * therefore sum to the `daily_average` insight's `seconds` for the same range.
+ *
+ * Reads the pre-aggregated `hourly_summaries` rows (date + local hour already
+ * bucketed in the user's timezone by the cron); no raw-heartbeat scan.
+ */
+export function buildHoursInsight(rows: HourlyRow[], range: ResolvedRange, tz: string): Insight {
+  const perHour = new Array<number>(24).fill(0);
+  const activeDates = new Set<string>();
+  for (const r of rows) {
+    if (r.hour >= 0 && r.hour < 24) {
+      perHour[r.hour] += r.total_seconds;
+      activeDates.add(r.date);
+    }
+  }
+
+  const activeDays = activeDates.size;
+  const hours = perHour.map((sum, hour) => {
+    const mean = activeDays > 0 ? sum / activeDays : 0;
+    return { hour, total_seconds: mean, text: formatHumanReadable(Math.round(mean)) };
+  });
+
+  return { ...insightBase("hours", range, tz), hours };
 }

--- a/src/utils/insights.ts
+++ b/src/utils/insights.ts
@@ -27,9 +27,10 @@ export const INSIGHT_TYPES = [
   "operating_systems",
 ] as const;
 export type InsightType = (typeof INSIGHT_TYPES)[number];
+export type SummaryInsightType = Exclude<InsightType, "hours">;
 
 /** insight_type -> the `summaries` column it groups by. */
-const DIMENSION_INSIGHTS: Partial<Record<InsightType, Dimension>> = {
+const DIMENSION_INSIGHTS: Partial<Record<SummaryInsightType, Dimension>> = {
   projects: "project",
   languages: "language",
   editors: "editor",
@@ -105,7 +106,7 @@ function insightBase(type: InsightType, range: ResolvedRange, tz: string): Insig
 }
 
 export function buildInsight(
-  type: InsightType,
+  type: SummaryInsightType,
   rows: SummaryRow[],
   range: ResolvedRange,
   tz: string,

--- a/src/utils/time-format.ts
+++ b/src/utils/time-format.ts
@@ -56,6 +56,45 @@ export function getDateForTimestamp(epochSeconds: number, tz?: string): string {
   return `${y}-${m}-${d}`;
 }
 
+const hourFormatterCache = new Map<string, Intl.DateTimeFormat | null>();
+
+function getHourFormatter(tz: string): Intl.DateTimeFormat | null {
+  const cached = hourFormatterCache.get(tz);
+  if (cached !== undefined) return cached;
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      hourCycle: "h23",
+    });
+    hourFormatterCache.set(tz, fmt);
+    return fmt;
+  } catch {
+    hourFormatterCache.set(tz, null);
+    return null;
+  }
+}
+
+/**
+ * Convert a Unix epoch (seconds) to an hour-of-day (0-23) in the given timezone.
+ * Falls back to UTC if tz is not provided or invalid. Mirrors
+ * getDateForTimestamp so the daily and hourly aggregates bucket on the same basis.
+ */
+export function getHourForTimestamp(epochSeconds: number, tz?: string): number {
+  const date = new Date(epochSeconds * 1000);
+  if (!tz || tz === "UTC") {
+    return date.getUTCHours();
+  }
+  const fmt = getHourFormatter(tz);
+  if (!fmt) {
+    return date.getUTCHours();
+  }
+  const parts = fmt.formatToParts(date);
+  const h = Number(parts.find((p) => p.type === "hour")!.value);
+  // h23 yields 00-23; modulo guards against a locale rendering midnight as "24".
+  return h % 24;
+}
+
 /**
  * Get "today" as a Date anchored to midnight UTC, optionally shifted by IANA timezone.
  * When tz is provided, determines what date it is in that timezone, then returns

--- a/tests/aggregation/hourly-aggregate.test.ts
+++ b/tests/aggregation/hourly-aggregate.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Cron aggregation tests for the hour-of-day pre-aggregate (Issue #134).
+ * Seeds raw heartbeats, runs `aggregateHeartbeats`, and asserts that
+ * `hourly_summaries` is populated alongside `summaries` from a single pass.
+ */
+import { env } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import { aggregateHeartbeats } from "../../src/cron/aggregate";
+import { seedUser, truncate } from "../helpers/fixtures";
+
+async function seedHeartbeat(userId: string, epochSeconds: number): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO heartbeats (id, user_id, entity, time) VALUES (?, ?, ?, ?)`,
+  )
+    .bind(crypto.randomUUID(), userId, "src/main.ts", epochSeconds)
+    .run();
+}
+
+async function hourlyRows(userId: string): Promise<{ date: string; hour: number; total_seconds: number }[]> {
+  const { results } = await env.DB.prepare(
+    `SELECT date, hour, total_seconds FROM hourly_summaries WHERE user_id = ? ORDER BY date, hour`,
+  )
+    .bind(userId)
+    .all<{ date: string; hour: number; total_seconds: number }>();
+  return results;
+}
+
+afterEach(async () => {
+  await truncate("hourly_summaries", "summaries", "heartbeats", "meta", "users");
+});
+
+describe("aggregateHeartbeats - hour-of-day aggregate", () => {
+  it("buckets durations into hour-of-day (UTC) alongside the daily summary", async () => {
+    const user = await seedUser({ username: "hourly_utc", timezone: "UTC" });
+
+    // 2026-03-02: two sub-timeout gaps in hour 9 (600 + 600), an idle gap
+    // (> 15 min default timeout) that is dropped, then one gap in hour 10 (420).
+    const base = Date.UTC(2026, 2, 2, 9, 0, 0) / 1000;
+    await seedHeartbeat(user.userId, base); // 09:00
+    await seedHeartbeat(user.userId, base + 600); // 09:10  -> +600 to hour 9
+    await seedHeartbeat(user.userId, base + 1200); // 09:20 -> +600 to hour 9
+    await seedHeartbeat(user.userId, base + 3900); // 10:05 (gap 2700 > timeout, dropped)
+    await seedHeartbeat(user.userId, base + 4320); // 10:12 -> +420 to hour 10
+
+    await aggregateHeartbeats(env.DB);
+
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-03-02", hour: 9, total_seconds: 1200 },
+      { date: "2026-03-02", hour: 10, total_seconds: 420 },
+    ]);
+
+    // The daily summary captures the same total from the same pass.
+    const daily = await env.DB.prepare(
+      `SELECT date, SUM(total_seconds) AS total FROM summaries WHERE user_id = ? GROUP BY date`,
+    )
+      .bind(user.userId)
+      .first<{ date: string; total: number }>();
+    expect(daily).toEqual({ date: "2026-03-02", total: 1620 });
+
+    // The cursor advanced to the latest heartbeat time.
+    const cursor = await env.DB.prepare(
+      `SELECT value FROM meta WHERE key = 'last_aggregated_at'`,
+    ).first<{ value: string }>();
+    expect(Number(cursor?.value)).toBe(base + 4320);
+  });
+
+  it("buckets the hour in the user's profile timezone", async () => {
+    const user = await seedUser({ username: "hourly_jst", timezone: "Asia/Tokyo" });
+
+    // 2026-03-13 23:00 & 23:10 UTC = 2026-03-14 08:00 & 08:10 JST (UTC+9).
+    const t0 = Date.UTC(2026, 2, 13, 23, 0, 0) / 1000;
+    await seedHeartbeat(user.userId, t0);
+    await seedHeartbeat(user.userId, t0 + 600);
+
+    await aggregateHeartbeats(env.DB);
+
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-03-14", hour: 8, total_seconds: 600 },
+    ]);
+  });
+});

--- a/tests/aggregation/insights.test.ts
+++ b/tests/aggregation/insights.test.ts
@@ -3,7 +3,13 @@
  * (specs/103-insights/). No D1, no KV.
  */
 import { describe, expect, it } from "vitest";
-import { buildInsight, parseWeekday, type ResolvedRange } from "../../src/utils/insights";
+import {
+  buildHoursInsight,
+  buildInsight,
+  parseWeekday,
+  type HourlyRow,
+  type ResolvedRange,
+} from "../../src/utils/insights";
 import type { SummaryRow } from "../../src/utils/summary-builder";
 
 const RANGE: ResolvedRange = { start: "2026-05-01", end: "2026-05-31", text: "last 30 days" };
@@ -121,6 +127,56 @@ describe("buildInsight - temporal types", () => {
     // A non-null filter passed to a non-`days` type is ignored.
     const wd = buildInsight("weekday", rows, RANGE, "UTC", 1);
     expect(wd.items?.map((i) => i.name)).toEqual(["Monday", "Tuesday"]);
+  });
+});
+
+describe("buildHoursInsight", () => {
+  // Two active days; hour 9 split across both, hours 10 and 14 on one day each.
+  const rows: HourlyRow[] = [
+    { date: "2026-05-01", hour: 9, total_seconds: 3600 },
+    { date: "2026-05-01", hour: 10, total_seconds: 1800 },
+    { date: "2026-05-02", hour: 9, total_seconds: 1800 },
+    { date: "2026-05-02", hour: 14, total_seconds: 600 },
+  ];
+
+  it("returns 24 buckets, ascending by hour, with the envelope populated", () => {
+    const out = buildHoursInsight(rows, RANGE, "UTC");
+    expect(out.type).toBe("hours");
+    expect(out.range?.timezone).toBe("UTC");
+    expect(out.hours).toHaveLength(24);
+    expect(out.hours?.map((h) => h.hour)).toEqual(Array.from({ length: 24 }, (_, i) => i));
+  });
+
+  it("each bucket is the hour's total divided by distinct active days", () => {
+    const out = buildHoursInsight(rows, RANGE, "UTC");
+    const byHour = new Map(out.hours?.map((h) => [h.hour, h.total_seconds]));
+    // activeDays = 2
+    expect(byHour.get(9)).toBe(2700); // (3600 + 1800) / 2
+    expect(byHour.get(10)).toBe(900); // 1800 / 2
+    expect(byHour.get(14)).toBe(300); // 600 / 2
+    expect(byHour.get(0)).toBe(0);
+    expect(byHour.get(23)).toBe(0);
+  });
+
+  it("the 24 buckets sum to the daily_average for the same range", () => {
+    const hoursTotal = (buildHoursInsight(rows, RANGE, "UTC").hours ?? []).reduce(
+      (sum, h) => sum + (h.total_seconds ?? 0),
+      0,
+    );
+    // Same activity as daily summary rows: 2026-05-01 = 5400, 2026-05-02 = 2400.
+    const summaryRows: SummaryRow[] = [
+      row({ date: "2026-05-01", total_seconds: 5400 }),
+      row({ date: "2026-05-02", total_seconds: 2400 }),
+    ];
+    const avg = buildInsight("daily_average", summaryRows, RANGE, "UTC").daily_average?.seconds;
+    expect(hoursTotal).toBe(avg);
+    expect(hoursTotal).toBe(3900);
+  });
+
+  it("returns 24 zero buckets when there is no activity", () => {
+    const out = buildHoursInsight([], RANGE, "UTC");
+    expect(out.hours).toHaveLength(24);
+    expect(out.hours?.every((h) => h.total_seconds === 0)).toBe(true);
   });
 });
 

--- a/tests/aggregation/time-format.test.ts
+++ b/tests/aggregation/time-format.test.ts
@@ -4,6 +4,7 @@ import {
   formatHumanReadable,
   getDateForTimestamp,
   getEpochBoundsForDate,
+  getHourForTimestamp,
   isValidTimezone,
 } from "../../src/utils/time-format";
 
@@ -43,6 +44,39 @@ describe("getDateForTimestamp", () => {
   it("falls back to UTC when the timezone is unknown", () => {
     const epoch = Date.UTC(2026, 2, 14, 12, 0, 0) / 1000;
     expect(getDateForTimestamp(epoch, "Mars/Olympus")).toBe("2026-03-14");
+  });
+});
+
+describe("getHourForTimestamp", () => {
+  it("returns the UTC hour (0-23) when no timezone is given", () => {
+    expect(getHourForTimestamp(Date.UTC(2026, 2, 14, 0, 30, 0) / 1000)).toBe(0);
+    expect(getHourForTimestamp(Date.UTC(2026, 2, 14, 9, 0, 0) / 1000)).toBe(9);
+    expect(getHourForTimestamp(Date.UTC(2026, 2, 14, 23, 59, 0) / 1000)).toBe(23);
+  });
+
+  it("shifts the hour into the user's timezone — Asia/Tokyo (UTC+9)", () => {
+    // 2026-03-13 23:30 UTC = 2026-03-14 08:30 JST
+    const epoch = Date.UTC(2026, 2, 13, 23, 30, 0) / 1000;
+    expect(getHourForTimestamp(epoch, "Asia/Tokyo")).toBe(8);
+    expect(getHourForTimestamp(epoch, "UTC")).toBe(23);
+  });
+
+  it("shifts the hour for a negative-offset timezone — America/New_York", () => {
+    // 2026-03-14 02:00 UTC = 2026-03-13 22:00 EDT (UTC-4 in March, post spring-forward)
+    const epoch = Date.UTC(2026, 2, 14, 2, 0, 0) / 1000;
+    expect(getHourForTimestamp(epoch, "America/New_York")).toBe(22);
+  });
+
+  it("reflects the local hour right after a DST spring-forward", () => {
+    // 2026-03-08 07:30 UTC. New York springs forward at 02:00->03:00 local;
+    // by 07:30 UTC the offset is -4, so local time is 03:30 -> hour 3.
+    const epoch = Date.UTC(2026, 2, 8, 7, 30, 0) / 1000;
+    expect(getHourForTimestamp(epoch, "America/New_York")).toBe(3);
+  });
+
+  it("falls back to the UTC hour when the timezone is unknown", () => {
+    const epoch = Date.UTC(2026, 2, 14, 15, 0, 0) / 1000;
+    expect(getHourForTimestamp(epoch, "Mars/Olympus")).toBe(15);
   });
 });
 

--- a/tests/integration/insights.test.ts
+++ b/tests/integration/insights.test.ts
@@ -22,7 +22,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await truncate("summaries", "users");
+  await truncate("hourly_summaries", "summaries", "users");
   await env.KV.delete(`apikey:${user.apiKeyHash}`);
 });
 
@@ -57,6 +57,19 @@ async function seedSummary(opts: {
       opts.editor ?? null,
       opts.totalSeconds,
     )
+    .run();
+}
+
+async function seedHourly(opts: {
+  userId: string;
+  date: string;
+  hour: number;
+  totalSeconds: number;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO hourly_summaries (user_id, date, hour, total_seconds) VALUES (?, ?, ?, ?)`,
+  )
+    .bind(opts.userId, opts.date, opts.hour, opts.totalSeconds)
     .run();
 }
 
@@ -193,5 +206,92 @@ describe("GET /insights/days/:range?weekday= (filter)", () => {
     expect(bogus.status).toBe(200);
     expect(filtered.names).toEqual(plain.names);
     expect(bogus.names).toEqual(plain.names);
+  });
+});
+
+describe("GET /insights/hours/:range", () => {
+  type HoursBucket = { hour: number; total_seconds: number; text: string };
+
+  // Two active days: hour 9 spans both, hours 10 and 14 on one day each.
+  async function seedHoursFixture(): Promise<void> {
+    await seedHourly({ userId: user.userId, date: "2026-03-01", hour: 9, totalSeconds: 3600 });
+    await seedHourly({ userId: user.userId, date: "2026-03-01", hour: 10, totalSeconds: 1800 });
+    await seedHourly({ userId: user.userId, date: "2026-03-02", hour: 9, totalSeconds: 1800 });
+    await seedHourly({ userId: user.userId, date: "2026-03-02", hour: 14, totalSeconds: 600 });
+  }
+
+  async function getHours(path: string): Promise<{ status: number; buckets: HoursBucket[] }> {
+    const res = await call(path, { headers: bearer(user.apiKey) });
+    if (res.status !== 200) return { status: res.status, buckets: [] };
+    const { data } = (await res.json()) as { data: { type: string; hours: HoursBucket[] } };
+    return { status: res.status, buckets: data.hours };
+  }
+
+  it("returns a 24-bucket profile of mean coding time per hour", async () => {
+    await seedHoursFixture();
+    const { status, buckets } = await getHours(`${INSIGHTS}/hours/${YEAR}`);
+    expect(status).toBe(200);
+    expect(buckets).toHaveLength(24);
+    expect(buckets.map((b) => b.hour)).toEqual(Array.from({ length: 24 }, (_, i) => i));
+    const byHour = new Map(buckets.map((b) => [b.hour, b.total_seconds]));
+    expect(byHour.get(9)).toBe(2700); // (3600 + 1800) / 2 active days
+    expect(byHour.get(10)).toBe(900); // 1800 / 2
+    expect(byHour.get(14)).toBe(300); // 600 / 2
+    expect(byHour.get(0)).toBe(0);
+  });
+
+  it("the 24 buckets sum to the daily_average for the same range", async () => {
+    await seedHoursFixture();
+    // Same activity expressed as daily summaries: 2026-03-01 = 5400, 2026-03-02 = 2400.
+    await seedSummary({ userId: user.userId, date: "2026-03-01", project: "p", totalSeconds: 5400 });
+    await seedSummary({ userId: user.userId, date: "2026-03-02", project: "p", totalSeconds: 2400 });
+
+    const { buckets } = await getHours(`${INSIGHTS}/hours/${YEAR}`);
+    const sum = buckets.reduce((acc, b) => acc + b.total_seconds, 0);
+
+    const avgRes = await call(`${INSIGHTS}/daily_average/${YEAR}`, { headers: bearer(user.apiKey) });
+    const avg = ((await avgRes.json()) as { data: { daily_average: { seconds: number } } }).data.daily_average.seconds;
+    expect(sum).toBe(avg);
+    expect(sum).toBe(3900);
+  });
+
+  it("returns 24 zero buckets for an empty range", async () => {
+    const { status, buckets } = await getHours(`${INSIGHTS}/hours/2099`);
+    expect(status).toBe(200);
+    expect(buckets).toHaveLength(24);
+    expect(buckets.every((b) => b.total_seconds === 0)).toBe(true);
+  });
+
+  it("accepts year, month, and named ranges", async () => {
+    await seedHoursFixture();
+    expect((await getHours(`${INSIGHTS}/hours/2026-03`)).status).toBe(200);
+    expect((await getHours(`${INSIGHTS}/hours/last_7_days`)).status).toBe(200);
+    expect((await getHours(`${INSIGHTS}/hours/2026-03`)).buckets).toHaveLength(24);
+  });
+
+  it("400s on an invalid range and 401s when unauthenticated", async () => {
+    const bad = await call(`${INSIGHTS}/hours/since_forever`, { headers: bearer(user.apiKey) });
+    expect(bad.status).toBe(400);
+    const unauth = await call(`${INSIGHTS}/hours/${YEAR}`);
+    expect(unauth.status).toBe(401);
+  });
+
+  it("ignores the weekday / timeout / writes_only query params", async () => {
+    await seedHoursFixture();
+    const plain = await getHours(`${INSIGHTS}/hours/${YEAR}`);
+    const withParams = await getHours(`${INSIGHTS}/hours/${YEAR}?weekday=monday&timeout=30&writes_only=true`);
+    expect(withParams.status).toBe(200);
+    expect(withParams.buckets).toEqual(plain.buckets);
+  });
+
+  it("isolates results per user", async () => {
+    await seedHoursFixture();
+    const bob = await seedUser({ username: "bob_hours", email: "bobhours@example.test" });
+    await seedHourly({ userId: bob.userId, date: "2026-03-01", hour: 3, totalSeconds: 9999 });
+
+    const { buckets } = await getHours(`${INSIGHTS}/hours/${YEAR}`);
+    // Bob's hour-3 activity must not leak into Alice's profile.
+    expect(buckets.find((b) => b.hour === 3)?.total_seconds).toBe(0);
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
   });
 });


### PR DESCRIPTION
## Summary

PR2 of 2 for #134 — the implementation, after the spec/design PR #140 merged. Adds the `hours`-of-day insight: a stable 24-bucket profile of mean coding time per hour-of-day, computed in the user's profile timezone, served from a new `hourly_summaries` pre-aggregate.

## Changes
- **`src/db/schema.sql` + `migrations/0003_hourly_summaries.sql`**: add the `hourly_summaries` table (`user_id, date, hour, total_seconds`) + unique index. The `hour` column is constrained to `0...23`.
- **`src/utils/time-format.ts`**: `getHourForTimestamp(epoch, tz) -> 0...23`, mirroring `getDateForTimestamp` (h23 clock, UTC fast path).
- **`src/cron/aggregate.ts`**: in the same `computeDurations` walk, also bucket each duration into `(user, date, hour)` and batch-UPSERT `hourly_summaries` alongside `summaries` in one `db.batch()`, off the same `last_aggregated_at` cursor — no extra heartbeat scan.
- **`src/utils/insights.ts`**: `buildHoursInsight` folds per-`(date,hour)` rows into 24 ascending buckets; each bucket = the hour's summed seconds / distinct active days, so the 24 buckets sum to the `daily_average`. Adds `hours` to `INSIGHT_TYPES` while keeping the summaries-backed `buildInsight()` typed to non-`hours` insight types.
- **`src/routes/insights.ts`**: for `insight_type === "hours"`, read `hourly_summaries` instead of `summaries`; other types unchanged.

## Tests
- `getHourForTimestamp`: UTC, +/- offset zones, DST spring-forward, unknown-tz fallback.
- Cron (`tests/aggregation/hourly-aggregate.test.ts`): hour bucketing in UTC and Asia/Tokyo, sub-timeout vs idle-gap attribution, daily + hourly populated from one pass, cursor advance.
- `buildHoursInsight`: 24-bucket shape, mean math, empty -> 24 zeros, sums-to-`daily_average` invariant.
- Endpoint integration: profile, daily_average equality, empty range -> 24 zeros, year/month/named ranges, 400/401, reserved-params (`weekday`/`timeout`/`writes_only`) ignored, per-user isolation.

## Verification
- `npm run typecheck` — clean.
- `npm test` — 27 files, 308 tests passed.
- `npm run lint:api` — clean.

## Notes
- **Forward-only**: `hourly_summaries` fills going forward from when the table exists; historical backfill is an out-of-scope follow-up (research D-6).
- No OpenAPI/spec/type changes here (those landed in PR #140) — this PR is implementation only.

Implements #134 (after PR #140).
