### PR TITLE
feat: instance-level opt-out for the public global stats endpoint (PR2)

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -81,6 +81,29 @@ In single-user mode the first OAuth login becomes the owner; all subsequent OAut
 
 For multi-user mode, set `INSTANCE_MODE=multi` in `wrangler.toml` `[vars]` and additionally configure the email provider (see [`email-setup.md`](./email-setup.md)).
 
+### Privacy: public global stats (`PUBLIC_STATS`)
+
+`GET /api/v1/stats/{range}` is unauthenticated and serves an instance-wide
+activity aggregate. On a single-user instance that aggregate is your entire
+coding profile — total time, daily average, language/editor/OS breakdowns —
+readable by anyone who knows your Worker URL.
+
+To disable the endpoint, add to `wrangler.toml` `[vars]`:
+
+```toml
+PUBLIC_STATS = "false"
+```
+
+A disabled instance answers `404` to every request on that path — the
+response does not reveal that the endpoint exists — and performs no cache or
+database work for it. Only the literal value `false` (trimmed,
+case-insensitive) disables; unset or any other value leaves the endpoint
+enabled, which is the backward-compatible default.
+
+**Recommended for single-user instances** unless you intentionally want a
+public activity profile. The setting takes effect on the next
+`wrangler deploy`.
+
 ## 7. Deploy
 
 ```bash

--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -39,6 +39,13 @@ meta.get("/program_languages", (c) => {
 // ─── GET /stats/:range (global stats) ────────────────────
 
 meta.get("/stats/:range", async (c) => {
+  // Instance-level opt-out (Issue #156): a disabled instance answers 404
+  // before range validation, the KV cache, and D1, so probing cannot
+  // distinguish "disabled" from "absent" and generates no load.
+  if ((c.env.PUBLIC_STATS ?? "").trim().toLowerCase() === "false") {
+    return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
+  }
+
   const rangeParam = c.req.param("range");
   // Global stats always aggregate in UTC (Issue #29): no timezone is accepted.
   // This keeps the cache key un-fragmentable on this unauthenticated endpoint

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,12 @@ export interface Env {
   // Instance mode: "single" (default) or "multi" (future)
   INSTANCE_MODE?: string;
 
+  // Instance-level switch for the unauthenticated global stats endpoint
+  // (Issue #156). Trimmed, case-insensitive "false" disables
+  // GET /api/v1/stats/{range} (blanket 404, no cache/D1 work); any other
+  // value, or unset, leaves it enabled.
+  PUBLIC_STATS?: string;
+
   // Optional raw-heartbeat retention window in days (Issue #108). Unset or
   // non-positive = retain forever. When set, the hourly cron purges raw
   // heartbeats older than this many days; pre-aggregated `summaries` are

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -22,6 +22,7 @@ declare global {
       DISCORD_CLIENT_SECRET: string;
       ENCRYPTION_KEY: string;
       INSTANCE_MODE?: string;
+      PUBLIC_STATS?: string;
       ENVIRONMENT?: string;
       APP_URL?: string;
       GOOGLE_HOSTED_DOMAIN?: string;

--- a/tests/integration/global-stats.test.ts
+++ b/tests/integration/global-stats.test.ts
@@ -10,7 +10,7 @@ import {
 } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import worker from "../../src/index";
-import { truncate } from "../helpers/fixtures";
+import { seedUser, truncate } from "../helpers/fixtures";
 
 const BASE = "https://test.cloudtime.dev";
 const CACHE_KEYS = [
@@ -40,9 +40,14 @@ afterEach(async () => {
   await clearGlobalStatsCache();
 });
 
-async function call(path: string): Promise<Response> {
+async function call(
+  path: string,
+  init: RequestInit = {},
+  envOverrides: Partial<Cloudflare.Env> = {},
+): Promise<Response> {
   const ctx = createExecutionContext();
-  const res = await worker.fetch(new Request(`${BASE}${path}`, {}), env, ctx);
+  const testEnv = { ...env, ...envOverrides };
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), testEnv, ctx);
   await waitOnExecutionContext(ctx);
   return res;
 }
@@ -82,5 +87,76 @@ describe("GET /api/v1/stats/:range (global, UTC)", () => {
   it("still 400s on an invalid range", async () => {
     const res = await call("/api/v1/stats/since_forever");
     expect(res.status).toBe(400);
+  });
+});
+
+describe("PUBLIC_STATS instance switch (#156)", () => {
+  const DISABLED = { PUBLIC_STATS: "false" };
+
+  it("disabled: returns 404 for a valid range and writes no cache entry", async () => {
+    const res = await call("/api/v1/stats/last_7_days", {}, DISABLED);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await env.KV.get("global-stats:last_7_days", "json")).toBeNull();
+  });
+
+  it("disabled: invalid range returns an identical 404, not 400 (FR-002)", async () => {
+    const valid = await call("/api/v1/stats/last_7_days", {}, DISABLED);
+    const invalid = await call("/api/v1/stats/since_forever", {}, DISABLED);
+    expect(valid.status).toBe(404);
+    expect(invalid.status).toBe(404);
+    // Identical bodies so probing cannot distinguish disabled from absent.
+    expect(await invalid.json()).toEqual(await valid.json());
+  });
+
+  it("disabled: does not serve an entry cached while enabled (FR-003)", async () => {
+    // Populate the cache via an enabled request, then flip the switch.
+    expect((await call("/api/v1/stats/last_7_days")).status).toBe(200);
+    expect(await env.KV.get("global-stats:last_7_days", "json")).not.toBeNull();
+
+    const res = await call("/api/v1/stats/last_7_days", {}, DISABLED);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found" });
+  });
+
+  it("enabled explicitly or with an unrecognized value: behavior unchanged (FR-001/FR-005)", async () => {
+    for (const value of ["true", "no", " FALSE-ish "]) {
+      await clearGlobalStatsCache();
+      const ok = await call("/api/v1/stats/last_7_days", {}, { PUBLIC_STATS: value });
+      expect(ok.status).toBe(200);
+      expect(((await ok.json()) as GlobalStatsBody).data.range.timezone).toBe("UTC");
+      expect(await env.KV.get("global-stats:last_7_days", "json")).not.toBeNull();
+
+      const bad = await call("/api/v1/stats/since_forever", {}, { PUBLIC_STATS: value });
+      expect(bad.status).toBe(400);
+    }
+  });
+
+  it("disabled: case-insensitive with surrounding whitespace", async () => {
+    const res = await call("/api/v1/stats/last_7_days", {}, { PUBLIC_STATS: " False " });
+    expect(res.status).toBe(404);
+  });
+
+  it("disabled: other public endpoints are unaffected (FR-006)", async () => {
+    for (const path of ["/api/v1/health", "/api/v1/meta", "/api/v1/editors", "/api/v1/program_languages"]) {
+      const res = await call(path, {}, DISABLED);
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("disabled: authenticated per-user stats are unaffected (FR-006)", async () => {
+    const user = await seedUser();
+    try {
+      const res = await call(
+        "/api/v1/users/current/stats/last_7_days",
+        { headers: { Authorization: `Bearer ${user.apiKey}` } },
+        DISABLED,
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      await env.KV.delete(`apikey:${user.apiKeyHash}`);
+      await truncate("users");
+    }
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,11 @@ import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Mirrors the [define] block in wrangler.toml; without it /api/v1/meta
+  // throws a ReferenceError (500) inside the test workers pool.
+  define: {
+    __APP_VERSION__: JSON.stringify("0.0.0-test"),
+  },
   plugins: [
     cloudflareTest({
       main: "./src/index.ts",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,6 +36,15 @@ INSTANCE_MODE = "single"
 #                            purges older raw heartbeats; aggregated `summaries`
 #                            are unaffected. See docs/operations.md.
 # HEARTBEAT_RETENTION_DAYS = "90"
+# PUBLIC_STATS - Optional. The unauthenticated global stats endpoint
+#                (GET /api/v1/stats/{range}) aggregates all activity; on a
+#                single-user instance that is the owner's coding profile.
+#                Set to "false" (exact literal; trimmed, case-insensitive) to
+#                disable the endpoint — it then returns 404 to every request
+#                and does no cache/DB work. Unset or any other value = enabled
+#                (backward-compatible default). Recommended "false" for
+#                single-user instances. See docs/deployment-guide.md (Issue #156).
+# PUBLIC_STATS = "false"
 
 # OAuth & Session secrets (set via `wrangler secret put <NAME>`)
 # GITHUB_CLIENT_ID


### PR DESCRIPTION
## Summary

PR2 (Implementation) of the SpecKit 2-PR workflow for #156; the contract landed in #160. Implements tasks T004-T011 of `specs/156-public-stats-optout/tasks.md`.

When the instance variable `PUBLIC_STATS` is the literal `false` (trimmed, case-insensitive), `GET /api/v1/stats/{range}` returns the standard `404` body **before** range validation, the KV cache, and D1 — for every range value — so probing cannot distinguish "disabled" from "absent" and a disabled endpoint generates no load. Any other value, or unset, leaves behavior byte-for-byte unchanged (backward-compatible default, research D-2/D-3).

## Changes

- `src/types.ts` — `PUBLIC_STATS?: string` on `Env` (manual bindings file)
- `src/routes/meta.ts` — early-return gate as the first statement of `getGlobalStats` (plan "Structure Decision", research D-4)
- `tests/integration/global-stats.test.ts` — 7 new cases: disabled valid/invalid-range parity (FR-002), no cache write + pre-seeded cache not served (FR-003), default unchanged for unset/`"true"`/unrecognized values (FR-001/FR-005), case/whitespace tolerance, scope: other public endpoints + authenticated per-user stats unaffected (FR-006)
- `tests/env.d.ts` — `PUBLIC_STATS` added to the test `Cloudflare.Env` augmentation
- `vitest.config.mts` — `define: { __APP_VERSION__ }` mirroring `wrangler.toml [define]`; without it `/api/v1/meta` throws a ReferenceError (500) in the test pool, which blocked the FR-006 scope test (pre-existing test-env gap, surfaced by this PR)
- `wrangler.toml` — commented `PUBLIC_STATS` entry under `[vars]` (FR-008)
- `docs/deployment-guide.md` — privacy section recommending `"false"` for single-user instances (FR-008, SC-004)

## Testing

- `npm run typecheck` clean
- `npm test`: 28 files / 331 tests passed (324 baseline + 7 new)

Closes #156. Refs #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)