### PR TITLE
fix: provider fetches used redirect:'error', unsupported on Workers

### DIFF
--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -37,9 +37,17 @@ export interface ProviderUserInfo {
 /** Timeout for all outbound OAuth/provider HTTP requests. */
 const FETCH_TIMEOUT = 10_000;
 
-/** Shared fetch options for outbound provider requests (SSRF defense-in-depth). */
-const PROVIDER_FETCH_OPTS = {
-  redirect: "error" as const,
+/**
+ * Shared fetch options for outbound provider requests (SSRF defense-in-depth).
+ * Workers does not implement redirect: "error" — workerd throws a TypeError on
+ * any fetch/Request carrying it (Issue #165) — so redirects are refused with
+ * "manual": a 3xx comes back as-is and every call site's `!res.ok` /
+ * JSON-parse handling treats it as a failure, preserving the
+ * never-follow-redirects intent. Exported for the workerd-validity
+ * regression test.
+ */
+export const PROVIDER_FETCH_OPTS = {
+  redirect: "manual" as const,
   get signal(): AbortSignal {
     return AbortSignal.timeout(FETCH_TIMEOUT);
   },

--- a/tests/security/provider-fetch-opts.test.ts
+++ b/tests/security/provider-fetch-opts.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression tests for Issue #165: PROVIDER_FETCH_OPTS must be a valid
+ * Workers RequestInit. redirect: "error" is not implemented by workerd —
+ * fetch()/new Request() throw a TypeError when RequestInit carries it —
+ * which made every outbound OAuth provider call (token exchange, user info,
+ * JWKS, revocation) fail in production.
+ */
+import { describe, expect, it } from "vitest";
+import { PROVIDER_FETCH_OPTS } from "../../src/utils/oauth";
+
+describe("PROVIDER_FETCH_OPTS (#165)", () => {
+  it("is accepted by the Workers Request constructor", () => {
+    // This exact construction threw with redirect: "error".
+    expect(() => new Request("https://provider.example/", PROVIDER_FETCH_OPTS)).not.toThrow();
+  });
+
+  it("never follows redirects (SSRF defense intent preserved)", () => {
+    expect(PROVIDER_FETCH_OPTS.redirect).toBe("manual");
+  });
+
+  it("attaches a fresh timeout signal per request", () => {
+    const a = PROVIDER_FETCH_OPTS.signal;
+    const b = PROVIDER_FETCH_OPTS.signal;
+    expect(a).toBeInstanceOf(AbortSignal);
+    expect(b).not.toBe(a);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #165. `PROVIDER_FETCH_OPTS` (`src/utils/oauth.ts`) set `redirect: "error"` on every outbound OAuth provider request. The Workers runtime does not implement that value — workerd throws `TypeError: Invalid redirect value, must be one of "follow" or "manual"...` on any `fetch()`/`new Request()` carrying it — so the token exchange (and user-info fetch, JWKS fetch, token revocation) failed unconditionally, turning every OAuth callback into a 500.

Together with #163 (anonymous initiate 401, fixed in #164), OAuth login was broken end-to-end on `develop`. Both bugs were invisible to CI until the #157 PR2 integration harness exercised the provider round-trip; this is the second pre-existing P1 that harness has caught.

## Fix

`redirect: "manual"` — redirects are still never followed (the SSRF-defense intent): a 3xx response is returned as-is and every call site already fails on it via its `!res.ok` check or JSON-parse guard (`exchangeCode`, GitHub/Discord user-info fetches, `getGoogleJWKS`; revocation logs the failure). The constant is now exported for the regression test.

## Testing

- New `tests/security/provider-fetch-opts.test.ts` (3 cases): the init is accepted by the Workers `Request` constructor (this exact construction threw before), `redirect === "manual"`, and the timeout signal is fresh per request
- `npm run typecheck` clean
- `npm test`: 30 files / 339 tests passed (336 baseline + 3 new)
- The full callback path will additionally be exercised on every CI run by the #157 PR2 integration suite, which lands next

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)