### PR TITLE
spec: instance-level opt-out for the public global stats endpoint (PR1)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/156-public-stats-optout"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,6 @@
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/156-public-stats-optout/plan.md`
 <!-- SPECKIT END -->

--- a/schemas/paths/meta/global-stats.yaml
+++ b/schemas/paths/meta/global-stats.yaml
@@ -10,6 +10,10 @@ get:
     key per range (a client-supplied timezone would otherwise fragment the
     cache on an unauthenticated endpoint) and avoids ambiguous cross-user date
     boundaries when `summaries.date` is bucketed per user timezone (#29).
+
+    Operators can disable this endpoint entirely by setting the instance
+    variable `PUBLIC_STATS` to `false`; a disabled instance responds `404`
+    to every request, regardless of the range value (#156).
   security: []
   parameters:
     - name: range
@@ -45,3 +49,5 @@ get:
                 type: string
     '400':
       $ref: ../../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml

--- a/specs/156-public-stats-optout/checklists/requirements.md
+++ b/specs/156-public-stats-optout/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Instance-level opt-out for the public global stats endpoint
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Content Quality: the Background and FR sections reference concrete endpoint
+  paths, the `summaries` table, and file paths. This follows the established
+  house style of prior specs (e.g. `specs/134-insights-hours-of-day/spec.md`)
+  where the "no implementation details" rule is read as "no prescriptive
+  implementation choices" — the references locate existing behavior rather
+  than prescribe new internals. Marked as passing on that basis.
+- Key design decisions (default-enabled, 404-not-403, no-work-when-disabled)
+  were fixed in advance by GitHub Issue #156, so no [NEEDS CLARIFICATION]
+  markers were required.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/156-public-stats-optout/contracts/openapi-diff.md
+++ b/specs/156-public-stats-optout/contracts/openapi-diff.md
@@ -1,0 +1,58 @@
+# OpenAPI Contract Diff: public global stats opt-out
+
+**Branch**: `156-public-stats-optout`
+**Files**: `schemas/paths/meta/global-stats.yaml` (operation `getGlobalStats`)
+
+This PR1 change is **additive**: one new documented response (`404`,
+`$ref`-ing the existing shared `NotFound` component) and one sentence of
+operation prose. No parameter, schema, or existing response changes.
+
+## 1. Operation description — document the instance switch
+
+**Before** (closing sentence of `description`)
+```
+    cache on an unauthenticated endpoint) and avoids ambiguous cross-user date
+    boundaries when `summaries.date` is bucketed per user timezone (#29).
+```
+
+**After**
+```
+    cache on an unauthenticated endpoint) and avoids ambiguous cross-user date
+    boundaries when `summaries.date` is bucketed per user timezone (#29).
+
+    Operators can disable this endpoint entirely by setting the instance
+    variable `PUBLIC_STATS` to `false`; a disabled instance responds `404`
+    to every request, regardless of the range value (#156).
+```
+
+## 2. Responses — add `404`
+
+**Before**
+```yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+```
+
+**After**
+```yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+```
+
+Note: the shared `NotFound` component carries its own fixed description
+("Resource not found") — OpenAPI 3.0 does not allow overriding a description
+alongside a `$ref`, and the disabled-instance semantics are documented in the
+operation prose above instead. The disabled gate precedes range validation,
+so a disabled instance returns `404` even for range values that would
+otherwise yield `400` (spec FR-002).
+
+## Generated types impact
+
+- `src/types/generated.ts`: the `getGlobalStats` operation's `responses` map
+  gains a `404` entry referencing the shared not-found error shape
+  (`{ error?: string }`). No existing member changes.
+- Verified by `npm run generate` followed by reviewing the `git diff` of
+  `src/types/generated.ts` (expected: the additive `404` response on
+  `getGlobalStats` plus the updated operation JSDoc; nothing else).

--- a/specs/156-public-stats-optout/data-model.md
+++ b/specs/156-public-stats-optout/data-model.md
@@ -1,0 +1,23 @@
+# Data Model: Instance-level opt-out for the public global stats endpoint
+
+**Branch**: `156-public-stats-optout` | **Date**: 2026-06-10
+
+This feature introduces **no persisted data changes**: no new tables, no new
+columns, no new KV keys, no migrations.
+
+## Configuration (not persisted)
+
+| Name | Where | Type | Values | Default |
+|------|-------|------|--------|---------|
+| `PUBLIC_STATS` | Workers `[vars]` binding (`Env`, `src/types.ts`, PR2) | `string \| undefined` | trimmed, case-insensitive `"false"` ⇒ disabled; anything else ⇒ enabled | unset ⇒ enabled |
+
+State transitions: none at runtime — Workers vars are immutable per
+deployment; the value changes only via redeploy.
+
+## Touched (unchanged) data surfaces
+
+- **`summaries` (D1)**: read by the enabled path exactly as today; never read
+  by the disabled path.
+- **`global-stats:{range}` (KV, 5-min TTL)**: read/written by the enabled
+  path exactly as today; never read or written by the disabled path. Entries
+  written before a disable simply expire (research D-5).

--- a/specs/156-public-stats-optout/plan.md
+++ b/specs/156-public-stats-optout/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Instance-level opt-out for the public global stats endpoint
+
+**Branch**: `156-public-stats-optout` | **Date**: 2026-06-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/156-public-stats-optout/spec.md`
+
+## Summary
+
+Add an optional `PUBLIC_STATS` instance variable. When its trimmed, case-insensitive value is `"false"`, the unauthenticated global stats endpoint (`GET /api/v1/stats/{range}`, `getGlobalStats`) returns `404 Not Found` before touching the KV cache or D1 — for every range value, valid or not. Any other value, or unset, leaves current behavior byte-for-byte unchanged. This closes the 2026-06-10 audit finding that a single-user instance's entire coding profile is publicly readable (Issue #156).
+
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI change (document the `404` response on `getGlobalStats`, reusing the existing `NotFound` response component) + regenerated types. **No route, config, or documentation-behavior changes.**
+
+**PR2 (after PR1 merges)**: add `PUBLIC_STATS?: string` to the manual `Env` type; add the disabled gate at the top of the handler; integration tests; operator docs (`wrangler.toml` comment + `docs/deployment-guide.md` section).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: none — no D1 schema change, no KV key change. The switch is a Workers `[vars]` binding read per request.
+**Testing**: Vitest + workers pool — integration tests in `tests/integration/global-stats.test.ts` (env override per request, as `pending-link-verify.test.ts` already does with `INSTANCE_MODE`): disabled → 404 for valid and invalid ranges, no cache write; unset/`"true"`/garbage → unchanged 200/202/400; other public endpoints unaffected.
+**Performance Goals**: <10ms CPU — the disabled path is a constant-time string compare returning early; the enabled path is unchanged.
+**Constraints**: the disabled check MUST precede range validation, cache read/write, and all D1 access (FR-002/FR-003); response must be `404`, never `403` (FR-004).
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | OpenAPI `404` documented first (PR1); gate + tests + docs follow in PR2. Types regenerated, never hand-edited. Additive spec change only. |
+| II. Cloudflare-Native | PASS | Disabled path does zero KV/D1 work — strictly less platform usage. Enabled path unchanged. `[vars]` is the idiomatic Workers configuration surface. |
+| III. Type Safety | PASS | The 404 response shape comes from the shared `NotFound` component; `src/types/generated.ts` gains it via `npm run generate`. `Env.PUBLIC_STATS` lives in the manual `src/types.ts` (bindings file, PR2) like every other binding. |
+| IV. Legal/Trademark | PASS | No third-party behavior consulted; the switch is CloudTime-specific and documented from our own schema. |
+| V. Simplicity First | PASS | One env var, one early-return gate, one documented response. No flag framework, no runtime toggle, no falsy-alias parsing. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/156-public-stats-optout/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/paths/meta/global-stats.yaml      # CHANGE: add '404' response ($ref NotFound) + operation prose note
+src/types/generated.ts                    # REGENERATED (npm run generate)
+
+# PR2 (after PR1 merges)
+src/types.ts                              # CHANGE: add PUBLIC_STATS?: string to Env (manual bindings file)
+src/routes/meta.ts                        # CHANGE: early-return 404 gate at the top of getGlobalStats
+tests/integration/global-stats.test.ts    # CHANGE: disabled/enabled/garbage-value/scope cases
+wrangler.toml                             # CHANGE: commented PUBLIC_STATS entry under [vars]
+docs/deployment-guide.md                  # CHANGE: privacy section recommending the switch for single-user instances
+```
+
+**Structure Decision**: The gate lives inside the `getGlobalStats` handler, not in middleware and not as conditional route registration. Hono routes are registered at module scope where no `env` is available, so registration cannot depend on a binding; a dedicated middleware for one route adds indirection for a two-line check (Principle V). At the top of the handler: if `(c.env.PUBLIC_STATS ?? "").trim().toLowerCase() === "false"`, return the standard `404` error body with no-store headers — before `resolveStatsRange`, before the KV read, before any D1 query. Everything below the gate is untouched.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add the `404` response and prose note to `schemas/paths/meta/global-stats.yaml`; `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: `Env.PUBLIC_STATS` + handler gate + integration tests + operator docs (`wrangler.toml`, `docs/deployment-guide.md`); `npm test` green; open PR referencing #156 and PR1.
+
+## Risks & Mitigations
+
+- **Operator expects falsy aliases (`0`, `no`, `off`) to work** → only `"false"` disables (fail-open default). Mitigated by documenting the exact value in `wrangler.toml` and the deployment guide (PR2), and by the explicit edge-case note in the spec.
+- **Stale cached stats served after disabling** → impossible by construction: the gate precedes the cache read, so entries written while enabled are never read while disabled and expire on the existing 5-minute TTL. Covered by an integration test (PR2).
+- **Probing distinguishes disabled from absent** → the gate precedes range validation, so valid and invalid ranges both yield `404`; the body reuses the standard error shape. Covered by an integration test (PR2).
+- **Accidental scope creep onto other endpoints** → the gate is local to `getGlobalStats`; a scope integration test asserts `/meta`, `/editors`, `/program_languages`, `/health`, and the authenticated per-user stats are unaffected (PR2).

--- a/specs/156-public-stats-optout/quickstart.md
+++ b/specs/156-public-stats-optout/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: validating the public global stats opt-out
+
+**Branch**: `156-public-stats-optout` | **Scope**: PR2 behavior (PR1 ships contract only)
+
+## Prerequisites
+
+- `npm install`, local D1 initialized (`npm run db:init`)
+- Some seeded activity (any heartbeats aggregated into `summaries`), or run
+  against the integration test fixtures
+
+## Scenario 1 — default: endpoint enabled, behavior unchanged
+
+```bash
+npx wrangler dev
+curl -i http://localhost:8787/api/v1/stats/last_7_days
+```
+
+**Expected**: `200` (or `202` while aggregation is pending) with the
+`GlobalStats` body; `400` for an invalid range such as `not_a_range`.
+Identical to the current release.
+
+## Scenario 2 — disabled: every request is 404, no work performed
+
+Add to `wrangler.toml` `[vars]` (or use `--var`):
+
+```toml
+PUBLIC_STATS = "false"
+```
+
+```bash
+npx wrangler dev
+curl -i http://localhost:8787/api/v1/stats/last_7_days   # valid range
+curl -i http://localhost:8787/api/v1/stats/not_a_range   # invalid range
+```
+
+**Expected**: both return `404` with the standard error body
+(`{"error": "..."}`); the responses are indistinguishable, and no
+`global-stats:*` KV entry is written (verifiable in tests via the KV
+binding; locally via `wrangler kv key list`).
+
+## Scenario 3 — scope: nothing else is affected
+
+With `PUBLIC_STATS = "false"` still set:
+
+```bash
+curl -i http://localhost:8787/api/v1/health              # 200
+curl -i http://localhost:8787/api/v1/editors             # 200
+curl -i http://localhost:8787/api/v1/program_languages   # 200
+curl -i -H "Authorization: Bearer $CK_API_KEY" \
+  http://localhost:8787/api/v1/users/current/stats/last_7_days   # 200/202
+```
+
+**Expected**: all unchanged — the switch governs only the unauthenticated
+global aggregate.
+
+## Automated validation (PR2)
+
+Integration tests in `tests/integration/global-stats.test.ts` cover the
+matrix above by passing `{ PUBLIC_STATS: "false" }` (and `"true"`, garbage
+values, unset) as per-request env overrides — the same pattern
+`tests/integration/pending-link-verify.test.ts` uses for `INSTANCE_MODE`.
+Run with:
+
+```bash
+npm run typecheck && npm test
+```
+
+Contract references: [contracts/openapi-diff.md](./contracts/openapi-diff.md)
+· decisions: [research.md](./research.md) · config surface:
+[data-model.md](./data-model.md)

--- a/specs/156-public-stats-optout/research.md
+++ b/specs/156-public-stats-optout/research.md
@@ -1,0 +1,129 @@
+# Research: Instance-level opt-out for the public global stats endpoint
+
+**Branch**: `156-public-stats-optout` | **Date**: 2026-06-10
+
+No `NEEDS CLARIFICATION` markers remained in the spec — Issue #156 fixed the
+contentious decisions up front. This document records those decisions and the
+alternatives considered.
+
+## D-1: Disabled response is `404`, not `403`
+
+**Decision**: When `PUBLIC_STATS="false"`, `GET /api/v1/stats/{range}` returns
+`404 Not Found` with the standard error body.
+
+**Rationale**: A `403` confirms to a prober that the endpoint exists and is
+deliberately guarded — exactly the information a privacy-motivated operator
+wants to withhold. `404` is indistinguishable from the endpoint never having
+existed. The shared `NotFound` response component
+(`schemas/components/responses/NotFound.yaml`) already models this body, so no
+new schema is needed.
+
+**Alternatives considered**:
+- `403 Forbidden` — rejected: leaks endpoint existence (spec FR-004).
+- `401` + auth requirement — rejected: turns a public endpoint into an
+  authenticated one, a breaking contract change; out of scope.
+- Empty/zeroed `200` — rejected: still confirms the endpoint and invites
+  clients to treat fabricated zeros as data.
+
+## D-2: Default is enabled (fail-open for unrecognized values)
+
+**Decision**: Unset, `"true"`, or any unrecognized value ⇒ enabled. Only the
+literal `"false"` (trimmed, case-insensitive) disables.
+
+**Rationale**: Existing deployments must observe zero behavior change on
+upgrade (spec SC-002); dashboards or badges built on the endpoint must not
+break silently. The privacy posture is an explicit operator opt-in,
+recommended prominently in the deployment guide (PR2).
+
+**Alternatives considered**:
+- Privacy-by-default (`disabled` unless `PUBLIC_STATS="true"`) — rejected for
+  this change: a silent breaking flip for every existing instance. Revisitable
+  as a major-version default change.
+- Defaulting by `INSTANCE_MODE` (disabled when `single`) — rejected: same
+  silent-flip problem for the project's default mode, and couples two
+  unrelated knobs.
+
+## D-3: Value parsing — single documented literal
+
+**Decision**: `(value ?? "").trim().toLowerCase() === "false"` disables;
+everything else enables.
+
+**Rationale**: One unambiguous value is trivial to document and test. Trimming
+and case-folding absorb the common copy-paste accidents (`"False"`, trailing
+space) without growing an alias vocabulary. Constitution Principle V.
+
+**Alternatives considered**:
+- Falsy-alias set (`"0"`, `"no"`, `"off"`) — rejected: more surface to
+  document and test for no real operator benefit.
+- Strict validation with an error on unrecognized values — rejected: Workers
+  has no startup hook to fail fast in; failing per-request would turn a typo
+  into an outage of the backward-compatible default.
+
+## D-4: Gate placement — top of the handler, not middleware or registration
+
+**Decision**: An early-return check at the top of the `getGlobalStats`
+handler in `src/routes/meta.ts`, before range validation, the KV cache read,
+and the D1 batch.
+
+**Rationale**: Hono routes are registered at module scope, where no `env` is
+available — conditional route registration is not possible on Workers.
+A per-route middleware would be indirection around a two-line check
+(Principle V). Placing the gate first satisfies FR-002/FR-003: every request
+answers `404` with zero cache/DB work and without revealing whether the range
+was valid.
+
+**Alternatives considered**:
+- Conditional route registration — not feasible (no `env` at module scope).
+- Dedicated middleware — rejected: one consumer, no reuse, more files.
+- Gate after range validation (400 for bad ranges) — rejected: a differing
+  status confirms the endpoint exists (FR-002, spec Edge Cases).
+
+## D-5: Cache handling across the toggle
+
+**Decision**: No purge mechanism. The gate precedes the cache read, so
+entries cached while enabled are never served while disabled; they expire on
+the existing 5-minute TTL (`global-stats:{range}` keys).
+
+**Rationale**: Toggling requires a redeploy (Workers vars are immutable at
+runtime), which takes longer than the TTL anyway; purge code would be dead
+weight (Principle V).
+
+**Alternatives considered**:
+- Explicit KV purge on first disabled request — rejected: requires KV
+  list/delete work on a path whose contract is "do no work", for entries that
+  expire in minutes on their own.
+
+## D-6: OpenAPI representation
+
+**Decision**: Add a `404` response to the `getGlobalStats` operation,
+`$ref`-ing the shared `NotFound` component, with a description naming the
+disabled-instance case, plus one sentence in the operation prose documenting
+`PUBLIC_STATS`. Additive change only.
+
+**Rationale**: SDD — the contract must document every response the endpoint
+can produce, and the disabled case must be discoverable from the schema
+(FR-007). Reusing `NotFound` keeps the generated types additive.
+
+**Alternatives considered**:
+- A bespoke `StatsDisabled` response component — rejected: the body is the
+  standard error shape; a new component implies a new shape that doesn't
+  exist.
+- Leaving the 404 undocumented ("operational behavior") — rejected: violates
+  SDD; clients deserve to know a permanent 404 is a documented state.
+
+## D-7: Relationship to multi-user per-user visibility
+
+**Decision**: Independent and composable. This switch removes the endpoint at
+the instance level; the planned `users.is_public` filter
+(`docs/multi-user-design.md` §"Public global stats becomes opt-in-scoped")
+scopes the aggregate's contents in multi-user mode.
+
+**Rationale**: A multi-user operator may want the endpoint gone entirely
+(this switch) or present but opt-in-scoped (`is_public`). Neither subsumes
+the other; when both exist, the instance switch wins (endpoint absent ⇒
+scoping moot).
+
+**Alternatives considered**:
+- Waiting for `is_public` and deriving instance behavior from it — rejected:
+  multi-user visibility is unscheduled future work and does not help the
+  single-user owner today (the audit's actual finding).

--- a/specs/156-public-stats-optout/spec.md
+++ b/specs/156-public-stats-optout/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: Instance-level opt-out for the public global stats endpoint
+
+**Feature Branch**: `156-public-stats-optout`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: GitHub Issue #156. `GET /api/v1/stats/{range}` is unauthenticated (`security: []`) and aggregates **all** rows in `summaries`. In single-user mode the "global" aggregate is the instance owner's entire coding profile — total time, daily average, language/editor/OS breakdowns — exposed to anyone who knows the Worker URL. Found in the 2026-06-10 security audit.
+
+## Background
+
+The global stats endpoint (`GET /api/v1/stats/{range}`, `src/routes/meta.ts`) is public by design, mirroring the WakaTime-compatible notion of an instance-wide activity summary. On a multi-user instance that aggregate is a blend of many users; on a single-user instance — the project's default and primary mode — it is exactly one person's coding profile, readable without credentials.
+
+`docs/multi-user-design.md` (D-2) already plans **per-user** `is_public` scoping for multi-user mode: only opted-in users would contribute to the public aggregate. That work does not help a single-user operator who simply does not want a public profile at all. This feature adds the missing **instance-level** switch: a configuration variable (`PUBLIC_STATS`) that disables the endpoint entirely.
+
+Design decisions fixed by Issue #156:
+
+- **Default enabled.** Existing deployments change nothing and see no behavior change.
+- **Disabled means `404 Not Found`, not `403`.** A 403 confirms the endpoint exists and is guarded; a 404 reveals nothing.
+- **Disabled means no work.** The handler must answer before touching the cache or the database, so a disabled endpoint cannot be used to generate load against either.
+
+The instance-level switch is orthogonal to the planned per-user `is_public` filter; when multi-user visibility ships, the two compose (instance switch off ⇒ endpoint gone; instance switch on ⇒ aggregate scoped to opted-in users).
+
+This spec covers PR1 of the SpecKit 2-PR workflow: specification, OpenAPI change (documenting the `404` response), and regenerated types. Implementation and tests follow in PR2.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator disables the public profile (Priority: P1)
+
+As the operator of a single-user CloudTime instance, I want to turn off the public global stats endpoint so that my coding activity is not readable by anyone who discovers my Worker URL.
+
+**Why this priority**: This is the entire feature — the privacy gap identified by the security audit.
+
+**Independent Test**: Deploy (or run tests) with `PUBLIC_STATS="false"`. Every request to `GET /api/v1/stats/{range}` returns `404` with the standard error body, and neither the stats cache nor the database is touched by the request.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PUBLIC_STATS="false"` and existing activity data, **When** an unauthenticated client requests `GET /api/v1/stats/last_7_days`, **Then** the response is `404` with the standard error body and contains no activity-derived information.
+2. **Given** `PUBLIC_STATS="false"`, **When** any range value is requested — valid (`last_30_days`, `2026`, `2026-05`) or invalid (`not_a_range`) — **Then** the response is `404` in every case (the disabled check precedes range validation, so the endpoint's existence is not confirmed by a differing `400`).
+3. **Given** `PUBLIC_STATS="false"` and a stats response cached before the switch was flipped, **When** the endpoint is requested, **Then** the response is `404` and the stale cache entry is not served (it expires unused).
+4. **Given** `PUBLIC_STATS="false"`, **When** the endpoint is requested repeatedly, **Then** no aggregate is computed and no cache entries are written.
+
+---
+
+### User Story 2 - Existing deployments are unaffected by default (Priority: P2)
+
+As an operator who upgrades CloudTime without reading the changelog, I want the endpoint to keep working exactly as before unless I explicitly disable it.
+
+**Why this priority**: Backward compatibility is a hard requirement; a silent behavior flip would break dashboards, badges, or monitors built on the endpoint.
+
+**Independent Test**: With `PUBLIC_STATS` unset (and again with `PUBLIC_STATS="true"`), `GET /api/v1/stats/{range}` behaves identically to the current release: `200` with data (or `202` while aggregation is pending), `400` for an invalid range, cache populated as today.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PUBLIC_STATS` is unset, **When** a valid range is requested, **Then** the response (status, body shape, caching behavior) is unchanged from current behavior.
+2. **Given** `PUBLIC_STATS="true"`, **When** a valid range is requested, **Then** behavior is identical to the unset case.
+3. **Given** `PUBLIC_STATS` set to any unrecognized value, **When** the endpoint is requested, **Then** the endpoint behaves as enabled (fail-open to the backward-compatible default; only an explicit `"false"` disables).
+
+---
+
+### User Story 3 - Only the global stats endpoint is affected (Priority: P3)
+
+As a user of the instance, I want my editor plugins, my own dashboards, and the other public utility endpoints to keep working regardless of the switch.
+
+**Why this priority**: Guards against over-reach; the switch must not become an accidental kill-switch for unrelated functionality.
+
+**Independent Test**: With `PUBLIC_STATS="false"`, the public utility endpoints (`/api/v1/meta`, `/api/v1/editors`, `/api/v1/program_languages`, `/api/v1/health`) and every authenticated endpoint (including `GET /api/v1/users/current/stats/{range}`) respond exactly as before.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PUBLIC_STATS="false"`, **When** the other public utility endpoints are requested, **Then** they respond unchanged.
+2. **Given** `PUBLIC_STATS="false"` and an authenticated user, **When** the user requests their own stats (`GET /api/v1/users/current/stats/{range}`), **Then** the response is unchanged — the switch governs only the unauthenticated global aggregate.
+
+---
+
+### Edge Cases
+
+- **Invalid range while disabled**: returns `404`, not `400` — the disabled check runs before range validation so probing cannot distinguish "disabled" from "absent".
+- **Cache poisoning across the toggle**: entries cached while enabled must not leak after disabling. Because the disabled check precedes the cache read, stale entries are simply never read and expire on their own short TTL. No purge step is required.
+- **Unrecognized switch values** (`"False "`, `"0"`, `"no"`, typos): values are trimmed and compared case-insensitively; the literal `false` disables, anything else (including unset) leaves the endpoint enabled. Fail-open to enabled is deliberate — the default must protect existing deployments from accidental breakage, and the privacy posture is opt-in by explicit operator action.
+- **Toggling back on**: re-enabling restores current behavior with no migration or cleanup; the next request repopulates the cache normally.
+- **Aggregation pending (202) while enabled**: unchanged; the switch does not interact with the pending-aggregation status.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support an optional instance configuration variable `PUBLIC_STATS` with string values; when its trimmed, case-insensitive value equals `"false"` the public global stats endpoint is **disabled**; for any other value, or when unset, it is **enabled**.
+- **FR-002**: When disabled, `GET /api/v1/stats/{range}` MUST return `404 Not Found` with the API's standard error body for **every** request, regardless of the range value's validity or the presence of data.
+- **FR-003**: When disabled, the handler MUST NOT read or write the stats cache and MUST NOT execute any database queries for this endpoint — the disabled check precedes all other processing, including range validation.
+- **FR-004**: The disabled response MUST be `404` (not `403` or any status that confirms the endpoint exists behind a guard).
+- **FR-005**: When enabled (set to a non-`"false"` value) or unset, the endpoint's behavior MUST be unchanged from the current release: same status codes (`200`/`202`/`400`), same response bodies, same caching behavior.
+- **FR-006**: The switch MUST affect only `GET /api/v1/stats/{range}`. The other public endpoints (`/meta`, `/editors`, `/program_languages`, `/health`) and all authenticated endpoints — including the per-user `GET /users/current/stats/{range}` — MUST be unaffected.
+- **FR-007**: The OpenAPI specification MUST document the `404` response on the global stats operation, identifying it as the disabled-instance response.
+- **FR-008**: Operator documentation MUST cover the variable: a commented entry in `wrangler.toml` and a section in `docs/deployment-guide.md` recommending that single-user instances disable public stats unless the owner intentionally wants a public profile.
+
+### Key Entities
+
+- **Instance configuration (`PUBLIC_STATS`)**: a deployment-time variable, not persisted data. No schema or stored-data changes are involved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the switch disabled, zero coding-activity information (totals, languages, editors, operating systems, date ranges) is retrievable through the public stats URL — every probe yields the same `404` error body.
+- **SC-002**: Deployments that change nothing observe zero behavioral difference after upgrading (100% backward compatibility for the unset case).
+- **SC-003**: An operator can disable the public profile with a single configuration change and no data migration; the change is effective from the next deployment.
+- **SC-004**: An operator reading the deployment guide can locate and apply the setting without consulting source code.
+
+## Assumptions
+
+- Default-enabled (fail-open for unrecognized values) is fixed by Issue #156 to guarantee backward compatibility; the privacy improvement is an explicit operator opt-in.
+- Only the literal value `false` (trimmed, case-insensitive) disables the endpoint; documenting one unambiguous value is simpler than enumerating falsy aliases (`0`, `no`, `off`), per the Simplicity First principle.
+- The `404` error body reuses the API's existing standard error shape; no new response schema is introduced.
+- Cloudflare Workers vars are immutable at runtime, so the switch takes effect on deployment; no live-toggle mechanism is in scope.
+- The planned multi-user per-user visibility (`is_public`, `docs/multi-user-design.md`) remains future work; this switch neither depends on it nor blocks it.
+- Rate limiting for this endpoint (Issue #159) is out of scope here; the disabled path's early return already minimizes its cost.

--- a/specs/156-public-stats-optout/tasks.md
+++ b/specs/156-public-stats-optout/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Instance-level opt-out for the public global stats endpoint
+
+**Input**: Design documents from `specs/156-public-stats-optout/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/openapi-diff.md, quickstart.md
+
+**Organization**: The SpecKit 2-PR rule splits delivery: Phase 1 is PR1 (this branch — contract only); Phases 2+ are PR2 (implementation, after PR1 merges). Tests are included because the spec's Independent Test criteria and the project testing baseline require integration coverage for endpoint behavior changes.
+
+## Phase 1: Setup — PR1, contract only (this branch)
+
+**Goal**: Land the documented contract (404 on `getGlobalStats`) and regenerated types with zero behavior change.
+
+- [ ] T001 Apply the contract diff in `specs/156-public-stats-optout/contracts/openapi-diff.md` to `schemas/paths/meta/global-stats.yaml`: add the `'404'` response (`$ref: ../../components/responses/NotFound.yaml`) after `'400'`, and append the `PUBLIC_STATS` paragraph to the operation `description`. Commit the spec change on its own.
+- [ ] T002 Run `npm run generate`; verify via `git diff src/types/generated.ts` that the only changes are the additive `404` response on `getGlobalStats` and updated operation JSDoc. Commit the regenerated output separately (never hand-edit).
+- [ ] T003 Run `npm run typecheck`; push branch `156-public-stats-optout` and open PR1 targeting `develop`, referencing Issue #156 and noting "spec + types only, implementation in PR2".
+
+**Checkpoint**: PR1 open and green. Phases below start only after PR1 merges, on a fresh branch off `develop`.
+
+## Phase 2: Foundational — PR2 prerequisite (blocking all user stories)
+
+- [ ] T004 Add `PUBLIC_STATS?: string` (with an operator-facing comment: trimmed, case-insensitive `"false"` disables the public global stats endpoint; anything else/unset = enabled) to the `Env` interface in `src/types.ts`.
+
+## Phase 3: User Story 1 — Operator disables the public profile (P1) 🎯 MVP
+
+**Goal**: With `PUBLIC_STATS="false"`, every `GET /api/v1/stats/{range}` request returns the standard `404` body before any cache or DB work.
+
+**Independent Test**: Run the integration suite with `{ PUBLIC_STATS: "false" }` env overrides — valid and invalid ranges both return identical `404` bodies and no `global-stats:*` KV entry is written.
+
+- [ ] T005 [US1] In `src/routes/meta.ts`, add the disabled gate as the first statement of the `getGlobalStats` handler: if `(c.env.PUBLIC_STATS ?? "").trim().toLowerCase() === "false"`, return `404` with the standard error body and `Cache-Control: no-store` — before `resolveStatsRange`, the KV read, and the D1 batch (plan "Structure Decision", research D-3/D-4).
+- [ ] T006 [US1] Add integration tests in `tests/integration/global-stats.test.ts` (env-override pattern from `tests/integration/pending-link-verify.test.ts`): disabled + valid range → 404; disabled + invalid range → 404 with an identical body (FR-002); disabled requests write no `global-stats:*` KV entry and serve no pre-seeded cache entry (FR-003, spec US1 scenario 3).
+
+**Checkpoint**: US1 deliverable — the privacy switch works end-to-end.
+
+## Phase 4: User Story 2 — Existing deployments unaffected by default (P2)
+
+**Goal**: Unset, `"true"`, or unrecognized values leave behavior byte-for-byte unchanged.
+
+**Independent Test**: The existing `global-stats` integration cases pass unmodified with `PUBLIC_STATS` unset; re-running them with `"true"` and a garbage value yields identical results.
+
+- [ ] T007 [P] [US2] Extend `tests/integration/global-stats.test.ts`: with `PUBLIC_STATS` unset, `"true"`, and an unrecognized value (e.g. `"no"`), a valid range returns the current `200`/`202` body and an invalid range returns `400`; cache population behavior unchanged (FR-001, FR-005, spec US2).
+
+## Phase 5: User Story 3 — Only the global stats endpoint is affected (P3)
+
+**Goal**: The switch is not an accidental kill-switch for other endpoints.
+
+**Independent Test**: With `PUBLIC_STATS="false"`, the other public endpoints and an authenticated per-user stats request respond exactly as before.
+
+- [ ] T008 [P] [US3] Extend `tests/integration/global-stats.test.ts`: with `PUBLIC_STATS="false"`, assert `/api/v1/health`, `/api/v1/meta`, `/api/v1/editors`, `/api/v1/program_languages` return `200`, and an authenticated `GET /api/v1/users/current/stats/last_7_days` (fixture user via `tests/helpers/fixtures.ts`) responds unchanged (FR-006, spec US3).
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T009 [P] Add a commented `PUBLIC_STATS` entry under `[vars]` in `wrangler.toml` documenting the exact disabling value and the default (FR-008).
+- [ ] T010 [P] Add a privacy section to `docs/deployment-guide.md` recommending `PUBLIC_STATS = "false"` for single-user instances unless a public profile is intended; cross-link from the global-stats notes in `docs/timezone-behavior.md` if a pointer fits naturally (FR-008, SC-004).
+- [ ] T011 Run `npm run typecheck && npm test` (all suites green); open PR2 targeting `develop`, referencing Issue #156 and PR1.
+
+## Dependencies
+
+- T001 → T002 → T003 (strict commit order, Constitution I)
+- PR1 merge gates everything below
+- T004 blocks T005 (type must exist before the handler reads it)
+- T005 blocks T006 (tests exercise the gate)
+- T006, T007, T008 are independent of each other once T005 lands ([P] where marked)
+- T009, T010 independent of code tasks; T011 last
+
+## Parallel Example
+
+After T005 merges into the PR2 working branch:
+
+```text
+# Run in parallel — different concerns, same test file extended in separate describe blocks:
+T007 [US2] default-behavior cases
+T008 [US3] scope cases
+T009 wrangler.toml comment
+T010 deployment-guide section
+```
+
+## Implementation Strategy
+
+MVP = Phase 3 (US1): the switch existing and returning blanket `404`s is the entire audit remediation. US2 is regression assurance (the code change for it is zero — only tests), US3 is scope assurance. Ship PR2 as one small PR; the stories stay independently verifiable through their test blocks.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -1198,6 +1198,7 @@ export interface paths {
         /**
          * Aggregate stats of all users
          * @description Aggregates activity across all users over the requested range. This endpoint is unauthenticated and **always aggregates in UTC** — it does not accept a timezone. Fixing UTC keeps the response cacheable under a single key per range (a client-supplied timezone would otherwise fragment the cache on an unauthenticated endpoint) and avoids ambiguous cross-user date boundaries when `summaries.date` is bucketed per user timezone (#29).
+         *     Operators can disable this endpoint entirely by setting the instance variable `PUBLIC_STATS` to `false`; a disabled instance responds `404` to every request, regardless of the range value (#156).
          */
         get: operations["getGlobalStats"];
         put?: never;
@@ -3745,6 +3746,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
         };
     };
 }


### PR DESCRIPTION
## Summary

PR1 (Spec + Design) of the SpecKit 2-PR workflow for #156. **No implementation code** — contract and design artifacts only; the handler gate, `Env` type, integration tests, and operator docs follow in PR2.

`GET /api/v1/stats/{range}` is unauthenticated and aggregates all `summaries` rows; on a single-user instance that is the owner''s entire coding profile, readable by anyone with the Worker URL (2026-06-10 security audit). This feature adds an optional `PUBLIC_STATS` instance variable: the literal value `false` (trimmed, case-insensitive) disables the endpoint — every request answers `404` before any KV or D1 work; anything else (including unset) leaves behavior byte-for-byte unchanged.

## Contents

- `specs/156-public-stats-optout/` — spec (3 user stories, FR-001…FR-008), plan (constitution check all-PASS), research (decisions D-1…D-7: 404-not-403, default-enabled fail-open, single literal value, handler-top gate, no cache purge, contract representation, relation to multi-user `is_public`), data-model (no persisted data changes), contract diff, quickstart, tasks
- `schemas/paths/meta/global-stats.yaml` — additive `404` response (`$ref` shared `NotFound`) + operation prose documenting `PUBLIC_STATS`
- `src/types/generated.ts` — regenerated; diff is exactly the additive `404` entry + JSDoc on `getGlobalStats`
- `CLAUDE.md` — SpecKit plan pointer updated

Commit order per constitution: SpecKit artifacts → spec change → `npm run generate` output.

## Testing

- `npm run lint:api` valid
- `npm run typecheck` clean
- `npm test`: 28 files / 323 tests passed (no behavior change in this PR)

Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)