### PR TITLE
fix: anonymous OAuth login blocked by wildcard session middleware

### DIFF
--- a/src/routes/auth/sessions.ts
+++ b/src/routes/auth/sessions.ts
@@ -20,7 +20,18 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 const sessions = new Hono<SessionAuthEnv>();
 
-sessions.use("*", sessionMw);
+// Session auth is scoped to this sub-app's own paths instead of a `use("*")`
+// wildcard: when mounted in auth/index.ts the wildcard would also run for the
+// public login routes registered after this sub-app (GET /:provider and
+// GET /:provider/callback, deliberately mounted last because they are
+// parameterized) and reject anonymous OAuth initiate/callback with 401
+// (Issue #163).
+sessions.use("/session", sessionMw);
+sessions.use("/sessions", sessionMw);
+sessions.use("/sessions/:session_id", sessionMw);
+sessions.use("/providers", sessionMw);
+sessions.use("/providers/:provider", sessionMw);
+sessions.use("/api-key", sessionMw);
 
 // GET /session
 sessions.get("/session", async (c) => {

--- a/tests/integration/auth-route-mounting.test.ts
+++ b/tests/integration/auth-route-mounting.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression tests for Issue #163: the wildcard session middleware in the
+ * sessions sub-app must not intercept the public login routes mounted after
+ * it (GET /auth/:provider and GET /auth/:provider/callback). Anonymous
+ * clients must be able to start an OAuth login; the session-scoped routes
+ * must remain protected.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUserWithSession, truncate } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+
+afterEach(async () => {
+  await truncate("sessions", "oauth_accounts", "users");
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("auth route mounting (#163)", () => {
+  it("anonymous OAuth initiate redirects to the provider (no middleware 401)", async () => {
+    const res = await call("/api/v1/auth/github");
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("Location") ?? "");
+    expect(location.origin).toBe("https://github.com");
+    expect(location.searchParams.get("state")).toBeTruthy();
+    expect(res.headers.get("Set-Cookie")).toContain("__Host-oauth_state=");
+  });
+
+  it("anonymous callback reaches handler-level validation (400, not 401)", async () => {
+    const res = await call("/api/v1/auth/github/callback");
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing state or code" });
+  });
+
+  it("invalid provider still yields the handler's 400", async () => {
+    const res = await call("/api/v1/auth/nope");
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid provider" });
+  });
+
+  it("session-scoped routes remain protected for anonymous clients", async () => {
+    for (const path of ["/api/v1/auth/session", "/api/v1/auth/sessions", "/api/v1/auth/providers"]) {
+      const res = await call(path);
+      expect(res.status, path).toBe(401);
+    }
+    const apiKey = await call("/api/v1/auth/api-key", {
+      method: "POST",
+      headers: { Origin: BASE },
+    });
+    expect(apiKey.status).toBe(401);
+  });
+
+  it("session-scoped routes still work with a valid session", async () => {
+    const user = await seedUserWithSession({ username: "owner" });
+    const res = await call("/api/v1/auth/session", {
+      headers: { Cookie: `__Host-session=${user.sessionToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { user: { id: string } } };
+    expect(body.data.user.id).toBe(user.userId);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #163. `sessions.use("*", sessionMw)` in `src/routes/auth/sessions.ts` applied to every `/api/v1/auth/*` path registered after the `sessions` sub-app — which is exactly the public login sub-app (`GET /:provider`, `GET /:provider/callback`, mounted last because they are parameterized). Anonymous clients therefore received `401 Unauthorized` before the initiate/callback handlers ran: **new-instance bootstrap and any re-login after session expiry were broken**; only clients holding a still-valid session cookie could "log in".

Discovered by the first OAuth-callback integration harness, built for #157 PR2 (which is rebased on this fix next).

## Fix

Replace the wildcard with path-scoped registration covering exactly the sub-app''s own routes: `/session`, `/sessions`, `/sessions/:session_id`, `/providers`, `/providers/:provider`, `/api-key`. Same per-path pattern `link.ts` already uses. No handler logic changes.

No OpenAPI change: the documented contract for these operations (302 redirect on initiate, 400/403 on callback validation, 401 on session routes) is what this fix restores.

## Testing

- New `tests/integration/auth-route-mounting.test.ts` (5 cases): anonymous initiate → 302 to the provider with state cookie; anonymous callback → handler-level `400 Missing state or code` (not middleware 401); invalid provider → 400; session routes still 401 anonymously (incl. POST /api-key with Origin); session routes still work with a valid session cookie
- `npm run typecheck` clean
- `npm test`: 29 files / 336 tests passed (331 baseline + 5 new)

Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)