### PR TITLE
feat: implement commit ingestion endpoint (PR2/2) #135

### DIFF
--- a/specs/135-commits-ingestion/tasks.md
+++ b/specs/135-commits-ingestion/tasks.md
@@ -25,7 +25,7 @@
 - [x] **T-102b**: Integration tests `tests/integration/commits.test.ts` (extend) — create + read-back, idempotent re-post (single row, updated fields), omitted total_seconds → "0 secs", validation 400s, 401, project-from-path, cross-user isolation.
 - [x] **T-103**: `npm run typecheck` — zero errors.
 - [x] **T-104**: `npm test` — full suite green (323 tests) incl. new unit + integration.
-- [ ] **T-105**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #135.
+- [x] **T-105**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #135.
 
 ## Dependencies
 

--- a/specs/135-commits-ingestion/tasks.md
+++ b/specs/135-commits-ingestion/tasks.md
@@ -20,10 +20,11 @@
 
 ## PR2 — Implementation (after PR1 merges)
 
-- [ ] **T-101**: `src/routes/commits.ts` — add the `POST /projects/:project/commits` handler under `authMiddleware`: zod-validate `CommitInput` (`hash` non-empty; `total_seconds` number `>= 0` if present; `author_date`/`committer_date` valid date-times if present), normalize dates, `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE`, shape via `rowToCommit`, return `201 { data: Commit }`. Update the file header (ingestion no longer deferred).
-- [ ] **T-102**: Integration tests `tests/integration/commits.test.ts` (extend) — quickstart A–H: create + read-back, idempotent re-post (single row, updated fields), omitted total_seconds → "0 secs", validation 400s (missing/blank hash, negative total_seconds, bad date), 401, project-from-path, cross-user isolation.
-- [ ] **T-103**: `npm run typecheck` — zero errors.
-- [ ] **T-104**: `npm test` — full suite green incl. new ingestion tests.
+- [x] **T-101**: `src/utils/commit-input.ts` (new) — `validateCommitInput` (manual validation, mirroring `external-duration-input`): `hash` non-empty; `total_seconds` number `>= 0` if present; `author_date`/`committer_date` parseable date-times normalized to SQLite datetime (UTC). `src/routes/commits.ts` — add the `POST /projects/:project/commits` handler under `authMiddleware`: validate → `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE … RETURNING` → shape via `rowToCommit` → `201 { data: Commit }`. File header updated.
+- [x] **T-102a**: Unit tests `tests/aggregation/commit-input.test.ts` — minimal/full bodies, date normalization (Z / offset / date-only), 400 cases (hash, total_seconds, dates, non-string fields, non-object body).
+- [x] **T-102b**: Integration tests `tests/integration/commits.test.ts` (extend) — create + read-back, idempotent re-post (single row, updated fields), omitted total_seconds → "0 secs", validation 400s, 401, project-from-path, cross-user isolation.
+- [x] **T-103**: `npm run typecheck` — zero errors.
+- [x] **T-104**: `npm test` — full suite green (323 tests) incl. new unit + integration.
 - [ ] **T-105**: Commit with `feat:` prefix, push, open PR against `develop` referencing PR1 and issue #135.
 
 ## Dependencies

--- a/src/routes/commits.ts
+++ b/src/routes/commits.ts
@@ -1,10 +1,10 @@
 /**
- * Per-commit coding-time read endpoints (specs/107-commits/).
+ * Per-commit coding-time endpoints (specs/107-commits/, specs/135-commits-ingestion/).
  *
- * Read surface only: a paginated list and a single-commit lookup over the
- * existing `commits` table. Ingestion (a coding-time plugin posting commits,
- * or a git webhook) is a deliberate follow-up; the table is seeded out of
- * band until then.
+ * Read: a paginated list and a single-commit lookup over the `commits` table.
+ * Write: `POST .../commits` ingests one commit (a git post-commit hook or a
+ * webhook adapter), idempotent on (user_id, project, hash). `total_seconds`
+ * is client-supplied; the server does not correlate heartbeats.
  */
 import { Hono } from "hono";
 import type { AuthEnv } from "../types";
@@ -12,6 +12,7 @@ import type { components } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
 import { normalizeDateTime } from "../utils/user";
 import { formatHumanReadable } from "../utils/time-format";
+import { validateCommitInput } from "../utils/commit-input";
 
 type Commit = components["schemas"]["Commit"];
 
@@ -34,6 +35,25 @@ interface CommitRow {
 
 const SELECT_COLUMNS =
   "hash, message, author_name, author_email, author_date, committer_name, committer_email, committer_date, total_seconds, ref, url, created_at";
+
+// Idempotent on the existing UNIQUE(user_id, project, hash) index: re-posting a
+// hash updates the row's mutable fields in place (id/created_at preserved).
+const UPSERT_SQL = `INSERT INTO commits
+  (id, user_id, project, hash, message, author_name, author_email, author_date,
+   committer_name, committer_email, committer_date, total_seconds, ref, url)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (user_id, project, hash) DO UPDATE SET
+  message = excluded.message,
+  author_name = excluded.author_name,
+  author_email = excluded.author_email,
+  author_date = excluded.author_date,
+  committer_name = excluded.committer_name,
+  committer_email = excluded.committer_email,
+  committer_date = excluded.committer_date,
+  total_seconds = excluded.total_seconds,
+  ref = excluded.ref,
+  url = excluded.url
+RETURNING ${SELECT_COLUMNS}`;
 
 function rowToCommit(row: CommitRow): Commit {
   return {
@@ -64,6 +84,53 @@ const commits = new Hono<AuthEnv>();
 
 commits.use("/projects/:project/commits", authMiddleware);
 commits.use("/projects/:project/commits/*", authMiddleware);
+
+commits.post("/projects/:project/commits", async (c) => {
+  const userId = c.get("userId");
+  const project = c.req.param("project");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const parsed = validateCommitInput(body);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+  const v = parsed.value;
+
+  try {
+    const row = await c.env.DB.prepare(UPSERT_SQL)
+      .bind(
+        crypto.randomUUID(),
+        userId,
+        project,
+        v.hash,
+        v.message,
+        v.author_name,
+        v.author_email,
+        v.author_date,
+        v.committer_name,
+        v.committer_email,
+        v.committer_date,
+        v.total_seconds,
+        v.ref,
+        v.url,
+      )
+      .first<CommitRow>();
+    if (!row) {
+      console.error("POST /projects/:project/commits error: upsert returned no row");
+      return c.json({ error: "Internal server error" }, 500);
+    }
+    return c.json({ data: rowToCommit(row) }, 201);
+  } catch (err) {
+    console.error("POST /projects/:project/commits error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
 
 commits.get("/projects/:project/commits", async (c) => {
   const userId = c.get("userId");

--- a/src/utils/commit-input.ts
+++ b/src/utils/commit-input.ts
@@ -34,6 +34,34 @@ function optionalString(v: unknown): string | null {
   return typeof v === "string" ? v : null;
 }
 
+const RFC3339_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isValidDateTime(v: string): boolean {
+  const m = RFC3339_DATE_TIME.exec(v);
+  if (!m) return false;
+
+  const [, yearRaw, monthRaw, dayRaw, hourRaw, minuteRaw, secondRaw] = m;
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+  const second = Number(secondRaw);
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+
+  return (
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59 &&
+    Number.isFinite(Date.parse(v))
+  );
+}
+
 /**
  * Validate an optional date-time field. Returns the value normalised to the
  * SQLite datetime format (UTC, no millis) or null when absent; `ok: false`
@@ -42,8 +70,8 @@ function optionalString(v: unknown): string | null {
 function normalizeOptionalDate(v: unknown): { ok: true; value: string | null } | { ok: false } {
   if (v === undefined || v === null) return { ok: true, value: null };
   if (typeof v !== "string") return { ok: false };
+  if (!isValidDateTime(v)) return { ok: false };
   const ms = Date.parse(v);
-  if (!Number.isFinite(ms)) return { ok: false };
   return { ok: true, value: toSqliteDateTime(new Date(ms)) };
 }
 

--- a/src/utils/commit-input.ts
+++ b/src/utils/commit-input.ts
@@ -1,0 +1,93 @@
+/**
+ * Validation for the commit ingestion request body (specs/135-commits-ingestion/).
+ *
+ * Pure: turns an untrusted parsed JSON value into a normalised row ready to
+ * upsert, or a 400-worthy error. No D1, no I/O. `project` is taken from the
+ * path by the route, not the body. Dates are normalised to the same SQLite
+ * datetime format `created_at` uses, so the read path renders them schema-valid.
+ */
+import { toSqliteDateTime } from "./user";
+
+export interface ValidatedCommit {
+  hash: string;
+  message: string | null;
+  author_name: string | null;
+  author_email: string | null;
+  author_date: string | null;
+  committer_name: string | null;
+  committer_email: string | null;
+  committer_date: string | null;
+  total_seconds: number | null;
+  ref: string | null;
+  url: string | null;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function fail(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+function optionalString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+/**
+ * Validate an optional date-time field. Returns the value normalised to the
+ * SQLite datetime format (UTC, no millis) or null when absent; `ok: false`
+ * when present but unparseable.
+ */
+function normalizeOptionalDate(v: unknown): { ok: true; value: string | null } | { ok: false } {
+  if (v === undefined || v === null) return { ok: true, value: null };
+  if (typeof v !== "string") return { ok: false };
+  const ms = Date.parse(v);
+  if (!Number.isFinite(ms)) return { ok: false };
+  return { ok: true, value: toSqliteDateTime(new Date(ms)) };
+}
+
+export function validateCommitInput(body: unknown): ValidationResult<ValidatedCommit> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return fail("Request body must be a JSON object");
+  }
+  const r = body as Record<string, unknown>;
+
+  if (typeof r.hash !== "string" || r.hash.length === 0) {
+    return fail("hash is required and must be a non-empty string");
+  }
+
+  if (r.total_seconds !== undefined && r.total_seconds !== null) {
+    if (typeof r.total_seconds !== "number" || !Number.isFinite(r.total_seconds) || r.total_seconds < 0) {
+      return fail("total_seconds must be a number >= 0");
+    }
+  }
+
+  for (const field of ["message", "author_name", "author_email", "committer_name", "committer_email", "ref", "url"] as const) {
+    if (r[field] !== undefined && r[field] !== null && typeof r[field] !== "string") {
+      return fail(`${field} must be a string`);
+    }
+  }
+
+  const authorDate = normalizeOptionalDate(r.author_date);
+  if (!authorDate.ok) return fail("author_date must be a valid date-time");
+  const committerDate = normalizeOptionalDate(r.committer_date);
+  if (!committerDate.ok) return fail("committer_date must be a valid date-time");
+
+  return {
+    ok: true,
+    value: {
+      hash: r.hash,
+      message: optionalString(r.message),
+      author_name: optionalString(r.author_name),
+      author_email: optionalString(r.author_email),
+      author_date: authorDate.value,
+      committer_name: optionalString(r.committer_name),
+      committer_email: optionalString(r.committer_email),
+      committer_date: committerDate.value,
+      total_seconds: (r.total_seconds ?? null) as number | null,
+      ref: optionalString(r.ref),
+      url: optionalString(r.url),
+    },
+  };
+}

--- a/tests/aggregation/commit-input.test.ts
+++ b/tests/aggregation/commit-input.test.ts
@@ -37,12 +37,11 @@ describe("validateCommitInput", () => {
     expect(v.total_seconds).toBe(1800);
   });
 
-  it("normalizes dates to UTC SQLite datetime (no millis), matching created_at", () => {
+  it("normalizes RFC3339 date-times to UTC SQLite datetime (no millis), matching created_at", () => {
     expect(ok({ hash: "h", author_date: "2026-06-05T01:00:00Z" }).author_date).toBe("2026-06-05 01:00:00");
     // Offset is converted to UTC.
     expect(ok({ hash: "h", author_date: "2026-06-05T10:00:00+09:00" }).author_date).toBe("2026-06-05 01:00:00");
-    // Date-only is widened to a full datetime (so the read path stays schema-valid).
-    expect(ok({ hash: "h", committer_date: "2026-06-05" }).committer_date).toBe("2026-06-05 00:00:00");
+    expect(ok({ hash: "h", committer_date: "2026-06-05T01:00:00.123Z" }).committer_date).toBe("2026-06-05 01:00:00");
   });
 
   it("rejects a missing, blank, or non-string hash", () => {
@@ -60,6 +59,9 @@ describe("validateCommitInput", () => {
 
   it("rejects unparseable date-times", () => {
     expect(validateCommitInput({ hash: "h", author_date: "not-a-date" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", author_date: "2026-06-05" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", author_date: "2026-06-05T01:00:00" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", author_date: "2026-02-31T00:00:00Z" }).ok).toBe(false);
     expect(validateCommitInput({ hash: "h", committer_date: "32 of Maybe" }).ok).toBe(false);
   });
 

--- a/tests/aggregation/commit-input.test.ts
+++ b/tests/aggregation/commit-input.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for src/utils/commit-input.ts — the pure commit ingestion
+ * validator (specs/135-commits-ingestion/). No D1, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { validateCommitInput } from "../../src/utils/commit-input";
+
+function ok(body: unknown) {
+  const r = validateCommitInput(body);
+  if (!r.ok) throw new Error(`expected ok, got: ${r.error}`);
+  return r.value;
+}
+
+describe("validateCommitInput", () => {
+  it("accepts a minimal body (hash only) and nulls the rest", () => {
+    const v = ok({ hash: "abc123" });
+    expect(v.hash).toBe("abc123");
+    expect(v.message).toBeNull();
+    expect(v.author_date).toBeNull();
+    expect(v.total_seconds).toBeNull();
+    expect(v.ref).toBeNull();
+  });
+
+  it("passes through all string fields and total_seconds", () => {
+    const v = ok({
+      hash: "abc123",
+      message: "fix: thing",
+      author_name: "Nao",
+      author_email: "nao@example.com",
+      ref: "main",
+      url: "https://example.com/c/abc123",
+      total_seconds: 1800,
+    });
+    expect(v.message).toBe("fix: thing");
+    expect(v.author_name).toBe("Nao");
+    expect(v.ref).toBe("main");
+    expect(v.total_seconds).toBe(1800);
+  });
+
+  it("normalizes dates to UTC SQLite datetime (no millis), matching created_at", () => {
+    expect(ok({ hash: "h", author_date: "2026-06-05T01:00:00Z" }).author_date).toBe("2026-06-05 01:00:00");
+    // Offset is converted to UTC.
+    expect(ok({ hash: "h", author_date: "2026-06-05T10:00:00+09:00" }).author_date).toBe("2026-06-05 01:00:00");
+    // Date-only is widened to a full datetime (so the read path stays schema-valid).
+    expect(ok({ hash: "h", committer_date: "2026-06-05" }).committer_date).toBe("2026-06-05 00:00:00");
+  });
+
+  it("rejects a missing, blank, or non-string hash", () => {
+    expect(validateCommitInput({ message: "x" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: 123 }).ok).toBe(false);
+  });
+
+  it("rejects a negative or non-numeric total_seconds", () => {
+    expect(validateCommitInput({ hash: "h", total_seconds: -1 }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", total_seconds: "30" }).ok).toBe(false);
+    // null / omitted are allowed.
+    expect(ok({ hash: "h", total_seconds: null }).total_seconds).toBeNull();
+  });
+
+  it("rejects unparseable date-times", () => {
+    expect(validateCommitInput({ hash: "h", author_date: "not-a-date" }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", committer_date: "32 of Maybe" }).ok).toBe(false);
+  });
+
+  it("rejects non-string optional string fields", () => {
+    expect(validateCommitInput({ hash: "h", message: 5 }).ok).toBe(false);
+    expect(validateCommitInput({ hash: "h", ref: true }).ok).toBe(false);
+  });
+
+  it("rejects a non-object body", () => {
+    expect(validateCommitInput(null).ok).toBe(false);
+    expect(validateCommitInput([{ hash: "h" }]).ok).toBe(false);
+    expect(validateCommitInput("hash=h").ok).toBe(false);
+  });
+});

--- a/tests/integration/commits.test.ts
+++ b/tests/integration/commits.test.ts
@@ -267,6 +267,8 @@ describe("POST .../commits (ingestion)", () => {
     expect((await postCommit(PROJECT, { hash: "" }, user.apiKey)).status).toBe(400);
     expect((await postCommit(PROJECT, { hash: "x", total_seconds: -5 }, user.apiKey)).status).toBe(400);
     expect((await postCommit(PROJECT, { hash: "x", author_date: "nope" }, user.apiKey)).status).toBe(400);
+    expect((await postCommit(PROJECT, { hash: "x", author_date: "2026-06-05" }, user.apiKey)).status).toBe(400);
+    expect((await postCommit(PROJECT, { hash: "x", author_date: "2026-02-31T00:00:00Z" }, user.apiKey)).status).toBe(400);
   });
 
   it("401s when unauthenticated", async () => {

--- a/tests/integration/commits.test.ts
+++ b/tests/integration/commits.test.ts
@@ -39,6 +39,16 @@ function bearer(apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}` };
 }
 
+async function postCommit(project: string, body: unknown, apiKey?: string): Promise<Response> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) Object.assign(headers, bearer(apiKey));
+  return call(`/api/v1/users/current/projects/${project}/commits`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
 interface SeedCommit {
   hash: string;
   authorDate?: string | null;
@@ -197,5 +207,85 @@ describe("GET .../commits/:hash (single)", () => {
 
   it("returns 401 when unauthenticated", async () => {
     expect((await call(`${COMMITS}/abc123`)).status).toBe(401);
+  });
+});
+
+describe("POST .../commits (ingestion)", () => {
+  it("ingests a commit and returns it, readable via the read endpoints", async () => {
+    const res = await postCommit(
+      PROJECT,
+      {
+        hash: "a1b2c3",
+        message: "fix: handle empty range",
+        author_name: "Nao",
+        author_email: "nao@example.com",
+        author_date: "2026-06-05T01:00:00Z",
+        ref: "main",
+        total_seconds: 1800,
+        url: "https://github.com/org/cloudtime/commit/a1b2c3",
+      },
+      user.apiKey,
+    );
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: CommitShape };
+    expect(data.hash).toBe("a1b2c3");
+    expect(data.total_seconds).toBe(1800);
+    expect(data.human_readable_total).toBe("30 mins");
+    expect(data.author_date).toBe("2026-06-05T01:00:00Z");
+    expect(data.ref).toBe("main");
+
+    const list = await call(COMMITS, { headers: bearer(user.apiKey) });
+    expect(((await list.json()) as { data: CommitShape[] }).data.map((c) => c.hash)).toContain("a1b2c3");
+
+    const single = await call(`${COMMITS}/a1b2c3`, { headers: bearer(user.apiKey) });
+    expect(single.status).toBe(200);
+    expect((await single.json() as { data: CommitShape }).data.hash).toBe("a1b2c3");
+  });
+
+  it("is idempotent on (user, project, hash): re-post updates in place", async () => {
+    await postCommit(PROJECT, { hash: "dup", message: "v1", total_seconds: 1000 }, user.apiKey);
+    const second = await postCommit(PROJECT, { hash: "dup", message: "v2", total_seconds: 2000 }, user.apiKey);
+    expect(second.status).toBe(201);
+
+    const list = await call(COMMITS, { headers: bearer(user.apiKey) });
+    const dups = ((await list.json()) as { data: CommitShape[] }).data.filter((c) => c.hash === "dup");
+    expect(dups).toHaveLength(1);
+    expect(dups[0].message).toBe("v2");
+    expect(dups[0].total_seconds).toBe(2000);
+  });
+
+  it("omitted total_seconds reads back as '0 secs' with no total_seconds field", async () => {
+    const res = await postCommit(PROJECT, { hash: "notime", message: "docs" }, user.apiKey);
+    expect(res.status).toBe(201);
+    const { data } = (await res.json()) as { data: CommitShape };
+    expect(data.human_readable_total).toBe("0 secs");
+    expect(data).not.toHaveProperty("total_seconds");
+  });
+
+  it("400s on missing/blank hash, negative total_seconds, or bad date", async () => {
+    expect((await postCommit(PROJECT, { message: "no hash" }, user.apiKey)).status).toBe(400);
+    expect((await postCommit(PROJECT, { hash: "" }, user.apiKey)).status).toBe(400);
+    expect((await postCommit(PROJECT, { hash: "x", total_seconds: -5 }, user.apiKey)).status).toBe(400);
+    expect((await postCommit(PROJECT, { hash: "x", author_date: "nope" }, user.apiKey)).status).toBe(400);
+  });
+
+  it("401s when unauthenticated", async () => {
+    expect((await postCommit(PROJECT, { hash: "x" })).status).toBe(401);
+  });
+
+  it("stores project from the path, ignoring any project in the body", async () => {
+    await postCommit(PROJECT, { hash: "p1", project: "other" }, user.apiKey);
+    expect((await call(`${COMMITS}/p1`, { headers: bearer(user.apiKey) })).status).toBe(200);
+    expect(
+      (await call("/api/v1/users/current/projects/other/commits/p1", { headers: bearer(user.apiKey) })).status,
+    ).toBe(404);
+  });
+
+  it("isolates ingested commits per user", async () => {
+    await postCommit(PROJECT, { hash: "mine", total_seconds: 100 }, user.apiKey);
+    const bob = await seedUser({ username: "bobpost", email: "bobpost@example.test" });
+    const bobList = await call(COMMITS, { headers: bearer(bob.apiKey) });
+    expect(((await bobList.json()) as { data: CommitShape[] }).data).toEqual([]);
+    await env.KV.delete(`apikey:${bob.apiKeyHash}`);
   });
 });


### PR DESCRIPTION
## Summary

PR2 of 2 for #135 — the implementation, after spec/design PR #143 merged. Adds the write path: `POST /users/current/projects/{project}/commits`, idempotent on `(user_id, project, hash)`.

## Changes
- **`src/utils/commit-input.ts`** (new): `validateCommitInput` — manual validation mirroring `external-duration-input`. `hash` required non-empty; `total_seconds` a number `>= 0` if present; `author_date`/`committer_date` must be RFC3339 date-times (`Z` or offset) and are normalized to the SQLite datetime format `created_at` uses (UTC, no millis) so the read path renders them schema-valid. `project` is not a body field.
- **`src/routes/commits.ts`**: `POST` handler under `authMiddleware` — validate → `INSERT … ON CONFLICT(user_id, project, hash) DO UPDATE … RETURNING` → shape via the existing `rowToCommit` → `201 { data: Commit }`. `project` from the path; `total_seconds` client-supplied (no heartbeat correlation). File header updated.

## Tests
- **Unit** (`tests/aggregation/commit-input.test.ts`): minimal/full bodies, date-time normalization (`Z` / `+09:00` offset / fractional seconds), strict date-time rejection (date-only, timezone-less, impossible calendar dates), and 400 cases (missing/blank/non-string hash, negative/non-numeric `total_seconds`, unparseable dates, non-string fields, non-object body).
- **Integration** (`tests/integration/commits.test.ts`): create + read-back (list & single), idempotent re-post (one row, updated fields), omitted `total_seconds` → `"0 secs"`, validation 400s, 401, `project`-from-path (body project ignored), cross-user isolation.

## Verification
- `npm run typecheck` — clean.
- `npm test` — **323 passed**.
- `npm run lint:api` — valid.

## Notes
- No schema change — the existing `UNIQUE(user_id, project, hash)` index backs the upsert.
- Out of scope (follow-ups): server-side `total_seconds` correlation, git-host webhook adapter, multi-commit bulk ingestion.

Implements #135 (after PR #143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)