### PR TITLE
spec: optional owner allowlist for the single-user first login (PR1)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/156-public-stats-optout"
+  "feature_directory": "specs/157-owner-allowlist"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,5 +50,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/156-public-stats-optout/plan.md`
+`specs/157-owner-allowlist/plan.md`
 <!-- SPECKIT END -->

--- a/schemas/paths/auth/provider-callback.yaml
+++ b/schemas/paths/auth/provider-callback.yaml
@@ -36,6 +36,13 @@ get:
        always requires manual PendingLink approval.
     6. **Session fixation prevention:** Always create a new session after successful
        authentication. Invalidate any pre-authentication session. Never reuse session IDs.
+    7. **Single-user owner allowlist (optional):** when the instance variable
+       `ALLOWED_OWNER_EMAIL` is set (non-blank) and the instance runs in
+       single-user mode, the first-login bootstrap only accepts an identity
+       whose provider-verified email equals the configured value (trimmed,
+       case-insensitive; a missing verified email is rejected). Any other
+       identity receives the same `403` used once registration is closed, so
+       responses do not reveal whether an allowlist is configured (#157).
 
     **Token endpoint Content-Type:** All three providers require
     `application/x-www-form-urlencoded` (per RFC 6749 §4.1.3). Discord is notably strict —

--- a/specs/157-owner-allowlist/checklists/requirements.md
+++ b/specs/157-owner-allowlist/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Optional owner allowlist for the single-user first login
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- House style (see `specs/134-insights-hours-of-day/`, `specs/156-public-stats-optout/`):
+  the Background section locates existing behavior with concrete file paths;
+  "no implementation details" is read as "no prescriptive implementation
+  choices". Marked passing on that basis.
+- The contentious decisions (identity attribute, bootstrap-only scope,
+  indistinguishable rejection, fail-closed matching) were fixed in advance by
+  GitHub Issue #157, so no [NEEDS CLARIFICATION] markers were required.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/157-owner-allowlist/contracts/openapi-diff.md
+++ b/specs/157-owner-allowlist/contracts/openapi-diff.md
@@ -1,0 +1,35 @@
+# OpenAPI Contract Diff: owner allowlist for the single-user first login
+
+**Branch**: `157-owner-allowlist`
+**Files**: `schemas/paths/auth/provider-callback.yaml` (operation `oauthCallback`)
+
+This PR1 change is **documentation-only**: one paragraph added to the
+operation `description`. No parameter, schema, status code, or response-shape
+changes — the `403` response (`$ref` shared `Forbidden`) the gate reuses is
+already part of the contract.
+
+## 1. Operation description — document the owner allowlist
+
+**Insertion point**: after the numbered "Security checks performed" list
+item 6 ("Session fixation prevention"), as a new item 7 (keeping the list
+numbering contiguous):
+
+```
+    7. **Single-user owner allowlist (optional):** when the instance variable
+       `ALLOWED_OWNER_EMAIL` is set (non-blank) and the instance runs in
+       single-user mode, the first-login bootstrap only accepts an identity
+       whose provider-verified email equals the configured value (trimmed,
+       case-insensitive; a missing verified email is rejected). Any other
+       identity receives the same `403` used once registration is closed, so
+       responses do not reveal whether an allowlist is configured (#157).
+```
+
+No other line in the file changes.
+
+## Generated types impact
+
+- `src/types/generated.ts`: JSDoc-only — the `oauthCallback` operation
+  description comment gains the new paragraph. No type, parameter, or
+  response member changes.
+- Verified by `npm run generate` followed by reviewing the `git diff` of
+  `src/types/generated.ts` (expected: description JSDoc lines only).

--- a/specs/157-owner-allowlist/data-model.md
+++ b/specs/157-owner-allowlist/data-model.md
@@ -1,0 +1,26 @@
+# Data Model: Optional owner allowlist for the single-user first login
+
+**Branch**: `157-owner-allowlist` | **Date**: 2026-06-10
+
+This feature introduces **no persisted data changes**: no new tables, no new
+columns, no new KV keys, no migrations.
+
+## Configuration (not persisted)
+
+| Name | Where | Type | Values | Default |
+|------|-------|------|--------|---------|
+| `ALLOWED_OWNER_EMAIL` | Workers `[vars]` or secret binding (`Env`, `src/types.ts`, PR2) | `string \| undefined` | non-blank ⇒ gate active, matched trimmed/case-insensitively against the provider-verified email; unset/blank ⇒ gate inactive | unset ⇒ inactive |
+
+State transitions: none at runtime — Workers vars are immutable per
+deployment. The gate consults the value only during the login callback's
+new-user creation branch; after the owner exists that branch is unreachable
+in practice (the only-if-no-users guard closes it), so the variable becomes
+inert post-bootstrap.
+
+## Touched (unchanged) data surfaces
+
+- **`users` (D1)**: the gate runs strictly before the bootstrap INSERT; on
+  rejection no row is written. The atomic only-if-no-users guard is
+  unchanged and still arbitrates concurrent allowed logins.
+- **`oauth_accounts`, `pending_links`, `sessions`**: untouched — rejected
+  identities reach none of them.

--- a/specs/157-owner-allowlist/plan.md
+++ b/specs/157-owner-allowlist/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Optional owner allowlist for the single-user first login
+
+**Branch**: `157-owner-allowlist` | **Date**: 2026-06-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/157-owner-allowlist/spec.md`
+
+## Summary
+
+Add an optional `ALLOWED_OWNER_EMAIL` instance variable. When set (non-blank) and `INSTANCE_MODE=single`, the new-user creation path of the OAuth login callback only proceeds if the identity's provider-verified email equals the configured value (trimmed, case-insensitive); every other identity — including ones with no usable verified email — receives the existing registration-closed `403`, byte-identical, with detail going to operator logs only (provider + candidate email domain). This binds the first-login bootstrap to an identity the operator controls, closing the audit's owner-race finding at the code level (Issue #157). Unset or blank = current behavior.
+
+**PR1 (this PR)**: SpecKit artifacts + a documentation paragraph in the `oauthCallback` operation description + regenerated types (JSDoc only — the `403` status and `Forbidden` body shape are already part of the contract). **No route, config, or behavior changes.**
+
+**PR2 (after PR1 merges)**: `Env.ALLOWED_OWNER_EMAIL`; a pure matching helper (`src/utils/owner-allowlist.ts`) unit-tested in `tests/security/`; the gate in the new-user creation path of `src/routes/auth/login.ts`; an OAuth-callback integration test using the workers-pool `fetchMock` if feasible (first such harness in the repo — fallback documented in research D-6); operator docs (`wrangler.toml` comment + deployment-guide race section update).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: none — no D1 schema change, no KV change. The variable is a Workers `[vars]`/secret binding read during the login callback only.
+**Testing**: Vitest + workers pool. Unit tests for the pure helper in `tests/security/owner-allowlist.test.ts` (unset/blank passes through; match/mismatch; case+whitespace folding; null email fails closed). Integration: the callback requires mocked provider HTTP; `cloudflare:test` exposes `fetchMock` (undici MockAgent) — planned as the repo's first OAuth-callback integration test (initiate → capture state cookie + redirect → mock token/user endpoints → callback), with a documented fallback to helper-level coverage if the harness proves unstable (research D-6).
+**Performance Goals**: <10ms CPU — one string comparison on the (cold) new-user path; zero work on every other path.
+**Constraints**: rejection must be byte-identical to the registration-closed `403` (FR-004); full candidate address never logged (FR-005); gate must sit strictly inside the single-user new-user creation branch (FR-006).
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Operation-description prose lands first (PR1) with regenerated types; helper, gate, tests, and docs follow in PR2. No status/shape change — additive documentation only. |
+| II. Cloudflare-Native | PASS | A per-login string compare; no new storage, no new platform usage. `[vars]`/secret is the idiomatic configuration surface. |
+| III. Type Safety | PASS | `Env.ALLOWED_OWNER_EMAIL` lives in the manual bindings file `src/types.ts` (PR2); generated types regenerated, never hand-edited. |
+| IV. Legal/Trademark | PASS | CloudTime-specific bootstrap policy; no third-party behavior consulted. |
+| V. Simplicity First | PASS | One env var, one pure helper, one early-return gate. Single address (not a list), one matching rule, no per-provider variables. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/157-owner-allowlist/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/paths/auth/provider-callback.yaml   # CHANGE: owner-allowlist paragraph in the operation description
+src/types/generated.ts                      # REGENERATED (npm run generate; JSDoc-only diff)
+
+# PR2 (after PR1 merges)
+src/types.ts                                # CHANGE: ALLOWED_OWNER_EMAIL?: string on Env (manual bindings file)
+src/utils/owner-allowlist.ts                # NEW: pure helper — ownerAllowlistRejects(allowedRaw, providerEmail)
+src/routes/auth/login.ts                    # CHANGE: gate in the single-user new-user creation branch
+tests/security/owner-allowlist.test.ts      # NEW: unit tests for the helper
+tests/integration/oauth-owner-allowlist.test.ts  # NEW (if fetchMock harness is viable): end-to-end callback cases
+tests/env.d.ts                              # CHANGE: ALLOWED_OWNER_EMAIL on the test Env augmentation
+wrangler.toml                               # CHANGE: commented ALLOWED_OWNER_EMAIL entry
+docs/deployment-guide.md                    # CHANGE: race section gains the code-level mitigation
+```
+
+**Structure Decision**: The matching rule lives in a pure helper so the security-relevant logic is unit-testable without the OAuth harness: `ownerAllowlistRejects(allowedRaw: string | undefined, providerEmail: string | null): boolean` returns `false` when `allowedRaw` is unset/blank (gate inactive) and otherwise compares trimmed, lower-cased values, treating a null/absent email as a rejection (fail closed). The gate sits in `src/routes/auth/login.ts` immediately after `const isSingleUser = …` in the new-user creation section — after the existing email-verified gate (so `providerEmail` semantics are settled) and before any INSERT or token-encryption work. On rejection it logs `[owner-allowlist] rejected provider=… reason=… candidate_domain=…` and returns the exact registration-closed body via the existing literal. Existing-user logins return earlier in the handler and never reach the gate; the link flow is a different route; multi-user mode short-circuits on `isSingleUser`.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add the owner-allowlist paragraph to the `oauthCallback` description; `npm run generate`; `npm run typecheck`.
+- **PR2 — Implementation**: helper + unit tests; `Env` + gate; fetchMock integration test (or documented fallback); `wrangler.toml` + deployment-guide docs; `npm test` green; PR referencing #157 and PR1.
+
+## Risks & Mitigations
+
+- **Operator typo locks out the bootstrap** → blank values deactivate the gate (never lock out by accident of emptiness); a typo'd address still requires only a config fix + redeploy because nothing has been claimed yet. Documented in the deployment guide (PR2).
+- **Owner's provider email changes before first login** → same recovery: fix the variable, redeploy; no state involved.
+- **fetchMock harness instability** (first OAuth integration test in the repo) → helper-level unit tests carry the security logic regardless; the integration test is additive coverage with a documented fallback (research D-6).
+- **Accidental scope creep onto linking/existing logins** → gate placement inside the new-user branch only, plus explicit US2 scenarios verifying linked-account logins and the link flow are untouched.
+- **Response divergence reveals the allowlist** → the rejection reuses the same literal as the registration-closed path; US3 test asserts byte-identical bodies.

--- a/specs/157-owner-allowlist/quickstart.md
+++ b/specs/157-owner-allowlist/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: validating the owner allowlist
+
+**Branch**: `157-owner-allowlist` | **Scope**: PR2 behavior (PR1 ships documentation only)
+
+## Prerequisites
+
+- `npm install`, local D1 initialized (`npm run db:init`) with an **empty
+  `users` table** (the gate only matters before bootstrap)
+- A configured OAuth provider for local testing (or rely on the automated
+  tests below — manual OAuth round-trips need real provider credentials)
+
+## Scenario 1 — default: variable unset, behavior unchanged
+
+With `ALLOWED_OWNER_EMAIL` absent from `[vars]`: first OAuth login creates
+the owner exactly as today; a second identity's login returns
+`403 {"error":"Registration closed. This instance only allows one user."}`.
+
+## Scenario 2 — allowlist active: only the configured email can bootstrap
+
+Add to `wrangler.toml` `[vars]` (or `wrangler secret put ALLOWED_OWNER_EMAIL`):
+
+```toml
+ALLOWED_OWNER_EMAIL = "owner@example.com"
+```
+
+- First login with a provider account whose **verified** email is
+  `owner@example.com` (any letter case) → owner created, login completes.
+- First login with any other account → `403` with the registration-closed
+  body — byte-identical to Scenario 1's post-bootstrap rejection — and a
+  `[owner-allowlist] rejected provider=… reason=email-mismatch
+  candidate_domain=…` line in `wrangler tail`. No user row is created.
+
+## Scenario 3 — scope: nothing else is constrained
+
+With the variable still set and the owner bootstrapped:
+
+- The owner's logins via already-linked providers succeed regardless of
+  email.
+- `POST /api/v1/auth/link/{provider}` (session required) links additional
+  providers as today.
+- In `INSTANCE_MODE=multi`, the variable is ignored entirely.
+
+## Automated validation (PR2)
+
+- `tests/security/owner-allowlist.test.ts` — pure matching rule: unset/blank
+  deactivates; match (case/whitespace folded) passes; mismatch and missing
+  email reject.
+- `tests/integration/oauth-owner-allowlist.test.ts` (fetchMock harness,
+  research D-6) — end-to-end callback: allowed email bootstraps; mismatched
+  email gets the byte-identical registration-closed 403 and writes no rows.
+
+```bash
+npm run typecheck && npm test
+```
+
+Contract references: [contracts/openapi-diff.md](./contracts/openapi-diff.md)
+· decisions: [research.md](./research.md) · config surface:
+[data-model.md](./data-model.md)

--- a/specs/157-owner-allowlist/research.md
+++ b/specs/157-owner-allowlist/research.md
@@ -1,0 +1,142 @@
+# Research: Optional owner allowlist for the single-user first login
+
+**Branch**: `157-owner-allowlist` | **Date**: 2026-06-10
+
+No `NEEDS CLARIFICATION` markers remained in the spec — Issue #157 fixed the
+contentious decisions. This document records those decisions and the
+alternatives considered.
+
+## D-1: Identity attribute — the provider-verified email, one variable
+
+**Decision**: A single `ALLOWED_OWNER_EMAIL` matched against the
+provider-verified email, uniformly across GitHub, Google, and Discord.
+
+**Rationale**: The operator knows their email before ever logging in;
+provider user IDs (GitHub numeric id, Google `sub`, Discord snowflake) are
+stable but practically undiscoverable until after a login — useless for
+configuring a not-yet-bootstrapped instance. Usernames are not uniformly
+unique (Google has no username; Discord global names are display names).
+The callback already refuses logins whose email the provider has not
+verified, and providers verify addresses by inbox challenge — so a verified
+email is proof of mailbox/provider-account control, exactly the identity
+property the bootstrap needs.
+
+**Alternatives considered**:
+- Per-provider vars (`ALLOWED_OWNER_GITHUB`, …) matching usernames/IDs —
+  rejected: three variables with three different semantics, two of which are
+  weak (mutable usernames, no Google username) or undiscoverable (IDs).
+- An allowlist of multiple addresses — rejected: single-user mode bootstraps
+  exactly one owner; a list is dead complexity (Principle V). Compatible to
+  add later.
+
+## D-2: Scope — new-user creation in single-user mode only
+
+**Decision**: The gate runs only in the login callback's new-user creation
+branch when `INSTANCE_MODE` is single. Existing-user logins, the
+authenticated link flow, the PendingLink flow, and multi-user mode are
+untouched. Unset/blank variable = gate inactive.
+
+**Rationale**: The audit finding is the bootstrap race — the only moment an
+unauthenticated stranger can acquire anything. After bootstrap, the
+only-if-no-users guard already closes registration; constraining later
+logins would add lockout risk (the owner's email can change at the provider)
+for zero security gain. Multi-user registration policy belongs to the
+invite-registration design (#148).
+
+**Alternatives considered**:
+- Enforcing the email on every owner login — rejected: lockout risk on
+  provider-side email changes; no threat addressed (the OAuth account link,
+  not the email, is the owner's credential after bootstrap).
+- Applying in multi-user mode — rejected: out of scope; #148 owns it.
+
+## D-3: Matching rule — trimmed, case-insensitive equality; fail closed
+
+**Decision**: `allowed.trim().toLowerCase() === email.trim().toLowerCase()`;
+a null/absent provider email while the variable is set is a mismatch.
+A blank (empty/whitespace-only) variable deactivates the gate.
+
+**Rationale**: Email local-parts are case-insensitive in practice at every
+supported provider, and trimming absorbs copy-paste accidents. Failing
+closed on a missing email is the safe default for a security gate; the
+existing email-verified gate makes that case rare. Blank-deactivates
+mirrors how an unset var behaves and prevents a stray space from locking
+the bootstrap.
+
+**Alternatives considered**:
+- Strict byte equality — rejected: case differences in configured values
+  would reject the legitimate owner for no security benefit.
+- Unicode/IDN normalization beyond lowercasing — rejected: provider-verified
+  addresses are returned in a canonical form; extra normalization is
+  speculative complexity.
+
+## D-4: Rejection response — reuse the registration-closed 403
+
+**Decision**: Mismatches return status and body byte-identical to the
+existing `403 {"error":"Registration closed. This instance only allows one
+user."}`.
+
+**Rationale**: A distinct message would tell a prober that an allowlist
+exists and that the instance is unclaimed — both useful to an attacker. The
+registration-closed body is already the documented contract for "you cannot
+register here" and is what the same request returns five minutes later once
+the owner has bootstrapped.
+
+**Alternatives considered**:
+- Dedicated "identity not allowed" message — rejected: information leak,
+  plus a new documented error string (contract surface) for no operator
+  benefit.
+- `404` — rejected: the callback endpoint must exist for the OAuth
+  round-trip; a 404 here would be incoherent and break provider tooling.
+
+## D-5: Observability — log reason + provider + candidate domain only
+
+**Decision**: One `console.warn` per rejection:
+`[owner-allowlist] rejected provider=<p> reason=<email-mismatch|email-missing> candidate_domain=<domain|(none)>`.
+
+**Rationale**: The operator needs to see that the gate fired (and against
+whom, roughly) to debug their own typo'd config; the full candidate address
+is third-party PII and is never logged — the same hygiene the hosted-domain
+restriction (`[google-hosted-domain] rejected …`) and the email pipeline
+(`recipient_domain=`) already follow.
+
+**Alternatives considered**:
+- Logging the full candidate email — rejected: PII in logs, against the
+  established pattern.
+- No logging — rejected: a typo'd `ALLOWED_OWNER_EMAIL` would be
+  undiagnosable (every login mysteriously "closed").
+
+## D-6: Test strategy — pure helper + first OAuth fetchMock integration test
+
+**Decision**: Extract the matching rule into `src/utils/owner-allowlist.ts`
+and unit-test it exhaustively in `tests/security/owner-allowlist.test.ts`.
+Additionally attempt the repo's first OAuth-callback integration test using
+`fetchMock` from `cloudflare:test` (undici MockAgent): GET
+`/api/v1/auth/github` → capture the state cookie and redirect → mock
+`github.com/login/oauth/access_token`, `api.github.com/user`,
+`api.github.com/user/emails` → GET the callback with code+state+cookie, and
+assert the allow/reject matrix end-to-end.
+
+**Rationale**: The security logic must not depend on a novel harness to be
+tested — the pure helper carries it. But the gate's placement (only the
+new-user branch) is exactly the kind of wiring a unit test cannot see, and
+an OAuth integration harness pays for itself for #157's siblings (#148
+multi-user, future provider work).
+
+**Fallback**: If the fetchMock harness proves unstable in the workers pool
+(e.g., outbound interception conflicts), ship PR2 with helper unit tests
+plus a direct-handler test that stubs `exchangeCode`/`fetchUserInfo` is NOT
+attempted (module mocking in workers pool is unreliable); instead document
+the gap in the PR and fold the harness into a follow-up issue. The helper
+tests still cover FR-001/002/003 logic exactly.
+
+## D-7: Configuration surface — `[vars]` or secret, documented next to the race warning
+
+**Decision**: Document `ALLOWED_OWNER_EMAIL` as a commented `wrangler.toml`
+`[vars]` entry and amend the deployment guide's "Critical: First-login owner
+race" section to present the variable as the code-level mitigation, with
+the existing log-in-immediately procedure as the universal baseline.
+
+**Rationale**: The value is not a secret (it gates, it does not
+authenticate), so `[vars]` is appropriate; operators who prefer can set it
+via `wrangler secret put` identically. Placing the docs inside the existing
+race section puts the fix where the warning already is (SC-003).

--- a/specs/157-owner-allowlist/spec.md
+++ b/specs/157-owner-allowlist/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Optional owner allowlist for the single-user first login
+
+**Feature Branch**: `157-owner-allowlist`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: GitHub Issue #157. In single-user mode, whoever completes an OAuth login first becomes the permanent instance owner. The race window runs from the moment the Worker URL is reachable until the operator logs in themselves; today the only mitigation is operational discipline (`docs/deployment-guide.md` §"Critical: First-login owner race"). Found in the 2026-06-10 security audit.
+
+## Background
+
+Single-user mode bootstraps its owner on first OAuth login: the user-creation
+statement is guarded by an atomic "only if no users exist" condition
+(`src/routes/auth/login.ts`), which makes the claim race-free between
+concurrent requests — but not identity-bound. Anyone who discovers the Worker
+URL before the operator's first login can claim the instance permanently;
+recovery is destructive (re-bootstrap, ibid.).
+
+This feature adds an optional instance variable `ALLOWED_OWNER_EMAIL` that
+binds the bootstrap to an identity the operator controls. When set, the
+new-user creation path in single-user mode only accepts an OAuth identity
+whose **provider-verified email** equals the configured value; everyone else
+receives the same rejection the instance already gives once registration is
+closed, so probing cannot reveal that an allowlist exists.
+
+Design decisions fixed by Issue #157 (full rationale in `research.md`):
+
+- **One variable, matched on the verified email**, uniform across GitHub,
+  Google, and Discord. Stable provider IDs are undiscoverable before first
+  login; usernames are not uniformly unique across providers. The callback's
+  existing email-verified gate makes the email trustworthy — verifying an
+  address at a provider requires inbox access.
+- **Bootstrap-only scope.** The check gates only new-user creation in
+  single-user mode. Existing-owner logins, account linking, the PendingLink
+  flow, and multi-user mode are untouched. Unset (or blank) = no change.
+- **Indistinguishable rejection.** Mismatches get the existing
+  registration-closed `403`; detail (provider + candidate email domain, never
+  the full address) goes to operator logs only.
+
+The instance variable is orthogonal to `GOOGLE_HOSTED_DOMAIN` (both may
+apply) and to the planned multi-user invite registration (#148).
+
+This spec covers PR1 of the SpecKit 2-PR workflow: specification artifacts
+plus a documentation paragraph in the OAuth callback operation description
+(no status-code or response-shape change — `403` is already part of the
+contract) and regenerated types. Implementation follows in PR2.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator pins the owner identity before sharing the URL (Priority: P1)
+
+As an operator deploying a single-user CloudTime instance, I want to declare
+up front which account may become the owner, so that discovering my Worker
+URL before my first login is no longer enough to take over the instance.
+
+**Why this priority**: This is the entire feature — it closes the audit's
+first-login race finding at the code level instead of relying on operator
+speed.
+
+**Independent Test**: With `ALLOWED_OWNER_EMAIL` set and an empty users
+table, complete an OAuth identity flow whose verified email differs from the
+configured value — the response is the registration-closed `403` and no user
+is created. Repeat with the matching email — the owner is created and logged
+in normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty instance with `ALLOWED_OWNER_EMAIL=owner@example.com`, **When** a first login arrives whose provider-verified email is `owner@example.com`, **Then** the owner account is created and the login completes exactly as today.
+2. **Given** the same instance, **When** a first login arrives whose provider-verified email is any other address, **Then** the response is the existing registration-closed `403` body, no user row is created, and the instance remains claimable by the allowed identity.
+3. **Given** the same instance, **When** a first login arrives whose provider reports no verified email usable for matching, **Then** it is rejected the same way (a configured allowlist never falls open).
+4. **Given** matching is in effect, **When** the configured value and the provider email differ only in letter case or surrounding whitespace, **Then** they still match (trimmed, case-insensitive comparison).
+
+---
+
+### User Story 2 - Existing instances and the owner's daily logins are unaffected (Priority: P2)
+
+As the owner of an already-bootstrapped instance (or an operator who never
+sets the variable), I want nothing about login, linking, or registration
+behavior to change.
+
+**Why this priority**: The feature must be a pure opt-in; any regression to
+the established login flow is unacceptable.
+
+**Independent Test**: With the variable unset, all existing auth flows behave
+as today. With it set on an instance whose owner already exists, the owner's
+logins (matching email or not — their OAuth account is already linked) and
+provider-linking flows behave as today.
+
+**Acceptance Scenarios**:
+
+1. **Given** `ALLOWED_OWNER_EMAIL` is unset or blank (empty/whitespace-only), **When** any login arrives, **Then** behavior is unchanged from the current release.
+2. **Given** the owner already exists and the variable is set, **When** the owner logs in via an already-linked provider account, **Then** the login succeeds regardless of that account's email — the allowlist gates only new-user creation.
+3. **Given** the owner already exists, **When** a stranger attempts a first login, **Then** they receive the same registration-closed `403` as today (the allowlist adds no new observable behavior after bootstrap).
+4. **Given** the variable is set, **When** the owner links an additional provider via the authenticated linking flow, **Then** linking behaves as today (the allowlist does not constrain linking).
+
+---
+
+### User Story 3 - Rejection reveals nothing about the configuration (Priority: P3)
+
+As an operator, I do not want rejected probes to learn whether an allowlist
+is configured or what address it expects.
+
+**Why this priority**: Defense-in-depth; an attacker who learns the gating
+attribute could target the owner's mailbox or provider account instead.
+
+**Independent Test**: Compare the rejection produced by the allowlist with
+the rejection produced by closed registration — status and body are
+identical. Operator logs carry the distinguishing detail instead.
+
+**Acceptance Scenarios**:
+
+1. **Given** an allowlist mismatch, **When** the requester inspects the response, **Then** the status and body are byte-identical to the registration-closed rejection.
+2. **Given** an allowlist mismatch, **When** the operator inspects the logs, **Then** a log line identifies the rejection reason, the provider, and the candidate email's domain — never the full address.
+
+---
+
+### Edge Cases
+
+- **Blank configuration** (`""` or whitespace-only): treated as unset — the
+  gate is skipped entirely, preserving current behavior rather than locking
+  everyone out on a copy-paste accident.
+- **No verified email from the provider while the variable is set**: counts
+  as a mismatch (fail closed). The callback's existing email-verification
+  gate already rejects most such logins before this check.
+- **Multi-user mode**: the variable is ignored entirely; multi-user
+  registration policy is owned by the invite-registration plan (#148).
+- **Allowlist set after the owner already exists**: no effect — the gate sits
+  on the new-user creation path, which closed at bootstrap. It does not lock
+  out an existing owner whose email differs from the configured value.
+- **Interplay with `GOOGLE_HOSTED_DOMAIN`**: independent checks; a Google
+  login must satisfy both when both are configured.
+- **Race between two allowed-email logins**: unchanged — the existing atomic
+  only-if-no-users guard still decides the winner.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support an optional instance configuration variable `ALLOWED_OWNER_EMAIL`; when unset, empty, or whitespace-only, all behavior MUST be unchanged from the current release.
+- **FR-002**: When the variable is set and the instance runs in single-user mode, the new-user creation path of the OAuth login callback MUST proceed only if the identity's provider-verified email equals the configured value under trimmed, case-insensitive comparison.
+- **FR-003**: When the variable is set, an identity with no provider-verified email available for matching MUST be rejected (the gate fails closed).
+- **FR-004**: A rejected first login MUST receive a response identical in status and body to the existing registration-closed rejection, so responses do not reveal whether an allowlist is configured.
+- **FR-005**: Each allowlist rejection MUST be recorded in operator logs with the rejection reason, the provider, and the candidate email's domain; the full candidate address MUST NOT be logged.
+- **FR-006**: The gate MUST apply only to new-user creation in single-user mode: existing-user logins, the authenticated provider-linking flow, the PendingLink flow, and multi-user mode MUST be unaffected.
+- **FR-007**: The OAuth callback operation's API documentation MUST describe the owner-allowlist behavior (no status-code or response-shape change — the documented `403` is reused).
+- **FR-008**: Operator documentation MUST cover the variable: a commented entry in `wrangler.toml` and an update to the deployment guide's first-login-race section presenting it as the code-level mitigation alongside the existing operational steps.
+
+### Key Entities
+
+- **Instance configuration (`ALLOWED_OWNER_EMAIL`)**: a deployment-time variable, not persisted data. No schema or stored-data changes are involved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the variable set, zero non-matching identities can claim an unbootstrapped instance, regardless of how early they discover the URL — the first-login race is reduced to identities controlling the configured mailbox/provider account.
+- **SC-002**: Deployments that do not set the variable observe zero behavioral difference (100% backward compatibility).
+- **SC-003**: An operator can enable the protection with a single configuration change before first deploy, and the deployment guide documents it next to the existing race warning.
+- **SC-004**: Rejected probes receive responses indistinguishable from a closed instance; configuration details appear only in operator logs.
+
+## Assumptions
+
+- The provider-verified email is an acceptable owner identifier: all three
+  supported providers expose one, and the callback already refuses logins
+  whose email the provider has not verified. An attacker cannot get a
+  provider to mark someone else's address as verified without inbox access.
+- A single allowed address (not a list) is sufficient for the single-user
+  bootstrap; the variable name stays singular and the simplest contract wins
+  (Simplicity First). A list can be added compatibly later if ever needed.
+- Workers vars are immutable at runtime; changing the value requires a
+  redeploy. The gate is read per login attempt, so a redeploy takes effect
+  immediately.
+- The rejection-body reuse means no API contract change: the callback's
+  documented `403` response already covers this case.
+- Logging only the email domain follows the established log-hygiene pattern
+  used by the hosted-domain restriction and the email-delivery path.

--- a/specs/157-owner-allowlist/tasks.md
+++ b/specs/157-owner-allowlist/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Optional owner allowlist for the single-user first login
+
+**Input**: Design documents from `specs/157-owner-allowlist/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/openapi-diff.md, quickstart.md
+
+**Organization**: Phase 1 is PR1 (this branch — documentation contract only); Phases 2+ are PR2 (implementation, after PR1 merges). Tests are included because the spec's Independent Test criteria and the project testing baseline require them; the security-relevant matching rule is deliberately a pure helper so its tests do not depend on the new OAuth harness (research D-6).
+
+## Phase 1: Setup — PR1, documentation contract only (this branch)
+
+**Goal**: Land the documented owner-allowlist behavior on the `oauthCallback` operation with zero behavior change.
+
+- [ ] T001 Apply the contract diff in `specs/157-owner-allowlist/contracts/openapi-diff.md` to `schemas/paths/auth/provider-callback.yaml`: append security-checks list item 7 (single-user owner allowlist) to the operation `description`. Commit the spec change on its own.
+- [ ] T002 Run `npm run generate`; verify via `git diff src/types/generated.ts` that the only change is the `oauthCallback` description JSDoc. Commit the regenerated output separately (never hand-edit).
+- [ ] T003 Run `npm run typecheck`; push branch `157-owner-allowlist` and open PR1 targeting `develop`, referencing Issue #157 and noting "spec + types only, implementation in PR2".
+
+**Checkpoint**: PR1 open and green. Phases below start only after PR1 merges, on a fresh branch off `develop`.
+
+## Phase 2: Foundational — PR2 prerequisites (blocking all user stories)
+
+- [ ] T004 [P] Add `ALLOWED_OWNER_EMAIL?: string` to the `Env` interface in `src/types.ts` with an operator-facing comment (non-blank value gates the single-user first-login bootstrap to the matching provider-verified email; unset/blank = inactive; see research D-1/D-3).
+- [ ] T005 [P] Create `src/utils/owner-allowlist.ts`: pure `ownerAllowlistRejects(allowedRaw: string | undefined, providerEmail: string | null): boolean` — `false` when `allowedRaw` is unset or blank after trim; otherwise trimmed, case-insensitive comparison with a null/absent email counting as a rejection (fail closed, research D-3).
+- [ ] T006 [P] Add `ALLOWED_OWNER_EMAIL?: string` to the test Env augmentation in `tests/env.d.ts`.
+
+## Phase 3: User Story 1 — Operator pins the owner identity (P1) 🎯 MVP
+
+**Goal**: With the variable set on an unbootstrapped single-user instance, only the matching verified email can create the owner.
+
+**Independent Test**: Helper unit tests prove the matching rule; the integration callback test (or quickstart Scenario 2 manually) proves only the allowed identity bootstraps.
+
+- [ ] T007 [P] [US1] Create `tests/security/owner-allowlist.test.ts` covering: unset and blank/whitespace-only `allowedRaw` → never rejects (FR-001); exact match and case/whitespace-folded match → not rejected (FR-002, spec US1 scenario 4); mismatched email → rejected (FR-002); `null` email with the variable set → rejected (FR-003).
+- [ ] T008 [US1] Wire the gate in `src/routes/auth/login.ts`: immediately after `const isSingleUser = c.env.INSTANCE_MODE !== "multi";` in the new-user creation section, when `isSingleUser && ownerAllowlistRejects(c.env.ALLOWED_OWNER_EMAIL, userInfo.providerEmail)`, log `[owner-allowlist] rejected provider=<provider> reason=<email-mismatch|email-missing> candidate_domain=<domain|(none)>` (never the full address, FR-005) and return the exact existing literal `{ error: "Registration closed. This instance only allows one user." }` with 403 + `noCacheHeaders()` (FR-004).
+- [ ] T009 [US1] Create `tests/integration/oauth-owner-allowlist.test.ts` using `fetchMock` from `cloudflare:test` (research D-6): drive GET `/api/v1/auth/github` to capture the state cookie + redirect URL, mock `https://github.com/login/oauth/access_token` and `https://api.github.com/user` + `/user/emails`, then GET the callback. Cases: allowed verified email on an empty instance → 200, `is_new_user: true`, user row created; mismatched email → 403 with body equal to the registration-closed literal and zero `users` rows. If the harness proves unstable after reasonable effort, drop this file, keep T007, and document the gap + follow-up in the PR body (research D-6 fallback).
+
+**Checkpoint**: US1 deliverable — the bootstrap is identity-bound.
+
+## Phase 4: User Story 2 — Existing behavior untouched (P2)
+
+**Goal**: Unset variable, post-bootstrap logins, and linking are all unchanged.
+
+**Independent Test**: Full existing suite stays green (no test modifications needed); added cases assert the gate's inactivity.
+
+- [ ] T010 [US2] Extend the integration test (if T009 landed) with: variable unset → first login bootstraps any identity exactly as today (FR-001); variable set but owner already exists → a stranger's login returns the same registration-closed 403 as today (no observable change, spec US2 scenario 3). If T009 was dropped, these are covered by T007's unset/blank cases plus the untouched existing suite — note in the PR body.
+
+## Phase 5: User Story 3 — Rejection indistinguishability (P3)
+
+**Goal**: Allowlist rejections are byte-identical to registration-closed rejections; detail lives in logs only.
+
+**Independent Test**: Body-equality assertion between the two rejection paths; code review confirms the log line carries domain only.
+
+- [ ] T011 [US3] In the integration test (if T009 landed), assert the allowlist rejection body deep-equals the post-bootstrap registration-closed body (spec US3 scenario 1). If T009 was dropped, assert in T007 that the helper exposes no message material (it returns only a boolean) and verify the literal reuse by review — note in the PR body.
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T012 [P] Add a commented `ALLOWED_OWNER_EMAIL` entry under `[vars]` in `wrangler.toml` documenting activation, matching rule, and the blank-deactivates behavior (FR-008, research D-7).
+- [ ] T013 [P] Update `docs/deployment-guide.md` §"Critical: First-login owner race": present `ALLOWED_OWNER_EMAIL` as the code-level mitigation (set it BEFORE first deploy), keep the log-in-immediately procedure as the baseline, and note the typo-recovery path (fix value, redeploy — nothing claimed yet) (FR-008, SC-003).
+- [ ] T014 Run `npm run typecheck && npm test` (all suites green); open PR2 targeting `develop`, referencing Issue #157 and PR1.
+
+## Dependencies
+
+- T001 → T002 → T003 (strict commit order, Constitution I)
+- PR1 merge gates everything below
+- T004, T005, T006 independent of each other ([P]); T005 blocks T007 and T008; T004+T006 block T008/T009 type-wise
+- T008 blocks T009/T010/T011 (the gate must exist before end-to-end cases)
+- T012, T013 independent of code tasks; T014 last
+
+## Parallel Example
+
+After PR1 merges, on the PR2 branch:
+
+```text
+# Wave 1 (parallel): T004 src/types.ts | T005 src/utils/owner-allowlist.ts | T006 tests/env.d.ts
+# Wave 2 (parallel): T007 helper unit tests | T012 wrangler.toml | T013 deployment guide
+# Wave 3 (serial):   T008 gate → T009 integration harness → T010/T011 cases → T014 verify + PR
+```
+
+## Implementation Strategy
+
+MVP = Phase 3 (US1): the pure helper + gate + its tests close the audit finding. US2 is regression assurance (zero code — only test cases), US3 is a single body-equality assertion. The fetchMock harness (T009) is the only risky item and has an explicit, pre-agreed fallback (research D-6) so it cannot block the security fix. Ship PR2 as one small PR.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -103,6 +103,13 @@ export interface paths {
          *        always requires manual PendingLink approval.
          *     6. **Session fixation prevention:** Always create a new session after successful
          *        authentication. Invalidate any pre-authentication session. Never reuse session IDs.
+         *     7. **Single-user owner allowlist (optional):** when the instance variable
+         *        `ALLOWED_OWNER_EMAIL` is set (non-blank) and the instance runs in
+         *        single-user mode, the first-login bootstrap only accepts an identity
+         *        whose provider-verified email equals the configured value (trimmed,
+         *        case-insensitive; a missing verified email is rejected). Any other
+         *        identity receives the same `403` used once registration is closed, so
+         *        responses do not reveal whether an allowlist is configured (#157).
          *
          *     **Token endpoint Content-Type:** All three providers require
          *     `application/x-www-form-urlencoded` (per RFC 6749 §4.1.3). Discord is notably strict —


### PR DESCRIPTION
## Summary

PR1 (Spec + Design) of the SpecKit 2-PR workflow for #157. **No implementation code** — design artifacts plus a documentation-only OpenAPI change; the helper, gate, tests, and operator docs follow in PR2.

In single-user mode, whoever completes an OAuth login first becomes the permanent owner; the race window is mitigated today only by operational discipline (2026-06-10 security audit). This feature adds an optional `ALLOWED_OWNER_EMAIL` instance variable: when set (non-blank), the first-login bootstrap only accepts an identity whose provider-verified email equals the configured value (trimmed, case-insensitive; missing email fails closed). Mismatches receive the **byte-identical** registration-closed `403`, so probing cannot reveal that an allowlist exists; detail goes to operator logs (provider + candidate domain only).

## Contents

- `specs/157-owner-allowlist/` — spec (3 user stories, FR-001…FR-008), plan (constitution check all-PASS), research (D-1…D-7: verified-email-as-identity, bootstrap-only scope, fail-closed matching, 403 reuse, log hygiene, fetchMock test strategy + fallback, config surface), data-model (no persisted data), contract diff, quickstart, tasks (14)
- `schemas/paths/auth/provider-callback.yaml` — security-checks item 7 documenting the allowlist. **No status/shape change** — the `403`/`Forbidden` response is already part of the contract
- `src/types/generated.ts` — regenerated; diff is JSDoc-only (7 lines)
- `CLAUDE.md` — SpecKit plan pointer updated

Commit order per constitution: SpecKit artifacts → spec change → `npm run generate` output.

## Testing

- `npm run lint:api` valid
- `npm run typecheck` clean
- `npm test`: full suite green (no behavior change in this PR)

Refs #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)