### PR TITLE
feat: optional owner allowlist for the single-user first login (PR2)

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -135,6 +135,31 @@ WHERE (SELECT COUNT(*) FROM users) = 0
 
 Whoever completes OAuth login first becomes the permanent owner. The race window is **from the moment your Worker URL is reachable until you complete OAuth login from your own browser**.
 
+### Code-level mitigation: `ALLOWED_OWNER_EMAIL` (recommended)
+
+Set the owner identity **before** the Worker is first reachable and the race
+disappears: only an OAuth identity whose provider-verified email matches can
+claim the instance.
+
+```toml
+[vars]
+ALLOWED_OWNER_EMAIL = "you@example.com"
+```
+
+- Matching is trimmed and case-insensitive; the email must be **verified** at
+  the provider (GitHub primary verified email, Google, or Discord).
+- Everyone else receives the same `403 Registration closed` response the
+  instance returns once bootstrapped, so probes cannot tell an allowlist
+  exists. Rejections appear in `wrangler tail` as `[owner-allowlist]
+  rejected …` with the candidate's email domain only.
+- A typo cannot lock you out permanently: nothing has been claimed yet, so
+  fix the value and redeploy. An unset or blank value disables the gate.
+- The variable gates only the first-login bootstrap; it does not constrain
+  the owner's later logins or provider linking.
+
+The procedure below remains the universal baseline — and the only mitigation
+on instances that do not set the variable.
+
 ### What you must do
 
 1. **Do not share the Worker URL** in public channels, README files, status pages, or DM screenshots until step 2 is complete.

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -40,6 +40,7 @@ import {
   getStateCookie,
   clearStateCookie,
 } from "../../utils/session";
+import { ownerAllowlistRejects } from "../../utils/owner-allowlist";
 import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../../utils/user";
 import { getRedirectUri, noCacheHeaders } from "./helpers";
 
@@ -345,6 +346,22 @@ login.get("/:provider/callback", oauthCallbackRateLimit, async (c) => {
 
     // No existing account — new user creation
     const isSingleUser = c.env.INSTANCE_MODE !== "multi";
+
+    // Owner allowlist (Issue #157): when configured, the single-user
+    // bootstrap only accepts the matching provider-verified email. The
+    // response reuses the registration-closed literal so probing cannot
+    // reveal whether an allowlist exists (specs/157-owner-allowlist/).
+    if (isSingleUser && ownerAllowlistRejects(c.env.ALLOWED_OWNER_EMAIL, userInfo.providerEmail)) {
+      const email = userInfo.providerEmail;
+      const reason = email ? "email-mismatch" : "email-missing";
+      const domain = email?.includes("@") ? email.slice(email.indexOf("@") + 1) : "(none)";
+      console.warn(`[owner-allowlist] rejected provider=${provider} reason=${reason} candidate_domain=${domain}`);
+      return c.json(
+        { error: "Registration closed. This instance only allows one user." },
+        403,
+        noCacheHeaders(),
+      );
+    }
 
     // Single-user guard: don't clear email if we can't create a new user to take it
     if (isSingleUser && unverifiedUserId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,13 @@ export interface Env {
   // value, or unset, leaves it enabled.
   PUBLIC_STATS?: string;
 
+  // Optional owner allowlist for the single-user first-login bootstrap
+  // (Issue #157). When non-blank, only an OAuth identity whose
+  // provider-verified email equals this value (trimmed, case-insensitive)
+  // can create the owner; everyone else gets the registration-closed 403.
+  // Unset or blank = gate inactive. Inert after bootstrap and in multi mode.
+  ALLOWED_OWNER_EMAIL?: string;
+
   // Optional raw-heartbeat retention window in days (Issue #108). Unset or
   // non-positive = retain forever. When set, the hourly cron purges raw
   // heartbeats older than this many days; pre-aggregated `summaries` are

--- a/src/utils/owner-allowlist.ts
+++ b/src/utils/owner-allowlist.ts
@@ -1,0 +1,20 @@
+/**
+ * Owner allowlist matching rule (Issue #157, specs/157-owner-allowlist/).
+ *
+ * Pure so the security-relevant comparison is unit-testable without an
+ * OAuth harness. Returns true when the configured allowlist REJECTS the
+ * candidate:
+ * - an unset or blank (empty / whitespace-only) configuration never rejects
+ *   — the gate is inactive and current behavior is preserved;
+ * - otherwise trimmed, case-insensitive equality is required, and a missing
+ *   provider-verified email counts as a rejection (fail closed).
+ */
+export function ownerAllowlistRejects(
+  allowedRaw: string | undefined,
+  providerEmail: string | null,
+): boolean {
+  const allowed = allowedRaw?.trim().toLowerCase() ?? "";
+  if (allowed === "") return false;
+  if (!providerEmail) return true;
+  return providerEmail.trim().toLowerCase() !== allowed;
+}

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -23,6 +23,7 @@ declare global {
       ENCRYPTION_KEY: string;
       INSTANCE_MODE?: string;
       PUBLIC_STATS?: string;
+      ALLOWED_OWNER_EMAIL?: string;
       ENVIRONMENT?: string;
       APP_URL?: string;
       GOOGLE_HOSTED_DOMAIN?: string;

--- a/tests/integration/oauth-owner-allowlist.test.ts
+++ b/tests/integration/oauth-owner-allowlist.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for the single-user owner allowlist (Issue #157,
+ * specs/157-owner-allowlist/), driving the real GitHub login flow with the
+ * provider's HTTP endpoints stubbed.
+ *
+ * Note on the harness (research D-6): the plan called for the workers-pool
+ * `fetchMock`, but @cloudflare/vitest-pool-workers 0.16.x does not export it
+ * (the undici MockAgent types in cloudflare-test.d.ts are vestigial). Tests
+ * and the imported worker share one isolate here, so outbound provider calls
+ * are stubbed by swapping `globalThis.fetch` per test instead — same
+ * coverage, strictly failing on any un-stubbed outbound request.
+ *
+ * Flow per attempt: GET /auth/github captures the state cookie + redirect,
+ * then GET /auth/github/callback runs the full handler — token exchange,
+ * user-info fetch, email-verified gate, and the allowlist gate — against
+ * real in-memory D1/KV.
+ */
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const REGISTRATION_CLOSED = {
+  error: "Registration closed. This instance only allows one user.",
+};
+
+// ─── Outbound fetch stub ─────────────────────────────────
+
+interface StubRoute {
+  method: string;
+  url: string; // "<origin><pathname>"
+  body: unknown;
+  hits: number;
+}
+
+const originalFetch = globalThis.fetch;
+let routes: StubRoute[] = [];
+
+function stubRoute(method: string, url: string, body: unknown): void {
+  routes.push({ method, url, body, hits: 0 });
+}
+
+beforeEach(() => {
+  routes = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = new Request(input, init);
+    const u = new URL(req.url);
+    const key = `${req.method} ${u.origin}${u.pathname}`;
+    const route = routes.find((r) => `${r.method} ${r.url}` === key);
+    if (!route) {
+      throw new Error(`Unexpected outbound fetch in test: ${key}`);
+    }
+    route.hits++;
+    return new Response(JSON.stringify(route.body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  for (const r of routes) {
+    expect(r.hits, `stubbed route never hit: ${r.method} ${r.url}`).toBeGreaterThan(0);
+  }
+  await truncate("sessions", "oauth_accounts", "users");
+});
+
+// ─── Flow helpers ────────────────────────────────────────
+
+async function call(
+  path: string,
+  init: RequestInit = {},
+  envOverrides: Partial<Cloudflare.Env> = {},
+): Promise<Response> {
+  const ctx = createExecutionContext();
+  const testEnv = { ...env, ...envOverrides };
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), testEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+/** Start a GitHub login and capture the state param + double-submit cookie. */
+async function startLogin(
+  envOverrides: Partial<Cloudflare.Env> = {},
+): Promise<{ state: string; cookie: string }> {
+  const res = await call("/api/v1/auth/github", {}, envOverrides);
+  expect(res.status).toBe(302);
+  const location = new URL(res.headers.get("Location") ?? "");
+  const state = location.searchParams.get("state");
+  const setCookie = res.headers.get("Set-Cookie") ?? "";
+  const match = setCookie.match(/__Host-oauth_state=([^;]+)/);
+  expect(state).toBeTruthy();
+  expect(match).toBeTruthy();
+  return { state: state as string, cookie: `__Host-oauth_state=${match![1]}` };
+}
+
+/** Stub the three GitHub endpoints one callback invocation hits. */
+function mockGitHub(opts: { id: number; login: string; email: string }): void {
+  stubRoute("POST", "https://github.com/login/oauth/access_token", {
+    access_token: "test-access-token",
+    token_type: "bearer",
+    scope: "read:user,user:email",
+  });
+  stubRoute("GET", "https://api.github.com/user", { id: opts.id, login: opts.login });
+  stubRoute("GET", "https://api.github.com/user/emails", [
+    { email: opts.email, primary: true, verified: true },
+  ]);
+}
+
+async function completeLogin(
+  ghUser: { id: number; login: string; email: string },
+  envOverrides: Partial<Cloudflare.Env> = {},
+): Promise<Response> {
+  const { state, cookie } = await startLogin(envOverrides);
+  mockGitHub(ghUser);
+  return call(
+    `/api/v1/auth/github/callback?code=test-code&state=${state}`,
+    { headers: { Cookie: cookie } },
+    envOverrides,
+  );
+}
+
+async function userCount(): Promise<number> {
+  const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM users").first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+// ─── Cases ───────────────────────────────────────────────
+
+describe("single-user owner allowlist (#157)", () => {
+  const ALLOW = { ALLOWED_OWNER_EMAIL: "owner@example.test" };
+
+  it("allowed verified email bootstraps the owner (US1)", async () => {
+    const res = await completeLogin(
+      { id: 1001, login: "owner", email: "owner@example.test" },
+      ALLOW,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { is_new_user: boolean } };
+    expect(body.data.is_new_user).toBe(true);
+    expect(await userCount()).toBe(1);
+  });
+
+  it("matches case-insensitively with surrounding whitespace (US1 scenario 4)", async () => {
+    const res = await completeLogin(
+      { id: 1002, login: "owner", email: "Owner@Example.TEST" },
+      { ALLOWED_OWNER_EMAIL: " owner@example.test " },
+    );
+    expect(res.status).toBe(200);
+    expect(await userCount()).toBe(1);
+  });
+
+  it("mismatched email gets the registration-closed 403 and writes nothing (US1)", async () => {
+    const res = await completeLogin(
+      { id: 2001, login: "intruder", email: "intruder@example.test" },
+      ALLOW,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(REGISTRATION_CLOSED);
+    expect(await userCount()).toBe(0);
+  });
+
+  it("rejection is byte-identical to the post-bootstrap registration-closed response (US3)", async () => {
+    // Allowlist rejection on an empty instance...
+    const rejected = await completeLogin(
+      { id: 2002, login: "intruder", email: "intruder@example.test" },
+      ALLOW,
+    );
+    expect(rejected.status).toBe(403);
+    const allowlistBody = await rejected.text();
+
+    // ...versus today's registration-closed rejection (owner exists, no allowlist).
+    await seedUser({ username: "owner" });
+    const closed = await completeLogin({
+      id: 2003,
+      login: "stranger",
+      email: "stranger@example.test",
+    });
+    expect(closed.status).toBe(403);
+    expect(await closed.text()).toBe(allowlistBody);
+  });
+
+  it("variable unset: any verified identity bootstraps exactly as today (US2/FR-001)", async () => {
+    const res = await completeLogin({
+      id: 3001,
+      login: "anyone",
+      email: "anyone@example.test",
+    });
+    expect(res.status).toBe(200);
+    expect(await userCount()).toBe(1);
+  });
+
+  it("owner already exists: a stranger gets the same 403 whether or not the allowlist is set (US2 scenario 3)", async () => {
+    await seedUser({ username: "owner", email: "owner@example.test" });
+    const res = await completeLogin(
+      { id: 4001, login: "stranger", email: "owner@example.test" },
+      ALLOW,
+    );
+    // Email matches the allowlist, but the instance is already claimed —
+    // the existing only-if-no-users guard answers, unchanged.
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(REGISTRATION_CLOSED);
+    expect(await userCount()).toBe(1);
+  });
+});

--- a/tests/integration/oauth-owner-allowlist.test.ts
+++ b/tests/integration/oauth-owner-allowlist.test.ts
@@ -51,7 +51,11 @@ beforeEach(() => {
     const req = new Request(input, init);
     const u = new URL(req.url);
     const key = `${req.method} ${u.origin}${u.pathname}`;
-    const route = routes.find((r) => `${r.method} ${r.url}` === key);
+    // Prefer a not-yet-consumed registration so a flow stubbed twice in one
+    // test (e.g. two login attempts) serves each registration once.
+    const route =
+      routes.find((r) => `${r.method} ${r.url}` === key && r.hits === 0) ??
+      routes.find((r) => `${r.method} ${r.url}` === key);
     if (!route) {
       throw new Error(`Unexpected outbound fetch in test: ${key}`);
     }
@@ -65,10 +69,12 @@ beforeEach(() => {
 
 afterEach(async () => {
   globalThis.fetch = originalFetch;
+  // Truncate before asserting so a failed assertion cannot leak DB state
+  // into the next test.
+  await truncate("sessions", "oauth_accounts", "users");
   for (const r of routes) {
     expect(r.hits, `stubbed route never hit: ${r.method} ${r.url}`).toBeGreaterThan(0);
   }
-  await truncate("sessions", "oauth_accounts", "users");
 });
 
 // ─── Flow helpers ────────────────────────────────────────

--- a/tests/security/owner-allowlist.test.ts
+++ b/tests/security/owner-allowlist.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the owner allowlist matching rule (Issue #157,
+ * specs/157-owner-allowlist/). The helper is pure so these tests carry the
+ * security-relevant logic independently of the OAuth integration harness.
+ */
+import { describe, expect, it } from "vitest";
+import { ownerAllowlistRejects } from "../../src/utils/owner-allowlist";
+
+describe("ownerAllowlistRejects", () => {
+  it("never rejects when the variable is unset (FR-001)", () => {
+    expect(ownerAllowlistRejects(undefined, "anyone@example.test")).toBe(false);
+    expect(ownerAllowlistRejects(undefined, null)).toBe(false);
+  });
+
+  it("never rejects when the variable is blank — gate inactive (FR-001)", () => {
+    expect(ownerAllowlistRejects("", "anyone@example.test")).toBe(false);
+    expect(ownerAllowlistRejects("   ", "anyone@example.test")).toBe(false);
+    expect(ownerAllowlistRejects("\t \n", null)).toBe(false);
+  });
+
+  it("does not reject an exact match (FR-002)", () => {
+    expect(ownerAllowlistRejects("owner@example.test", "owner@example.test")).toBe(false);
+  });
+
+  it("folds case and surrounding whitespace on both sides (FR-002, US1 scenario 4)", () => {
+    expect(ownerAllowlistRejects(" Owner@Example.TEST ", "owner@example.test")).toBe(false);
+    expect(ownerAllowlistRejects("owner@example.test", "  OWNER@EXAMPLE.test\t")).toBe(false);
+  });
+
+  it("rejects a mismatched email (FR-002)", () => {
+    expect(ownerAllowlistRejects("owner@example.test", "intruder@example.test")).toBe(true);
+    expect(ownerAllowlistRejects("owner@example.test", "owner@example.org")).toBe(true);
+  });
+
+  it("rejects a missing provider email when the variable is set — fail closed (FR-003)", () => {
+    expect(ownerAllowlistRejects("owner@example.test", null)).toBe(true);
+    expect(ownerAllowlistRejects("owner@example.test", "")).toBe(true);
+  });
+
+  it("returns only a boolean — no message material to leak (US3)", () => {
+    const result = ownerAllowlistRejects("owner@example.test", "intruder@example.test");
+    expect(typeof result).toBe("boolean");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,6 +45,14 @@ INSTANCE_MODE = "single"
 #                (backward-compatible default). Recommended "false" for
 #                single-user instances. See docs/deployment-guide.md (Issue #156).
 # PUBLIC_STATS = "false"
+# ALLOWED_OWNER_EMAIL - Optional but recommended. Binds the single-user
+#                first-login bootstrap to one identity: only an OAuth login
+#                whose provider-verified email equals this value (trimmed,
+#                case-insensitive) can become the instance owner. Everyone
+#                else gets the same 403 as a closed instance. Unset or blank
+#                = gate inactive. Set it BEFORE the first deploy to close the
+#                first-login owner race; see docs/deployment-guide.md (#157).
+# ALLOWED_OWNER_EMAIL = "you@example.com"
 
 # OAuth & Session secrets (set via `wrangler secret put <NAME>`)
 # GITHUB_CLIENT_ID


### PR DESCRIPTION
## Summary

PR2 (Implementation) of the SpecKit 2-PR workflow for #157; the contract landed in #162. Implements tasks T004-T014 of `specs/157-owner-allowlist/tasks.md`.

When the instance variable `ALLOWED_OWNER_EMAIL` is non-blank and `INSTANCE_MODE=single`, the new-user creation path of the OAuth login callback only proceeds if the identity''s provider-verified email equals the configured value (trimmed, case-insensitive); a missing verified email fails closed. Mismatches receive the **byte-identical** registration-closed `403` (research D-4: do not reveal the allowlist); operator logs carry provider + candidate email domain only (D-5). Unset or blank deactivates the gate entirely — zero behavior change by default.

## Changes

- `src/types.ts` — `ALLOWED_OWNER_EMAIL?: string` on `Env`
- `src/utils/owner-allowlist.ts` — pure `ownerAllowlistRejects(allowedRaw, providerEmail)` carrying the matching rule (D-3)
- `src/routes/auth/login.ts` — gate immediately after `const isSingleUser = …` in the new-user creation branch, before any INSERT/encryption work; reuses the exact registration-closed literal + `noCacheHeaders()`
- `tests/security/owner-allowlist.test.ts` — 7 unit cases (unset/blank inactive, exact + case/whitespace-folded match, mismatch, null-email fail-closed, boolean-only output)
- `tests/integration/oauth-owner-allowlist.test.ts` — 6 end-to-end cases driving the real GitHub login flow (initiate → state cookie → callback → token exchange → user info → gate) against real D1/KV: bootstrap-allowed, case folding, mismatch rejection with zero rows, byte-identity with the post-bootstrap rejection, unset passthrough, claimed-instance behavior
- `tests/env.d.ts` — test Env augmentation
- `wrangler.toml` + `docs/deployment-guide.md` — operator docs; the race section now presents the variable as the code-level mitigation to set **before** first deploy (FR-008)

## Harness note (research D-6 fallback)

The plan called for the workers-pool `fetchMock`, but `@cloudflare/vitest-pool-workers` 0.16.x does not export it (the MockAgent types in `cloudflare-test.d.ts` are vestigial; the dist fetch-mock module is a passthrough). Tests and the imported worker share one isolate, so outbound provider calls are stubbed by swapping `globalThis.fetch` per test — strictly failing on any un-stubbed outbound request, with per-registration consumption and leak-proof cleanup.

This harness — the repo''s first OAuth round-trip coverage — uncovered and is the regression guard for two pre-existing P1 bugs fixed en route: #163/PR #164 (wildcard session middleware 401''d anonymous login) and #165/PR #166 (`redirect: "error"` unsupported by workerd, all provider fetches threw).

## Testing

- `npm run typecheck` clean
- `npm test`: 32 files / 352 tests passed (339 baseline + 7 unit + 6 integration)

Closes #157. Refs #162, #164, #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)