### PR TITLE
Security hardening: non-UX-affecting fixes from 2026-06-10 audit

### DIFF
--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -152,13 +152,26 @@ change is required.
 ## API Key Format
 
 ```
-ck_<32 random hex characters>
-Example: ck_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+ck_<43 url-safe base64 characters>
+Example: ck_Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2RlZmdoaWo
 ```
 
-- Generated via Web Crypto API
+- Generated via Web Crypto API: `ck_` + base64url of 32 random bytes (256-bit entropy)
 - Stored as SHA-256 hash in DB (`api_key_hash` column); plaintext shown only once
 - Can be regenerated via POST /auth/api-key (old key immediately invalidated)
+
+### API Key Transport
+
+Three transport methods are accepted for WakaTime compatibility
+(`src/utils/auth.ts`):
+
+1. `Authorization: Basic <base64(api_key)>` — what wakatime-cli sends. Preferred.
+2. `Authorization: Bearer <api_key>` — equivalent; also preferred.
+3. `?api_key=<api_key>` query parameter — **compatibility fallback only.**
+   Query strings are recorded in access logs, proxy logs, and browser
+   history, so a key sent this way is more likely to leak. Use an
+   `Authorization` header anywhere a header can be set, and rotate the key
+   via `POST /auth/api-key` if it was ever pasted into a shared URL.
 
 ## Token Encryption at Rest
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,29 @@ import { processPendingDumps, purgeExpiredDumps } from "./cron/data-dumps";
 
 const app = new Hono<{ Bindings: Env }>();
 
+// ENVIRONMENT=development relaxes the __Host-/Secure cookie attributes, CSRF
+// origin checks, and OAuth redirect-URI validation. If such an instance is
+// serving non-local traffic the operator has almost certainly misconfigured a
+// production deployment — surface it loudly, once per isolate (Issue #153).
+// Log-only on purpose: intentional dev tunnels keep working.
+let warnedDevEnvironment = false;
+const LOCAL_HOSTNAME_RE = /^(localhost|127\.0\.0\.1|\[::1\]|.+\.localhost)$/;
+
+app.use("/*", async (c, next) => {
+  if (!warnedDevEnvironment && c.env.ENVIRONMENT === "development") {
+    const hostname = new URL(c.req.url).hostname;
+    if (!LOCAL_HOSTNAME_RE.test(hostname)) {
+      warnedDevEnvironment = true;
+      console.warn(
+        `[env] ENVIRONMENT=development is serving non-local host "${hostname}" — ` +
+          "cookie security attributes, CSRF origin checks, and OAuth redirect-URI " +
+          "validation are relaxed in this mode. Unset ENVIRONMENT for production deployments.",
+      );
+    }
+  }
+  return next();
+});
+
 app.use(
   "/*",
   secureHeaders({

--- a/src/routes/auth/link.ts
+++ b/src/routes/auth/link.ts
@@ -34,6 +34,12 @@ import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../../
 import { sessionMw } from "./middleware";
 import { getRedirectUri, noCacheHeaders } from "./helpers";
 
+// Verification tokens are base64url(randomBytes(32)) — exactly 43 url-safe
+// characters (see generateVerificationToken). Rejecting anything else before
+// hashing keeps this unauthenticated route from issuing D1 queries for
+// arbitrary garbage input (Issue #152).
+const VERIFY_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/;
+
 const VERIFY_SUCCESS_HTML =
   `<!doctype html><html><head><meta charset="utf-8"><title>Email verified — CloudTime</title></head>` +
   `<body><h1>Email verified</h1>` +
@@ -58,7 +64,7 @@ link.all("/link/verify/:token", async (c) => {
   }
 
   const token = c.req.param("token");
-  if (!token) {
+  if (!token || !VERIFY_TOKEN_RE.test(token)) {
     return c.json({ error: "Token not found" }, 410, noCacheHeaders());
   }
   let tokenHash: string;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -48,7 +48,10 @@ export async function getUserId(
     .first<{ id: string }>();
 
   if (row) {
-    await env.KV.put(`apikey:${keyHash}`, row.id, { expirationTtl: 3600 });
+    // 300s matches SESSION_CACHE_TTL in utils/session.ts: bounds how long a
+    // rotated-away key can keep authenticating if the rotation-time KV delete
+    // is lost or delayed by KV eventual consistency (Issue #151).
+    await env.KV.put(`apikey:${keyHash}`, row.id, { expirationTtl: 300 });
   }
 
   return row?.id ?? null;

--- a/tests/integration/pending-link-verify.test.ts
+++ b/tests/integration/pending-link-verify.test.ts
@@ -121,6 +121,20 @@ describe("GET /api/v1/auth/link/verify/:token", () => {
     expect(await res.json()).toEqual({ error: "Token not found" });
   });
 
+  it("returns 410 'Token not found' for malformed tokens (format pre-check)", async () => {
+    // Real tokens are exactly 43 url-safe base64 chars (Issue #152). A wrong
+    // length or an out-of-alphabet character must produce the same response
+    // as an unknown token so the pre-check is not distinguishable.
+    const wrongLength = "A".repeat(42);
+    const badCharset = "x".repeat(42) + "!";
+
+    for (const bad of [wrongLength, badCharset]) {
+      const res = await call(`/api/v1/auth/link/verify/${bad}`);
+      expect(res.status).toBe(410);
+      expect(await res.json()).toEqual({ error: "Token not found" });
+    }
+  });
+
   it("returns 410 'Token expired' when the underlying row has expired", async () => {
     const { token, pendingLinkId } = await seedPendingLink({ ownerId: owner.userId });
     // Force expiry by editing the row.


### PR DESCRIPTION
## Summary

Implements the UX-neutral subset of findings from the 2026-06-10 security audit. No API contract changes (request/response shapes and status codes are unchanged), so no OpenAPI spec update is required.

- **#151 — Shorten api-key KV cache TTL (3600s → 300s)** in `src/utils/auth.ts`, matching `SESSION_CACHE_TTL`. Bounds how long a rotated-away key can keep authenticating if the rotation-time KV delete is lost or delayed by eventual consistency.
- **#152 — Pre-validate token format on `GET /auth/link/verify/:token`**. Tokens are always 43 url-safe base64 chars; anything else now returns the existing `410 Token not found` without issuing D1 queries on this unauthenticated route.
- **#153 — One-time warning when `ENVIRONMENT=development` serves non-local hosts**. Development mode relaxes cookie security attributes, CSRF origin checks, and OAuth redirect-URI validation; a misconfigured production deployment is now visible in `wrangler tail`. Log-only.
- **#154 — docs: correct API key format description and document transport caveats** (`?api_key=` query param leaks into logs/history; prefer `Authorization` headers).

Closes #151, closes #152, closes #153, closes #154.

## Out of scope (need spec-first PRs or operator-visible behavior changes)

- Public global stats opt-out flag for single-user mode
- First-login owner allowlist
- Max-length caps on heartbeat input fields (no `maxLength` in the OpenAPI spec today)
- Rate-limit bindings beyond the OAuth endpoints

## Testing

- `npm run typecheck` clean
- `npm test`: 28 files / 324 tests passed, including a new integration case for the malformed-token pre-check in `tests/integration/pending-link-verify.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)