### PR TITLE
spec: add commit ingestion POST endpoint (PR1/2) #135

### DIFF
--- a/schemas/components/schemas/CommitInput.yaml
+++ b/schemas/components/schemas/CommitInput.yaml
@@ -1,0 +1,34 @@
+type: object
+required:
+  - hash
+properties:
+  hash:
+    type: string
+    minLength: 1
+  message:
+    type: string
+  author_name:
+    type: string
+  author_email:
+    type: string
+    format: email
+  author_date:
+    type: string
+    format: date-time
+  committer_name:
+    type: string
+  committer_email:
+    type: string
+    format: email
+  committer_date:
+    type: string
+    format: date-time
+  total_seconds:
+    type: number
+    format: double
+    minimum: 0
+  ref:
+    type: string
+  url:
+    type: string
+    format: uri

--- a/schemas/paths/commits/commits.yaml
+++ b/schemas/paths/commits/commits.yaml
@@ -10,11 +10,10 @@ get:
     `author_email`) and `branch` (matches the commit `ref`) filter the
     results. `human_readable_total` is derived from `total_seconds`.
 
-    Commits are stored in the `commits` table. This is the read surface only —
-    the ingestion path (a coding-time plugin posting commits, or a git
-    webhook) is a deliberate follow-up decision and is out of scope here, so
-    the list is empty until commits are populated. An invalid `page` returns
-    400.
+    Commits are stored in the `commits` table and populated via the `POST`
+    ingestion endpoint below (a git `post-commit` hook or a webhook adapter
+    posts each commit). The list is empty until commits are ingested. An
+    invalid `page` returns 400.
   parameters:
     - name: project
       in: path
@@ -58,6 +57,55 @@ get:
               total_pages:
                 type: integer
                 minimum: 0
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+post:
+  operationId: createProjectCommit
+  tags:
+    - commits
+  summary: Ingest a commit for a project
+  description: |
+    Records one commit for the authenticated user under `project` (taken from
+    the path; any `project` in the body is ignored). Intended for a git
+    `post-commit` hook or a webhook adapter.
+
+    Idempotent on `(user_id, project, hash)`: re-posting the same `hash`
+    updates the existing row in place (message, author/committer fields,
+    `total_seconds`, `ref`, `url`) rather than creating a duplicate, so hooks
+    can be retried safely. Always returns 201 with the stored `Commit`.
+
+    `hash` is required and must be non-empty. `total_seconds` is the optional
+    client-supplied coding time for the commit (the server does not correlate
+    heartbeats); when present it must be a number >= 0. `author_date` and
+    `committer_date`, when present, must be valid date-times. `ref` is the
+    branch (the read endpoints filter `branch` against it). Validation
+    failures return 400.
+  parameters:
+    - name: project
+      in: path
+      required: true
+      schema:
+        type: string
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/CommitInput.yaml
+  responses:
+    '201':
+      description: Commit ingested
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/Commit.yaml
     '400':
       $ref: ../../components/responses/BadRequest.yaml
     '401':

--- a/specs/135-commits-ingestion/checklists/requirements.md
+++ b/specs/135-commits-ingestion/checklists/requirements.md
@@ -30,4 +30,4 @@ Quality gate for the spec before implementation. Each item is verifiable against
 
 - [x] No schema change; single-row D1 upsert on the existing UNIQUE index (Cloudflare-Native, Simplicity).
 - [x] Generated-types impact assessed (additive `createProjectCommit` + `CommitInput`) in contracts/openapi-diff.md.
-- [x] Original first-party endpoint; no WakaTime source consulted, no provider payload copied (Legal/Trademark).
+- [x] Original first-party endpoint; no third-party source consulted, no provider payload copied (Legal/Trademark).

--- a/specs/135-commits-ingestion/checklists/requirements.md
+++ b/specs/135-commits-ingestion/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Requirements Checklist: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion` | **Spec**: [spec.md](../spec.md)
+
+Quality gate for the spec before implementation. Each item is verifiable against `spec.md`.
+
+## Completeness
+
+- [x] Every functional requirement (FR-001…FR-010) maps to at least one acceptance scenario or success criterion.
+- [x] Ingestion model fixed and justified (dedicated POST; webhook + heartbeat-attach rejected) — research D-1.
+- [x] Idempotency contract fixed: upsert on `(user_id, project, hash)`, always 201 — FR-002, research D-2.
+- [x] `total_seconds` semantics fixed: client-supplied, optional, `>= 0`, not server-computed — FR-004, research D-3.
+- [x] Date validation/normalization specified — FR-005, research D-4.
+- [x] Request-body fields enumerated (`CommitInput`); `project` sourced from path — FR-008, data-model.
+
+## Consistency
+
+- [x] Response is the existing `Commit` shape via the read-path shaping — FR-006, data-model.
+- [x] Idempotent-POST + 201 mirrors the `createExternalDuration` convention — research D-2.
+- [x] Read endpoints (#107) unchanged; ingested rows flow through their ordering/filters — FR-009.
+- [x] Out-of-scope items named: server-side timing, webhooks, bulk, aggregate writes (research D-3/D-1/D-6, FR-010).
+
+## Testability
+
+- [x] Each user story has an Independent Test.
+- [x] Success criteria are measurable (SC-001…SC-005).
+- [x] Quickstart scenarios A–H cover create, read-back, idempotency, omitted time, 400s, 401, path-project, isolation.
+
+## Compliance
+
+- [x] No schema change; single-row D1 upsert on the existing UNIQUE index (Cloudflare-Native, Simplicity).
+- [x] Generated-types impact assessed (additive `createProjectCommit` + `CommitInput`) in contracts/openapi-diff.md.
+- [x] Original first-party endpoint; no WakaTime source consulted, no provider payload copied (Legal/Trademark).

--- a/specs/135-commits-ingestion/contracts/openapi-diff.md
+++ b/specs/135-commits-ingestion/contracts/openapi-diff.md
@@ -1,0 +1,75 @@
+# OpenAPI Contract Diff: Commit ingestion
+
+**Branch**: `135-commits-ingestion`
+**Files**: `schemas/paths/commits/commits.yaml` (path item gains `post`), `schemas/components/schemas/CommitInput.yaml` (new)
+
+This PR1 change is **additive**: a new `post` operation on an existing path and a new request-body schema. `npm run generate` adds `operations["createProjectCommit"]`, a `CommitInput` schema, and flips the commits path item's `post?` from `never` to the operation. No existing operation or schema changes (apart from the read-op description prose).
+
+## 1. New request schema `CommitInput.yaml`
+
+```yaml
+type: object
+required:
+  - hash
+properties:
+  hash:           { type: string, minLength: 1 }
+  message:        { type: string }
+  author_name:    { type: string }
+  author_email:   { type: string, format: email }
+  author_date:    { type: string, format: date-time }
+  committer_name: { type: string }
+  committer_email:{ type: string, format: email }
+  committer_date: { type: string, format: date-time }
+  total_seconds:  { type: number, format: double, minimum: 0 }
+  ref:            { type: string }
+  url:            { type: string, format: uri }
+```
+
+(`project` is intentionally **not** a body field — it comes from the path.)
+
+## 2. `commits.yaml` — add the `post` operation
+
+```yaml
+post:
+  operationId: createProjectCommit
+  tags: [commits]
+  summary: Ingest a commit for a project
+  description: |
+    … idempotent on (user_id, project, hash); always 201; project from path;
+    total_seconds client-supplied; dates validated; 400 on bad input …
+  parameters:
+    - name: project
+      in: path
+      required: true
+      schema: { type: string }
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/CommitInput.yaml
+  responses:
+    '201':
+      description: Commit ingested
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data]
+            properties:
+              data:
+                $ref: ../../components/schemas/Commit.yaml
+    '400': { $ref: ../../components/responses/BadRequest.yaml }
+    '401': { $ref: ../../components/responses/Unauthorized.yaml }
+```
+
+## 3. Read-op (`get`) description — note ingestion now exists
+
+**Before**: "the ingestion path … is a deliberate follow-up decision and is out of scope here, so the list is empty until commits are populated."
+
+**After**: "populated via the `POST` ingestion endpoint below (a git `post-commit` hook or a webhook adapter posts each commit). The list is empty until commits are ingested."
+
+## Generated types impact
+
+- `src/types/generated.ts`: `paths[".../commits"].post` becomes `operations["createProjectCommit"]`; new `components["schemas"]["CommitInput"]`; new `operations["createProjectCommit"]` with the `application/json` request body and the `201 { data: Commit }` response. No existing member changes.
+- Verified by `npm run generate` + reviewing the `git diff` of `src/types/generated.ts` (additive only).

--- a/specs/135-commits-ingestion/data-model.md
+++ b/specs/135-commits-ingestion/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion` | **Date**: 2026-06-05
+
+## Storage
+
+**No schema change.** The `commits` table and its uniqueness constraint already exist (`src/db/schema.sql`):
+
+```sql
+CREATE TABLE IF NOT EXISTS commits (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  project TEXT NOT NULL,
+  hash TEXT NOT NULL,
+  message TEXT,
+  author_name TEXT,
+  author_email TEXT,
+  author_date TEXT,
+  committer_name TEXT,
+  committer_email TEXT,
+  committer_date TEXT,
+  total_seconds REAL,
+  ref TEXT,
+  url TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, project, hash)
+);
+```
+
+The `UNIQUE(user_id, project, hash)` constraint backs the idempotent upsert.
+
+## Request → row mapping (PR2)
+
+| Body field (`CommitInput`) | Column | Notes |
+|---|---|---|
+| — (path) | `project` | from the URL path, not the body (FR-008) |
+| — (auth) | `user_id` | authenticated user |
+| — (server) | `id` | `crypto.randomUUID()` on insert; unchanged on update |
+| `hash` (required, non-empty) | `hash` | part of the dedup key |
+| `message` | `message` | stored as given |
+| `author_name` / `author_email` | `author_name` / `author_email` | |
+| `author_date` (valid date-time if present) | `author_date` | `normalizeDateTime`; null if omitted |
+| `committer_name` / `committer_email` | `committer_name` / `committer_email` | |
+| `committer_date` (valid date-time if present) | `committer_date` | `normalizeDateTime`; null if omitted |
+| `total_seconds` (number `>= 0` if present) | `total_seconds` | client-supplied; null if omitted |
+| `ref` | `ref` | branch; read path filters `branch` against it |
+| `url` | `url` | stored as given |
+
+## Write path (PR2)
+
+```sql
+INSERT INTO commits
+  (id, user_id, project, hash, message, author_name, author_email, author_date,
+   committer_name, committer_email, committer_date, total_seconds, ref, url)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (user_id, project, hash) DO UPDATE SET
+  message          = excluded.message,
+  author_name      = excluded.author_name,
+  author_email     = excluded.author_email,
+  author_date      = excluded.author_date,
+  committer_name   = excluded.committer_name,
+  committer_email  = excluded.committer_email,
+  committer_date   = excluded.committer_date,
+  total_seconds    = excluded.total_seconds,
+  ref              = excluded.ref,
+  url              = excluded.url
+```
+
+`created_at` and `id` are preserved on update (only the row's mutable fields change). The handler then reads the stored row (or uses `RETURNING`) and shapes it through the existing `rowToCommit` for the `201` `{ data: Commit }` response — identical to the read endpoints.
+
+## Read path (unchanged, #107)
+
+`GET .../commits` (paginated, `author`/`branch` filters) and `GET .../commits/{hash}` already shape `commits` rows via `rowToCommit`, defaulting a missing `author_date` to `created_at`. Ingested rows flow through unchanged (FR-009).
+
+## Untouched
+
+Ingestion writes only `commits`. It does **not** modify `summaries`, `hourly_summaries`, or `user_projects` (FR-010) — commits are an independent series.

--- a/specs/135-commits-ingestion/plan.md
+++ b/specs/135-commits-ingestion/plan.md
@@ -27,7 +27,7 @@ Add a dedicated authenticated `POST /users/current/projects/{project}/commits` t
 | I. SDD | PASS | OpenAPI operation + request schema land first (PR1); handler follows in PR2. Types regenerated, never hand-edited. |
 | II. Cloudflare-Native | PASS | Single-row D1 upsert keyed on the existing UNIQUE index; no scan, no extra binding. Fast handler, nothing offloaded to cron. |
 | III. Type Safety | PASS | Handler uses `components["schemas"]["CommitInput"]` / `["Commit"]` from generated types. |
-| IV. Legal/Trademark | PASS | Original first-party endpoint; no WakaTime source consulted, no provider-specific payload copied. |
+| IV. Legal/Trademark | PASS | Original first-party endpoint; no third-party source consulted, no provider-specific payload copied. |
 | V. Simplicity First | PASS | One operation, one new request schema, no schema change, no heartbeat correlation. Single commit per request; bulk and server-side timing deferred. |
 
 ## Project Structure

--- a/specs/135-commits-ingestion/plan.md
+++ b/specs/135-commits-ingestion/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion` | **Date**: 2026-06-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/135-commits-ingestion/spec.md`
+
+## Summary
+
+Add a dedicated authenticated `POST /users/current/projects/{project}/commits` that ingests one commit, idempotent on `(user_id, project, hash)`, returning 201 with the stored `Commit`. `total_seconds` is client-supplied (the server does not correlate heartbeats). No schema change — the `commits` table and its `(user_id, project, hash)` UNIQUE index already exist.
+
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI (`createProjectCommit` operation + new `CommitInput` request schema, plus the read-op description note) + regenerated types. **No route/business logic.**
+
+**PR2 (after PR1 merges)**: the `POST` handler (validate → upsert → return `Commit`) + integration tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7; zod (already a dependency) for body validation
+**Storage**: D1 `commits` (existing) — write via `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE`
+**Testing**: Vitest + workers pool — integration tests for create, idempotent re-post, validation 400s, 401, read-back, cross-user isolation
+**Performance Goals**: <10ms CPU — a single-row upsert, no scan
+**Constraints**: reuse the existing `commits` table & read-path `rowToCommit` shaping; mirror the external-durations idempotent-POST convention
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI operation + request schema land first (PR1); handler follows in PR2. Types regenerated, never hand-edited. |
+| II. Cloudflare-Native | PASS | Single-row D1 upsert keyed on the existing UNIQUE index; no scan, no extra binding. Fast handler, nothing offloaded to cron. |
+| III. Type Safety | PASS | Handler uses `components["schemas"]["CommitInput"]` / `["Commit"]` from generated types. |
+| IV. Legal/Trademark | PASS | Original first-party endpoint; no WakaTime source consulted, no provider-specific payload copied. |
+| V. Simplicity First | PASS | One operation, one new request schema, no schema change, no heartbeat correlation. Single commit per request; bulk and server-side timing deferred. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/135-commits-ingestion/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/paths/commits/commits.yaml          # CHANGE: add `post` (createProjectCommit); note ingestion in the get description
+schemas/components/schemas/CommitInput.yaml # NEW: request body schema
+src/types/generated.ts                      # REGENERATED (npm run generate)
+
+# PR2 (after PR1 merges)
+src/routes/commits.ts                       # CHANGE: add the POST handler (validate + upsert + return Commit); update file header
+```
+
+**Structure Decision**: Keep the handler thin. Validate the body with zod (`hash` non-empty; `total_seconds` a number `>= 0` if present; `author_date`/`committer_date` valid date-times if present), normalize dates with the existing `normalizeDateTime`, then a single `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE SET …` and re-shape the stored row through the existing `rowToCommit` for the 201 response. `project` is read from the path; auth is the existing `authMiddleware`. No new table, no aggregate writes.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add the `post` operation + `CommitInput`; note ingestion in the read-op prose; `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: POST handler + validation + upsert + integration tests; `npm test` green; open PR referencing #135 and PR1.
+
+## Risks & Mitigations
+
+- **Duplicate rows from retries** → idempotent upsert on the existing `(user_id, project, hash)` UNIQUE index (FR-002); integration test posts the same hash twice and asserts a single row.
+- **Schema-invalid dates breaking the read path** → validate `author_date`/`committer_date` on ingest and normalize; missing `author_date` falls back to `created_at` in the read path (the #128 fix). (research D-4)
+- **Scope creep into server-side timing / webhooks / bulk** → explicitly out of scope; documented in research D-3 and tasks "Out of scope".
+- **Type drift** → request/response types are generated from `CommitInput`/`Commit`; the generate diff is reviewed to confirm only the additive operation + schema.

--- a/specs/135-commits-ingestion/quickstart.md
+++ b/specs/135-commits-ingestion/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion`
+
+Manual verification scenarios (run against a worker). These map directly to the PR2 integration tests. Auth via API key (Bearer). Project comes from the path; base path:
+
+```
+/api/v1/users/current/projects/cloudtime/commits
+```
+
+## A. Ingest a commit
+
+```
+POST .../projects/cloudtime/commits
+Authorization: Bearer <api_key>
+{
+  "hash": "a1b2c3",
+  "message": "fix: handle empty range",
+  "author_name": "Nao",
+  "author_email": "nao@example.com",
+  "author_date": "2026-06-05T01:00:00Z",
+  "ref": "main",
+  "total_seconds": 1800,
+  "url": "https://github.com/org/cloudtime/commit/a1b2c3"
+}
+```
+Expect `201` with `{data:{hash:"a1b2c3", message:"fix: handle empty range", total_seconds:1800, human_readable_total:"30 mins", ref:"main", ...}}`.
+
+## B. Read it back
+
+```
+GET .../projects/cloudtime/commits
+GET .../projects/cloudtime/commits/a1b2c3
+```
+Expect the list to include `a1b2c3` and the single GET to return it. `GET ...?branch=main` returns it; `?branch=dev` → 404.
+
+## C. Idempotent re-post
+
+```
+POST .../projects/cloudtime/commits
+{ "hash": "a1b2c3", "message": "fix: handle empty range (amended)", "total_seconds": 2400 }
+```
+Expect `201`. Then `GET .../commits` shows **one** `a1b2c3`, now with the amended message and `total_seconds:2400` (no duplicate).
+
+## D. Omitted total_seconds
+
+```
+POST .../projects/cloudtime/commits
+{ "hash": "d4e5f6", "message": "docs", "author_date": "2026-06-05T02:00:00Z" }
+```
+Expect `201`; read-back `human_readable_total` is `"0 secs"` and `total_seconds` is absent.
+
+## E. Validation → 400
+
+```
+POST .../commits  { "message": "no hash" }                 -> 400 (missing hash)
+POST .../commits  { "hash": "" }                           -> 400 (blank hash)
+POST .../commits  { "hash": "x", "total_seconds": -5 }     -> 400 (negative)
+POST .../commits  { "hash": "x", "author_date": "nope" }   -> 400 (bad date)
+```
+Each returns 400 and stores nothing.
+
+## F. Unauthenticated → 401
+
+```
+POST .../projects/cloudtime/commits   (no/invalid Bearer)
+```
+Expect `401` (checked before body validation).
+
+## G. Project from path
+
+```
+POST .../projects/cloudtime/commits  { "hash": "p1", "project": "other" }
+```
+Expect the commit stored under `cloudtime` (path), not `other`; `GET .../projects/other/commits` does not list it.
+
+## H. Cross-user isolation
+
+A commit posted by user A under `cloudtime` is not returned by user B's `GET .../projects/cloudtime/commits`.

--- a/specs/135-commits-ingestion/research.md
+++ b/specs/135-commits-ingestion/research.md
@@ -1,0 +1,55 @@
+# Research & Decisions: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion` | **Date**: 2026-06-05
+
+Documented decisions that shape the contract. Each records the choice, the alternatives, and why.
+
+## D-1: Ingestion model — a dedicated authenticated POST
+
+**Decision**: Ingest via `POST /users/current/projects/{project}/commits` with the user's API key. A git `post-commit` hook, a CI step, or a webhook→HTTP adapter is the caller.
+
+**Why**: A commit's identity (`hash`) only comes into existence at `git commit` time, not during the high-frequency heartbeat stream, so attaching commit context to heartbeats is both awkward (the hash is unknown while coding) and wasteful (metadata on every few-second beat). A first-party POST is the smallest correct contract and is provider-agnostic: it does not couple CloudTime to any git host's payload format or signature scheme.
+
+**Alternatives rejected**:
+- *Git-host webhook receiver* (`POST /webhooks/git/{provider}`): requires per-user webhook secrets, repo→project mapping, and provider-specific payload parsing/verification — a heavier integration that can sit *in front of* this endpoint later as an adapter.
+- *Commit context on heartbeats*: hash unknown at heartbeat time; pollutes the hot path; deriving commits from beats is unreliable.
+
+(Chosen interactively with the maintainer before authoring this spec.)
+
+## D-2: Idempotent upsert, always 201
+
+**Decision**: `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE SET <mutable fields>`. Re-posting the same hash updates in place. The endpoint always returns `201`.
+
+**Why**: Hooks and webhooks retry; the `commits` table already has a `(user_id, project, hash)` UNIQUE index, so the upsert is natural and duplicate-free. Returning 201 on both insert and update mirrors the existing `createExternalDuration` convention ("re-sending … updates the existing row in place" → 201), keeping the API internally consistent. Distinguishing 200-on-update would add a pre-SELECT for no client benefit.
+
+**Alternatives rejected**: 200-on-update / 201-on-create split — needs an existence probe and complicates the contract; reject-on-duplicate (409) — hostile to safe retries.
+
+## D-3: `total_seconds` is client-supplied; no server-side correlation
+
+**Decision**: Accept an optional `total_seconds` (number `>= 0`) and store it verbatim (nullable). The server does **not** compute coding time by correlating heartbeats around the commit.
+
+**Why**: Keeps ingestion a thin, fast, single-row write. Heartbeat↔commit correlation (which window, which branch, session boundaries) is a meaningfully harder design with its own edge cases and belongs in a separate issue. A client that knows the commit's coding time (e.g. a plugin) can still supply it; one that doesn't simply omits it (read path renders `"0 secs"`).
+
+**Alternatives rejected**: server computes `total_seconds` from heartbeats — heavier, deferred; require `total_seconds` — many callers (a bare git hook) have no coding-time figure.
+
+## D-4: Date handling mirrors the read-path contract
+
+**Decision**: `author_date` / `committer_date` are optional; when present they must parse as valid date-times (else 400) and are stored via the existing `normalizeDateTime`. A missing `author_date` is allowed (stored null).
+
+**Why**: The `Commit` response requires `author_date`; the read path already defaults a missing one to `created_at` (the #128 fix) and normalizes formats. Validating on ingest stops schema-invalid dates from ever entering the table, keeping the read endpoints contract-clean without a second guard.
+
+**Alternatives rejected**: store raw strings unchecked — risks the read path emitting a non-`date-time` value; require `author_date` — over-constrains simple hooks.
+
+## D-5: Minimal validation surface; `project` from the path
+
+**Decision**: Enforce only what protects the read contract: `hash` non-empty, `total_seconds` numeric `>= 0` if present, dates valid if present. `project` comes from the path; a body `project` is ignored. `message`, `ref`, `url` are stored as given.
+
+**Why**: Simplicity. The path already scopes the project (consistent with the read endpoints); echoing/validating a body project invites mismatch bugs. `ref` is the branch the read endpoints filter on, stored verbatim. `url` is advisory (OpenAPI `format: uri`) and not hard-rejected at the route to avoid over-strict failures on valid-but-unusual URLs.
+
+## D-6: Single commit per request; bulk deferred
+
+**Decision**: One commit per POST. Multi-commit (git push event) bulk ingestion is a future addition.
+
+**Why**: Mirrors `createExternalDuration` (single) vs the separate `*-bulk` endpoints; keeps this PR focused. A webhook adapter can fan a push event into N single POSTs, or a future `commits/bulk` can batch them (like `heartbeats/bulk`).
+
+**Alternatives rejected**: accept an array now — broadens the contract and the validation/partial-failure surface beyond this issue's need.

--- a/specs/135-commits-ingestion/spec.md
+++ b/specs/135-commits-ingestion/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Commit ingestion (write path)
+
+**Feature Branch**: `135-commits-ingestion`
+**Created**: 2026-06-05
+**Status**: Draft
+**Input**: Commit **read** endpoints exist (`GET /users/current/projects/{project}/commits[/{hash}]`, #107), but there is no way to populate the `commits` table — ingestion was explicitly deferred. Issue #135.
+
+## Background
+
+CloudTime stores per-commit coding-time rows in the `commits` table and exposes them read-only. Until now the table could only be seeded out of band (tests insert rows directly). This feature adds a **first-party ingestion endpoint** so a git `post-commit` hook or a webhook adapter can record commits.
+
+The ingestion model was chosen in design (research D-1): a **dedicated authenticated `POST`**, not a git-host webhook receiver and not commit context piggybacked on heartbeats. A commit's identity (hash) only exists at `git commit` time — not during the high-frequency heartbeat stream — so a small dedicated endpoint is the simplest correct contract and stays provider-agnostic. Any caller (a local hook, a CI step, or a webhook→HTTP adapter) posts a commit with an API key.
+
+Per-commit coding time (`total_seconds`) is **client-supplied** and optional (research D-3); the server does not correlate heartbeats to compute it here. Server-side time attribution is a separable concern (out of scope, see below).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Record a commit and read it back (Priority: P1)
+
+As an authenticated user (via a git hook), I want to post a commit so it appears in my project's commit list with its coding time.
+
+**Why this priority**: This is the feature — without it the read endpoints have no data path.
+
+**Independent Test**: `POST /users/current/projects/cloudtime/commits` with `{hash, message, author_*, ref, total_seconds}` returns 201 with `{data: Commit}`; a subsequent `GET .../commits` includes that commit, and `GET .../commits/{hash}` returns it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid body with `hash`, **When** posting to a project, **Then** 201 with `{data: Commit}` in the same shape the read endpoints return, and the commit is stored under the authenticated `user_id` and the path `project`.
+2. **Given** a posted commit, **When** listing the project's commits, **Then** it appears (newest-first by `author_date`), and a single-hash GET returns it.
+3. **Given** `total_seconds` in the body, **When** read back, **Then** `total_seconds` round-trips and `human_readable_total` is derived from it; **given** `total_seconds` omitted, **then** it is stored null and `human_readable_total` is `"0 secs"`.
+
+---
+
+### User Story 2 - Re-posting the same commit is idempotent (Priority: P1)
+
+As a hook author whose delivery may retry, I want re-posting the same commit to update the row in place, not duplicate it.
+
+**Why this priority**: Hooks/webhooks retry; duplicates would corrupt counts and lists.
+
+**Independent Test**: Post `hash=abc` twice (second with a changed `message` / `total_seconds`); `GET .../commits` shows exactly one `abc` with the updated fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** a commit already stored for `(user, project, hash)`, **When** posting the same `hash` again, **Then** no duplicate row is created (dedup on `(user_id, project, hash)`).
+2. **Given** the re-post carries changed mutable fields (`message`, author/committer, `total_seconds`, `ref`, `url`), **When** read back, **Then** the stored row reflects the new values.
+3. **Given** either post, **Then** the response status is 201 (the upsert is treated as an accepted write, mirroring the external-durations convention).
+
+---
+
+### User Story 3 - Malformed input is rejected (Priority: P2)
+
+As a client author, I want clear 400s for bad input so I can fix my request.
+
+**Why this priority**: Prevents silently storing junk that breaks the read-path contract.
+
+**Independent Test**: Posting without `hash`, with a blank `hash`, with a negative `total_seconds`, or with an unparseable `author_date` each returns 400.
+
+**Acceptance Scenarios**:
+
+1. **Given** a body missing `hash` or with an empty `hash`, **When** posted, **Then** 400.
+2. **Given** `total_seconds` present but not a number `>= 0`, **When** posted, **Then** 400.
+3. **Given** `author_date` or `committer_date` present but not a valid date-time, **When** posted, **Then** 400.
+4. **Given** no/invalid credentials, **When** posted, **Then** 401 (auth checked before body validation).
+
+### Edge Cases
+
+- **Project from path**: the stored `project` is always the path segment; a `project` field in the body (if any) is ignored.
+- **Missing `author_date`**: allowed; stored null. The read path already renders a valid `author_date` by falling back to `created_at` (the #128 read-path fix), so the response stays schema-valid.
+- **`ref` vs branch**: `ref` is the branch name; the read endpoints' `branch` filter matches against it. Omitted `ref` stores null.
+- **Long `message` / unusual `hash`**: stored as given; only non-emptiness of `hash` is enforced.
+- **Single commit per request**: this endpoint ingests one commit; multi-commit (push-event) bulk ingestion is a future addition (out of scope).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose `POST /users/current/projects/{project}/commits` that records a commit for the authenticated user under the path `project`.
+- **FR-002**: The write MUST be idempotent on `(user_id, project, hash)` — re-posting the same `hash` updates the existing row's mutable fields (`message`, `author_name`/`author_email`/`author_date`, `committer_*`, `total_seconds`, `ref`, `url`) in place rather than inserting a duplicate.
+- **FR-003**: `hash` MUST be required and non-empty; otherwise 400.
+- **FR-004**: `total_seconds` MUST be optional; when present it MUST be a number `>= 0` (else 400) and is stored as-is. The server MUST NOT compute it from heartbeats.
+- **FR-005**: `author_date` and `committer_date` MUST be optional; when present they MUST be valid date-times (else 400) and are stored normalized so the read path renders them schema-valid.
+- **FR-006**: On success the system MUST return `201` with `{ data: Commit }` in the same `Commit` shape as the read endpoints.
+- **FR-007**: The endpoint MUST require authentication (Bearer API key); an unauthenticated request returns 401, checked before body validation.
+- **FR-008**: The stored `project` MUST come from the path; any `project` in the body MUST be ignored.
+- **FR-009**: An ingested commit MUST be immediately retrievable via the existing read endpoints (list + single), honoring their ordering and `author`/`branch` filters.
+- **FR-010**: Ingestion MUST NOT alter unrelated aggregates (`summaries`, `hourly_summaries`, `user_projects`) — commits are an independent series.
+
+### Key Entities
+
+- **`commits`** (existing table, no schema change): `(user_id, project, hash)` is already `UNIQUE`, which backs the idempotent upsert. Columns `message, author_name, author_email, author_date, committer_name, committer_email, committer_date, total_seconds, ref, url` are populated from the body.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After a `POST`, the commit is returned by `GET .../commits` and `GET .../commits/{hash}` for the same user/project.
+- **SC-002**: Posting the same `hash` N times yields exactly one stored row, reflecting the latest mutable-field values.
+- **SC-003**: Every malformed input (missing/blank `hash`, negative/non-numeric `total_seconds`, unparseable date) returns 400 and stores nothing.
+- **SC-004**: A commit posted by user A is never visible to user B (cross-user isolation preserved).
+- **SC-005**: A supplied `total_seconds` surfaces in `human_readable_total`; an omitted one yields `"0 secs"`.

--- a/specs/135-commits-ingestion/tasks.md
+++ b/specs/135-commits-ingestion/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Commit ingestion (write path)
+
+**Branch**: `135-commits-ingestion`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Generated**: 2026-06-05 · **Issue**: #135
+
+## PR1 — Spec + Design
+
+- [x] **T-001**: Author `spec.md` (US1 create+read, US2 idempotent, US3 validation; FR-001..FR-010; edge cases; SC-001..SC-005).
+- [x] **T-002**: Author `plan.md` (Constitution Check; thin upsert handler; no schema change).
+- [x] **T-003**: Author `research.md` (D-1 dedicated POST, D-2 idempotent/201, D-3 client-supplied total_seconds, D-4 date handling, D-5 minimal validation/path project, D-6 single-vs-bulk).
+- [x] **T-004**: Author `data-model.md` (no schema change; request→row mapping; upsert SQL; untouched aggregates).
+- [x] **T-005**: Author `quickstart.md` (scenarios A–H).
+- [x] **T-006**: Author `contracts/openapi-diff.md` (additive `post` + `CommitInput`).
+- [x] **T-007**: Author `checklists/requirements.md`.
+- [x] **T-008**: Add `schemas/components/schemas/CommitInput.yaml`.
+- [x] **T-009**: Update `schemas/paths/commits/commits.yaml` — add the `post` (`createProjectCommit`) operation; note ingestion in the `get` description.
+- [x] **T-010**: Run `npm run generate` (expect additive `createProjectCommit` + `CommitInput` in `src/types/generated.ts`); run `npm run typecheck`.
+- [ ] **T-011**: Commit PR1 in SDD order (spec/schemas, then regenerated types), push, open PR against `develop` referencing #135.
+
+## PR2 — Implementation (after PR1 merges)
+
+- [ ] **T-101**: `src/routes/commits.ts` — add the `POST /projects/:project/commits` handler under `authMiddleware`: zod-validate `CommitInput` (`hash` non-empty; `total_seconds` number `>= 0` if present; `author_date`/`committer_date` valid date-times if present), normalize dates, `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE`, shape via `rowToCommit`, return `201 { data: Commit }`. Update the file header (ingestion no longer deferred).
+- [ ] **T-102**: Integration tests `tests/integration/commits.test.ts` (extend) — quickstart A–H: create + read-back, idempotent re-post (single row, updated fields), omitted total_seconds → "0 secs", validation 400s (missing/blank hash, negative total_seconds, bad date), 401, project-from-path, cross-user isolation.
+- [ ] **T-103**: `npm run typecheck` — zero errors.
+- [ ] **T-104**: `npm test` — full suite green incl. new ingestion tests.
+- [ ] **T-105**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #135.
+
+## Dependencies
+
+```
+T-001 .. T-010 → T-011                  (PR1)
+T-011 → T-101 .. T-105                   (PR2 after PR1 merge)
+T-101 → T-102 → T-103 → T-104 → T-105
+```
+
+## Out of scope
+
+- Server-side `total_seconds` correlation from heartbeats (research D-3) — separate issue.
+- Git-host webhook receiver / signature verification (research D-1) — can sit in front as an adapter later.
+- Multi-commit / push-event bulk ingestion (research D-6) — future `commits/bulk`, mirroring `heartbeats/bulk`.
+- Any change to `summaries` / `hourly_summaries` / `user_projects` or the read endpoints' contract.

--- a/specs/135-commits-ingestion/tasks.md
+++ b/specs/135-commits-ingestion/tasks.md
@@ -16,7 +16,7 @@
 - [x] **T-008**: Add `schemas/components/schemas/CommitInput.yaml`.
 - [x] **T-009**: Update `schemas/paths/commits/commits.yaml` — add the `post` (`createProjectCommit`) operation; note ingestion in the `get` description.
 - [x] **T-010**: Run `npm run generate` (expect additive `createProjectCommit` + `CommitInput` in `src/types/generated.ts`); run `npm run typecheck`.
-- [ ] **T-011**: Commit PR1 in SDD order (spec/schemas, then regenerated types), push, open PR against `develop` referencing #135.
+- [x] **T-011**: Commit PR1 in SDD order (spec/schemas, then regenerated types), push, open PR against `develop` referencing #135.
 
 ## PR2 — Implementation (after PR1 merges)
 

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -996,15 +996,32 @@ export interface paths {
          *     `author_email`) and `branch` (matches the commit `ref`) filter the
          *     results. `human_readable_total` is derived from `total_seconds`.
          *
-         *     Commits are stored in the `commits` table. This is the read surface only —
-         *     the ingestion path (a coding-time plugin posting commits, or a git
-         *     webhook) is a deliberate follow-up decision and is out of scope here, so
-         *     the list is empty until commits are populated. An invalid `page` returns
-         *     400.
+         *     Commits are stored in the `commits` table and populated via the `POST`
+         *     ingestion endpoint below (a git `post-commit` hook or a webhook adapter
+         *     posts each commit). The list is empty until commits are ingested. An
+         *     invalid `page` returns 400.
          */
         get: operations["getProjectCommits"];
         put?: never;
-        post?: never;
+        /**
+         * Ingest a commit for a project
+         * @description Records one commit for the authenticated user under `project` (taken from
+         *     the path; any `project` in the body is ignored). Intended for a git
+         *     `post-commit` hook or a webhook adapter.
+         *
+         *     Idempotent on `(user_id, project, hash)`: re-posting the same `hash`
+         *     updates the existing row in place (message, author/committer fields,
+         *     `total_seconds`, `ref`, `url`) rather than creating a duplicate, so hooks
+         *     can be retried safely. Always returns 201 with the stored `Commit`.
+         *
+         *     `hash` is required and must be non-empty. `total_seconds` is the optional
+         *     client-supplied coding time for the commit (the server does not correlate
+         *     heartbeats); when present it must be a number >= 0. `author_date` and
+         *     `committer_date`, when present, must be valid date-times. `ref` is the
+         *     branch (the read endpoints filter `branch` against it). Validation
+         *     failures return 400.
+         */
+        post: operations["createProjectCommit"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1820,6 +1837,25 @@ export interface components {
             /** Format: uri */
             url?: string;
             ref?: string;
+        };
+        CommitInput: {
+            hash: string;
+            message?: string;
+            author_name?: string;
+            /** Format: email */
+            author_email?: string;
+            /** Format: date-time */
+            author_date?: string;
+            committer_name?: string;
+            /** Format: email */
+            committer_email?: string;
+            /** Format: date-time */
+            committer_date?: string;
+            /** Format: double */
+            total_seconds?: number;
+            ref?: string;
+            /** Format: uri */
+            url?: string;
         };
         Organization: {
             id: string;
@@ -3409,6 +3445,36 @@ export interface operations {
                         data: components["schemas"]["Commit"][];
                         page: number;
                         total_pages: number;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    createProjectCommit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CommitInput"];
+            };
+        };
+        responses: {
+            /** @description Commit ingested */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["Commit"];
                     };
                 };
             };


### PR DESCRIPTION
## Summary

PR1 of 2 for #135 — **spec + design only, no route/business logic** (SpecKit 2-PR workflow). Adds the write path for commits: a dedicated authenticated `POST /users/current/projects/{project}/commits`.

**Ingestion model and `total_seconds` handling were chosen interactively with the maintainer** before authoring (research D-1, D-3):
- **Dedicated authenticated POST** (not a git-host webhook receiver, not heartbeat-attached commit context) — a commit''s `hash` only exists at commit time; a first-party endpoint is the smallest correct, provider-agnostic contract. A git `post-commit` hook or a webhook→HTTP adapter is the caller.
- **`total_seconds` is client-supplied** (optional, `>= 0`) — the server does not correlate heartbeats. Server-side timing is a separate, out-of-scope concern.

### What lands here
- **OpenAPI**: `createProjectCommit` operation added to `schemas/paths/commits/commits.yaml` + new `schemas/components/schemas/CommitInput.yaml`; read-op description updated (ingestion no longer deferred).
- **Contract**: idempotent on `(user_id, project, hash)` — re-posting the same hash updates in place, always returns `201 { data: Commit }` (mirrors `createExternalDuration`). `project` comes from the path; `hash` required non-empty; dates validated; 400 on bad input; 401 unauth.
- **No schema change** — the `commits` table''s `UNIQUE(user_id, project, hash)` already backs the upsert.
- **Generated types**: `npm run generate` — additive `createProjectCommit` + `CommitInput` only.
- **SpecKit artifacts**: `specs/135-commits-ingestion/` (spec, plan, research, data-model, quickstart, tasks, contracts, checklist).

### Verification
- `npm run lint:api` — valid.
- `npm run generate` — additive diff only.
- `npm run typecheck` — clean.

### Out of scope (→ PR2 / follow-ups)
PR2: the POST handler (validate → upsert → return `Commit`) + integration tests. Follow-ups: server-side `total_seconds` correlation, git-host webhook adapter, multi-commit bulk ingestion.

Tracks #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)