### PR TITLE
spec: maximum lengths on write-input fields (PR1)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/157-owner-allowlist"
+  "feature_directory": "specs/158-input-maxlength"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,5 +50,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/157-owner-allowlist/plan.md`
+`specs/158-input-maxlength/plan.md`
 <!-- SPECKIT END -->

--- a/schemas/components/schemas/CommitInput.yaml
+++ b/schemas/components/schemas/CommitInput.yaml
@@ -5,21 +5,27 @@ properties:
   hash:
     type: string
     minLength: 1
+    maxLength: 64
   message:
     type: string
+    maxLength: 4096
   author_name:
     type: string
+    maxLength: 255
   author_email:
     type: string
     format: email
+    maxLength: 254
   author_date:
     type: string
     format: date-time
   committer_name:
     type: string
+    maxLength: 255
   committer_email:
     type: string
     format: email
+    maxLength: 254
   committer_date:
     type: string
     format: date-time
@@ -29,6 +35,8 @@ properties:
     minimum: 0
   ref:
     type: string
+    maxLength: 255
   url:
     type: string
     format: uri
+    maxLength: 2048

--- a/schemas/components/schemas/CustomRuleInput.yaml
+++ b/schemas/components/schemas/CustomRuleInput.yaml
@@ -37,6 +37,7 @@ properties:
   source_value:
     type: string
     minLength: 1
+    maxLength: 1024
   destination:
     type: string
     description: Required for `change` actions; ignored for `hide`.
@@ -49,6 +50,7 @@ properties:
       - entity
   destination_value:
     type: string
+    maxLength: 1024
     description: Required (non-empty) for `change` actions; ignored for `hide`.
   priority:
     type: integer

--- a/schemas/components/schemas/ExternalDurationInput.yaml
+++ b/schemas/components/schemas/ExternalDurationInput.yaml
@@ -8,8 +8,10 @@ required:
 properties:
   external_id:
     type: string
+    maxLength: 255
   entity:
     type: string
+    maxLength: 4096
   type:
     type: string
     enum:
@@ -26,9 +28,13 @@ properties:
     $ref: ./Category.yaml
   project:
     type: string
+    maxLength: 255
   branch:
     type: string
+    maxLength: 255
   language:
     type: string
+    maxLength: 255
   meta:
     type: string
+    maxLength: 8192

--- a/schemas/components/schemas/HeartbeatInput.yaml
+++ b/schemas/components/schemas/HeartbeatInput.yaml
@@ -6,6 +6,7 @@ required:
 properties:
   entity:
     type: string
+    maxLength: 4096
     description: File path, app name, or domain
   type:
     type: string
@@ -23,20 +24,26 @@ properties:
     $ref: ./Category.yaml
   project:
     type: string
+    maxLength: 255
   project_root_count:
     type: integer
   branch:
     type: string
+    maxLength: 255
   language:
     type: string
+    maxLength: 255
   dependencies:
     description: Dependency names, as comma-separated string or array
     oneOf:
       - type: string
+        maxLength: 8192
         description: Comma-separated dependency names
       - type: array
+        maxItems: 100
         items:
           type: string
+          maxLength: 255
         description: Array of dependency names
   lines:
     type: integer
@@ -52,11 +59,15 @@ properties:
     type: boolean
   editor:
     type: string
+    maxLength: 255
   operating_system:
     type: string
+    maxLength: 255
   machine:
     type: string
+    maxLength: 255
     description: Machine/device name
   user_agent:
     type: string
+    maxLength: 512
     description: User agent string from editor plugin

--- a/specs/158-input-maxlength/checklists/requirements.md
+++ b/specs/158-input-maxlength/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Maximum lengths on write-input fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- House style (see prior specs): the Background locates existing behavior
+  with concrete schema/file references; "no implementation details" is read
+  as "no prescriptive implementation choices".
+- The cap values themselves were fixed by Issue #158 + the 2026-06-10
+  research pass (WakaTime public API docs document no limits; platform
+  invariants chosen instead — see research.md R-1…R-4), so no
+  [NEEDS CLARIFICATION] markers were required.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/158-input-maxlength/contracts/openapi-diff.md
+++ b/specs/158-input-maxlength/contracts/openapi-diff.md
@@ -1,0 +1,47 @@
+# OpenAPI Contract Diff: write-input maximum lengths
+
+**Branch**: `158-input-maxlength`
+**Files**: `schemas/components/schemas/HeartbeatInput.yaml`, `CommitInput.yaml`, `ExternalDurationInput.yaml`, `CustomRuleInput.yaml`
+
+This PR1 change is **additive constraint documentation**: `maxLength` /
+`maxItems` keywords on existing string/array properties. No fields,
+operations, status codes, or response shapes change. The exact values are
+tabulated in [data-model.md](../data-model.md); the per-file edits are:
+
+## 1. HeartbeatInput.yaml
+
+- `entity`: `maxLength: 4096`
+- `project`, `branch`, `language`, `editor`, `operating_system`, `machine`: `maxLength: 255`
+- `user_agent`: `maxLength: 512`
+- `dependencies` `oneOf` string branch: `maxLength: 8192`
+- `dependencies` `oneOf` array branch: `maxItems: 100`, items `maxLength: 255`
+
+## 2. CommitInput.yaml
+
+- `hash`: `maxLength: 64` (keeps `minLength: 1`)
+- `message`: `maxLength: 4096`
+- `author_name`, `committer_name`: `maxLength: 255`
+- `author_email`, `committer_email`: `maxLength: 254`
+- `ref`: `maxLength: 255`
+- `url`: `maxLength: 2048`
+
+## 3. ExternalDurationInput.yaml
+
+- `external_id`: `maxLength: 255`
+- `entity`: `maxLength: 4096`
+- `project`, `branch`, `language`: `maxLength: 255`
+- `meta`: `maxLength: 8192`
+
+## 4. CustomRuleInput.yaml
+
+- `source_value`: `maxLength: 1024` (keeps `minLength: 1`)
+- `destination_value`: `maxLength: 1024`
+
+## Generated types impact
+
+- `src/types/generated.ts`: openapi-typescript does not encode
+  `maxLength`/`maxItems` in TypeScript types, so the expected diff is
+  **empty or JSDoc-only** (description-less constraints emit nothing).
+  Verified by `npm run generate` + reviewing the diff; spec↔validator value
+  parity is held in PR2 by `src/utils/input-limits.ts` plus a pinning unit
+  test (research R-6).

--- a/specs/158-input-maxlength/data-model.md
+++ b/specs/158-input-maxlength/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: Maximum lengths on write-input fields
+
+**Branch**: `158-input-maxlength` | **Date**: 2026-06-10
+
+**No persisted data changes**: no new tables, columns, KV keys, or
+migrations. The feature constrains four existing request schemas; D1 columns
+remain TEXT (SQLite has no enforced VARCHAR width — the validators are the
+enforcement point).
+
+## Constrained request schemas (contract-level)
+
+| Schema | Field | Cap (inclusive, UTF-16 code units) |
+|---|---|---|
+| HeartbeatInput | entity | 4096 |
+| | project / branch / language / editor / operating_system / machine | 255 |
+| | user_agent | 512 |
+| | dependencies (string) | 8192 |
+| | dependencies (array) | maxItems 100; items 255 |
+| CommitInput | hash | 64 |
+| | message | 4096 |
+| | author_name / committer_name | 255 |
+| | author_email / committer_email | 254 |
+| | ref | 255 |
+| | url | 2048 |
+| ExternalDurationInput | external_id | 255 |
+| | entity | 4096 |
+| | project / branch / language | 255 |
+| | meta | 8192 |
+| CustomRuleInput | source_value / destination_value | 1024 |
+
+## Ambient (header-derived) values — truncated, not rejected
+
+| Source | Cap | Applied at |
+|---|---|---|
+| `User-Agent` header → `user_agents.value` | 512 | `resolveUserAgentId` (PR2) |
+| `X-Machine-Name` header → `machine_names.value` / `heartbeats.machine` | 255 | heartbeat ingestion (PR2) |
+
+Pre-existing rows that exceed a cap (if any) are untouched (research R-7).

--- a/specs/158-input-maxlength/plan.md
+++ b/specs/158-input-maxlength/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Maximum lengths on write-input fields
+
+**Branch**: `158-input-maxlength` | **Date**: 2026-06-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/158-input-maxlength/spec.md`
+
+## Summary
+
+Declare inclusive `maxLength`/`maxItems` on every free-text field of the four write-input schemas and enforce them in the corresponding validators: body fields reject with the endpoints' existing 400 formats; ambient header-derived values (User-Agent → 512, X-Machine-Name → 255) truncate instead. Caps are platform-invariant-sized (research R-1…R-4) so no legitimate WakaTime-compatible client can hit them. Closes the audit's storage-abuse finding (Issue #158).
+
+**PR1 (this PR)**: SpecKit artifacts + `maxLength`/`maxItems` in `HeartbeatInput.yaml`, `CommitInput.yaml`, `ExternalDurationInput.yaml`, `CustomRuleInput.yaml` + regenerated types. **No enforcement, no behavior change.**
+
+**PR2 (after PR1 merges)**: a shared limits module (`src/utils/input-limits.ts`) holding the cap constants + a `tooLong()` helper; enforcement wired into `validateHeartbeatInput` (`src/routes/heartbeats.ts`), `src/utils/commit-input.ts`, `src/utils/external-duration-input.ts`, `src/utils/custom-rule-input.ts`; header truncation at the two ingestion call sites; unit + integration tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7
+**Storage**: none — no D1/KV changes; the caps bound what future writes can store.
+**Testing**: Vitest + workers pool. Unit tests per validator (boundary at cap / cap+1, dependencies forms); integration tests for the heartbeat single + bulk endpoints (per-item 400 shape preserved, header-truncation cases); existing corpus must pass unmodified (SC-002).
+**Performance Goals**: <10ms CPU — length checks are O(fields) string-length comparisons on paths that already iterate the fields.
+**Constraints**: spec↔validator value parity (FR-007) — enforced by defining the constants once in `src/utils/input-limits.ts` and pinning them in a parity unit test; truncation only for header-derived values (FR-004); caps inclusive (FR-003).
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | Constraints land in the OpenAPI schemas first (PR1) with regenerated types; validators follow (PR2). Additive constraint documentation — no operation/status/shape change. |
+| II. Cloudflare-Native | PASS | Pure in-handler string checks; strictly less platform usage (bounded rows, bounded KV values). |
+| III. Type Safety | PASS | `maxLength` does not change generated TS types (openapi-typescript emits strings regardless) — parity is held by the shared constants module + a parity unit test instead. |
+| IV. Legal/Trademark | PASS | Caps derived from WakaTime's public API documentation (which documents no limits) and platform invariants; WakaTime source code not consulted (constitution constraint). |
+| V. Simplicity First | PASS | One constants module, one helper, per-validator one-line checks. No generic validation framework. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/158-input-maxlength/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/components/schemas/HeartbeatInput.yaml        # CHANGE: maxLength per field; dependencies maxItems/maxLength
+schemas/components/schemas/CommitInput.yaml           # CHANGE: maxLength per field
+schemas/components/schemas/ExternalDurationInput.yaml # CHANGE: maxLength per field
+schemas/components/schemas/CustomRuleInput.yaml       # CHANGE: maxLength on source_value/destination_value
+src/types/generated.ts                                # REGENERATED (JSDoc-only diff)
+
+# PR2 (after PR1 merges)
+src/utils/input-limits.ts                  # NEW: cap constants (single source for validators) + tooLong helper
+src/routes/heartbeats.ts                   # CHANGE: length checks in validateHeartbeatInput; header-machine truncation
+src/utils/user-agent.ts                    # CHANGE: truncate value to the UA cap in resolveUserAgentId
+src/utils/commit-input.ts                  # CHANGE: length checks
+src/utils/external-duration-input.ts       # CHANGE: length checks
+src/utils/custom-rule-input.ts             # CHANGE: length checks
+tests/security/input-limits.test.ts        # NEW: constants parity + helper behavior
+tests/aggregation/commit-input.test.ts     # CHANGE: boundary cases
+tests/aggregation/external-duration-input.test.ts  # CHANGE: boundary cases
+tests/aggregation/custom-rules.test.ts     # CHANGE: boundary cases (validator part)
+tests/integration/heartbeats.test.ts       # CHANGE: oversized-field 400 (single + per-item bulk), header truncation acceptance
+```
+
+**Structure Decision**: One constants module (`INPUT_LIMITS`) is the single source the four validators import, so the contract values cannot drift between validators (FR-007); a parity unit test pins the constants to the documented numbers. Validators keep their existing error-string formats — each gains "X must be at most N characters" style messages in the same voice as the current "X must be a string". Truncation happens where ambient values enter: `resolveUserAgentId` truncates its `value` argument (covering header and cache paths uniformly), and the heartbeat handlers truncate the header-sourced `machine` before `machineUpsertStmt`; body-sourced `machine`/`user_agent` are rejected earlier by the validator, so truncation never masks a body violation.
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add the constraints to the four schemas; `npm run generate`; `npm run lint:api`; `npm run typecheck`.
+- **PR2 — Implementation**: constants module + validator checks + truncation + tests; `npm test` green; PR referencing #158 and PR1.
+
+## Risks & Mitigations
+
+- **A legitimate client exceeds a cap** → caps sit 4–30× above realistic maxima (research R-1…R-4); boundary tests document the inclusive limit; loosening later is an additive spec change.
+- **Spec/validator drift** (FR-007) → single constants module + parity test naming each documented value.
+- **Bulk-shape regression** → integration tests pin the per-item heartbeat error shape and the all-or-nothing external-durations contract.
+- **Truncation hides abuse via headers** → header values are capped, not trusted: truncation bounds storage exactly like rejection does; the body path (attacker-chosen by definition) still rejects.
+- **openapi-typescript emits no runtime checks for maxLength** → acknowledged; enforcement is the validators' job (PR2), parity held by the constants module.

--- a/specs/158-input-maxlength/quickstart.md
+++ b/specs/158-input-maxlength/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: validating write-input maximum lengths
+
+**Branch**: `158-input-maxlength` | **Scope**: PR2 behavior (PR1 ships contract only)
+
+## Prerequisites
+
+- `npm install`, local D1 initialized (`npm run db:init`), an API key
+  (or run the automated tests, which mint one via fixtures)
+
+## Scenario 1 — oversized body field rejected (User Story 1)
+
+```bash
+# entity over 4096 chars → 400, nothing stored
+python - <<'EOF'
+print('{"entity":"%s","type":"file","time":1750000000}' % ("x"*5000))
+EOF
+# POST that JSON to /api/v1/users/current/heartbeats with your API key
+```
+
+**Expected**: the endpoint's standard `400` validation error naming
+`entity`; no heartbeat row written. Bulk requests report the oversized item
+per-item while valid siblings persist.
+
+## Scenario 2 — boundary value accepted (User Story 2)
+
+A heartbeat whose `entity` is exactly 4096 characters (or `project` exactly
+255) is accepted — caps are inclusive. The entire pre-existing test corpus
+passes unmodified.
+
+## Scenario 3 — ambient headers truncate (User Story 3)
+
+Send a heartbeat with a >512-character `User-Agent` header (no body
+`user_agent`): the heartbeat succeeds and `GET /api/v1/users/current/user_agents`
+shows the value truncated to 512. Same for a >255-character `X-Machine-Name`
+header → `machine_names` value truncated to 255. Oversized **body**
+`user_agent`/`machine` fields are rejected per Scenario 1.
+
+## Automated validation (PR2)
+
+- `tests/security/input-limits.test.ts` — constants pinned to the documented
+  values (FR-007) + helper behavior
+- validator unit tests — cap / cap+1 boundaries per schema, dependencies
+  string/array forms
+- `tests/integration/heartbeats.test.ts` — oversized single + bulk per-item
+  400 shapes; header-truncation acceptance
+
+```bash
+npm run typecheck && npm test
+```
+
+Contract: [contracts/openapi-diff.md](./contracts/openapi-diff.md) · values:
+[data-model.md](./data-model.md) · decisions: [research.md](./research.md)

--- a/specs/158-input-maxlength/research.md
+++ b/specs/158-input-maxlength/research.md
@@ -1,0 +1,111 @@
+# Research: Maximum lengths on write-input fields
+
+**Branch**: `158-input-maxlength` | **Date**: 2026-06-10
+
+Sources consulted (2026-06-10): WakaTime public API documentation
+(`wakatime.com/developers`, heartbeats endpoint — documents fields and the
+25-item bulk cap but **no length limits**; the general API rate limit is
+"fewer than 10 requests per second on average over any 5 minute period"),
+platform invariants (Linux `PATH_MAX`, RFC 5321 §4.5.3.1 address maxima,
+git object-name widths, the de-facto 2048-character URL convention).
+Per the project constitution, WakaTime **source code was not consulted**.
+
+## R-1: HeartbeatInput caps
+
+**Decision**:
+
+| Field | Cap | Basis |
+|---|---|---|
+| `entity` | 4096 | Linux `PATH_MAX` (4096) — `entity` carries file paths, and also covers `url`/`domain` types (browser URL convention is 2048) |
+| `project`, `branch`, `language`, `editor`, `operating_system`, `machine` | 255 | name-like identifiers; 255 is the classic single-component / VARCHAR convention and ≥4× any observed real value |
+| `user_agent` | 512 | UA strings are oversized name-likes; 512 doubles the worst real-world UA we could find |
+| `dependencies` (string form) | 8192 | comma-separated list; bounds the raw value before splitting |
+| `dependencies` (array form) | maxItems 100, items ≤255 | dependency detection yields dozens at most; 100 names with full 255-char names ≈ 25 KB worst case |
+
+**Rationale**: the threat is multi-hundred-KB fields, not realistic data; caps
+4–30× above realistic maxima eliminate the abuse with zero compatibility
+risk (spec SC-001/SC-002).
+
+**Alternatives considered**: tighter "realistic" caps (e.g. entity 1024) —
+rejected: deep monorepo paths plus URL entities make 1024 conceivably
+reachable; the defense gains nothing from tightness. Byte-based caps —
+rejected: UTF-16 code-unit counting (`String.length`) matches `maxLength`
+convention and is what validators can check for free.
+
+## R-2: CommitInput caps
+
+**Decision**: `hash` 64 (SHA-256 hex width; SHA-1 is 40), `message` 4096,
+`author_name`/`committer_name` 255, `author_email`/`committer_email` 254
+(RFC 5321 maximum address length), `ref` 255, `url` 2048 (URL convention).
+
+**Rationale**: git object names are fixed-width; the 72-char commit-subject
+convention makes 4096 a generous whole-message budget; RFC 5321 is the
+canonical email bound; refs beyond 255 don't survive real filesystems.
+
+**Alternatives considered**: pattern-validating `hash` as hex — rejected
+here as scope creep beyond #158 (length only); can be a later additive
+constraint.
+
+## R-3: ExternalDurationInput caps
+
+**Decision**: `external_id` 255, `entity` 4096, `project`/`branch`/`language`
+255, `meta` 8192.
+
+**Rationale**: mirrors heartbeat fields for the shared dimensions;
+`external_id` is a foreign system's identifier (UUIDs, ULIDs, calendar event
+ids — all ≪255); `meta` is a free-form payload the API stores opaquely, so it
+gets the largest budget, aligned with the dependencies-string cap.
+
+## R-4: CustomRuleInput caps
+
+**Decision**: `source_value` and `destination_value` 1024.
+
+**Rationale**: rules may match on `entity`, so values can legitimately be
+long path prefixes — 255 would be too tight; 1024 covers any plausible
+prefix while keeping the 50-rule KV-cached set ≤ ~100 KB worst case.
+
+**Alternatives considered**: per-source-field caps (255 for names, 4096 for
+entity) — rejected: the validator would need the cap to depend on another
+field's value; one generous bound is simpler (Principle V) and still 200×
+below the abuse scale.
+
+## R-5: Reject bodies, truncate ambient headers
+
+**Decision**: body fields exceeding caps → the endpoint's existing 400
+validation error. `User-Agent`-header- and `X-Machine-Name`-header-derived
+values → truncated to 512 / 255 at ingestion.
+
+**Rationale**: a body value is chosen by the client and is correctable; an
+ambient header often is not (corporate proxies, runtime-composed UA
+strings), and losing time-tracking data over it punishes the wrong party.
+Truncation bounds storage exactly as well as rejection. Spec FR-002/FR-004.
+
+**Alternatives considered**: rejecting on oversized headers — rejected (data
+loss for users who can't fix it); truncating body fields — rejected
+(silently storing something other than what the client sent corrupts
+round-trips; contract-clean rejection is honest).
+
+## R-6: Single source of truth for the values
+
+**Decision**: PR2 defines all caps once in `src/utils/input-limits.ts`; the
+four validators import from it; a parity unit test pins each constant to the
+documented value.
+
+**Rationale**: `maxLength` in OpenAPI does not surface in generated TS types
+(openapi-typescript emits `string` regardless), so the type system cannot
+hold spec↔validator parity — a constants module plus a pinning test is the
+lightest drift guard (FR-007).
+
+**Alternatives considered**: generating validators from the schema (e.g.
+ajv at runtime) — rejected: a new runtime dependency and validation model
+for one class of check (Principle V); deriving constants from the bundled
+YAML at build time — rejected: build tooling complexity for four files.
+
+## R-7: No migration / backfill
+
+**Decision**: enforcement applies to new writes only; pre-existing oversized
+rows (if any) are left alone.
+
+**Rationale**: read paths and the cron already tolerate them; raw heartbeats
+age out under `HEARTBEAT_RETENTION_DAYS`; a backfill would be a destructive
+scan for a hypothetical.

--- a/specs/158-input-maxlength/spec.md
+++ b/specs/158-input-maxlength/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Maximum lengths on write-input fields
+
+**Feature Branch**: `158-input-maxlength`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: GitHub Issue #158. The write-input schemas (`HeartbeatInput`, `CommitInput`, `ExternalDurationInput`, `CustomRuleInput`) define no length bounds; validators check types and enums only, so string fields are limited solely by the global 256 KB request-body cap. Found in the 2026-06-10 security audit.
+
+## Background
+
+Every write endpoint validates structure (types, enums, required fields) but
+not size. An authenticated client can persist multi-hundred-kilobyte strings
+per field; those values then flow onward into aggregate group-by keys
+(`summaries`), the per-project registry (`user_projects`), the device and
+user-agent registries (`machine_names.value`, `user_agents.value`), KV-cached
+rule sets, and export bundles — multiplying the bloat at every hop.
+
+WakaTime's public API documentation (checked 2026-06-10) documents the
+heartbeat fields but specifies **no length limits** — only the 25-item bulk
+cap, which CloudTime already enforces. The caps are therefore CloudTime's own
+design choice, sized generously from platform invariants (file-system path
+maxima, e-mail and URL conventions, commit-hash widths) so that no legitimate
+editor plugin or integration can ever hit them; full derivations live in
+`research.md`.
+
+Two delivery rules shape the behavior:
+
+- **Body fields reject; ambient headers truncate.** A field the client put in
+  the request body is rejected with the existing 400 validation error — the
+  client chose the value and can fix it. The `User-Agent` and
+  `X-Machine-Name` headers are ambient (plugin users often cannot control
+  them), so header-derived values are silently truncated to the same caps
+  instead of failing the heartbeat.
+- **No new error surface.** Oversized fields produce the same 400 shapes the
+  endpoints emit today (per-item errors on bulk endpoints included); no
+  status code or response schema changes.
+
+This spec covers PR1 of the SpecKit 2-PR workflow: specification artifacts
+plus the `maxLength`/`maxItems` additions to the four input schemas and
+regenerated types. Enforcement follows in PR2.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Oversized write-input fields are rejected (Priority: P1)
+
+As an instance operator, I want write requests with absurdly long field
+values rejected at validation time so a buggy or abusive client cannot bloat
+my database, caches, and aggregates.
+
+**Why this priority**: This is the audit finding — unbounded inputs are a
+storage-abuse vector everywhere a written value is re-stored or re-keyed.
+
+**Independent Test**: POST a heartbeat (and a commit, an external duration,
+and a custom-rule set) where exactly one field exceeds its cap — each
+request returns the endpoint's standard 400 validation error naming the
+field, and nothing is persisted for the rejected item.
+
+**Acceptance Scenarios**:
+
+1. **Given** a heartbeat whose `entity` exceeds 4096 characters (or any capped field exceeds its limit), **When** it is POSTed singly, **Then** the response is the standard 400 validation error and no row is written.
+2. **Given** a bulk heartbeat request where one item has an oversized field and the others are valid, **When** it is POSTed, **Then** the oversized item reports its per-item 400 error while the valid items persist — exactly today's partial-failure shape.
+3. **Given** a commit, external duration, or custom rule with an oversized field, **When** it is submitted, **Then** the endpoint's existing 400 format reports the violating field (bulk external durations keep their all-or-nothing contract).
+4. **Given** a `dependencies` array of more than 100 items (or an item longer than 255 characters, or a comma-separated string longer than 8192 characters), **When** the heartbeat is POSTed, **Then** it is rejected with the standard 400.
+
+---
+
+### User Story 2 - Every legitimate client stays unaffected (Priority: P2)
+
+As a user of a WakaTime-compatible editor plugin, I want my heartbeats and
+integrations to keep working unchanged, because the caps are far above
+anything real clients produce.
+
+**Why this priority**: Compatibility is the project's reason to exist; a cap
+that rejects real traffic is a regression, not a defense.
+
+**Independent Test**: The entire existing test corpus passes unmodified, and
+boundary cases at exactly the cap (e.g. a 4096-character `entity`, a
+255-character `project`) are accepted.
+
+**Acceptance Scenarios**:
+
+1. **Given** any write payload the existing test suite sends today, **When** validation runs with caps enforced, **Then** every such payload is accepted unchanged.
+2. **Given** a field at exactly its cap length, **When** submitted, **Then** it is accepted (limits are inclusive).
+3. **Given** realistic worst-case values — a deep file path of a few hundred characters, a long git branch name, a verbose commit message — **When** submitted, **Then** they are accepted with ample headroom.
+
+---
+
+### User Story 3 - Ambient header values are truncated, not fatal (Priority: P3)
+
+As a plugin user whose editor sends an unusually long `User-Agent` (or whose
+environment injects a long machine name), I want my heartbeats recorded
+rather than rejected for something I cannot configure.
+
+**Why this priority**: Headers are not chosen per request by the user;
+failing the write would punish the wrong party and lose time-tracking data.
+
+**Independent Test**: Send a heartbeat with a >512-character `User-Agent`
+header (and a >255-character `X-Machine-Name` header) — the heartbeat is
+accepted and the stored user-agent/machine values are the truncated
+prefixes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a heartbeat with an oversized `User-Agent` header and no body `user_agent`, **When** POSTed, **Then** it succeeds and the registered user-agent value is truncated to 512 characters.
+2. **Given** an oversized `X-Machine-Name` header and no body `machine`, **When** POSTed, **Then** it succeeds and the registered machine value is truncated to 255 characters.
+3. **Given** an oversized `user_agent` or `machine` **body field**, **When** POSTed, **Then** it is rejected with 400 (body fields are chosen by the client and follow User Story 1).
+
+---
+
+### Edge Cases
+
+- **Exactly at the cap**: accepted; caps are inclusive maxima.
+- **Multi-byte characters**: limits count UTF-16 code units (the platform's
+  native string length), matching how `maxLength` is conventionally
+  enforced; documented so clients are not surprised by emoji-heavy values.
+- **`dependencies` given as a comma-separated string**: the raw string is
+  capped at 8192 before splitting; after splitting, the per-item (255) and
+  item-count (100) caps apply to the result.
+- **Truncated header collisions**: two distinct >512-char user agents that
+  share their first 512 characters register as one — acceptable; the
+  registries are best-effort telemetry, not identity.
+- **Existing oversized rows** (written before enforcement): unaffected;
+  validation applies to new writes only, no migration or backfill.
+- **Custom-rule values vs entity matching**: rules may target `entity`
+  prefixes, so rule values get a higher cap (1024) than name-like fields.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The API contract MUST declare an inclusive maximum length for every free-text string field of `HeartbeatInput`, `CommitInput`, `ExternalDurationInput`, and `CustomRuleInput`, and a maximum item count for `dependencies`, using the values fixed in `research.md` (R-1…R-4).
+- **FR-002**: Validation MUST reject a body field exceeding its cap with the endpoint's existing 400 validation-error format, naming the violating field; bulk endpoints keep their existing per-item (heartbeats) or all-or-nothing (external durations) semantics.
+- **FR-003**: A field at exactly its cap MUST be accepted.
+- **FR-004**: Values derived from the `User-Agent` or `X-Machine-Name` request headers MUST be truncated to the corresponding cap (512 / 255) instead of causing rejection; body-supplied `user_agent`/`machine` fields follow FR-002.
+- **FR-005**: `dependencies` MUST enforce: comma-separated string form ≤ 8192 characters; array form ≤ 100 items; each resulting item ≤ 255 characters.
+- **FR-006**: No status codes, response schemas, or success shapes may change; the additions are constraints on already-documented 400 behavior.
+- **FR-007**: Length limits MUST be defined once per schema in the API contract and the enforced values MUST match the contract exactly (no drift between spec and validators).
+
+### Key Entities
+
+No new entities; no schema or stored-data changes. The caps constrain four
+existing request schemas only.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After enforcement, no single write-input field can persist more than its cap (worst case 8192 characters) — versus ~256,000 today — bounding per-row bloat by a factor of ≥30.
+- **SC-002**: 100% of the pre-existing test corpus passes without modification (zero legitimate-traffic regressions).
+- **SC-003**: Boundary values at exactly each cap are accepted; values one character over are rejected — verified per schema by tests.
+- **SC-004**: Heartbeats with oversized ambient headers are still recorded (no data loss for plugin users), with stored values capped.
+
+## Assumptions
+
+- Caps count UTF-16 code units (native string length), the conventional
+  `maxLength` interpretation; byte-exact budgeting is not required since the
+  goal is bounding abuse, not precise quotas.
+- Generous caps are preferred over tight ones: the threat is megabyte-scale
+  abuse, so rejecting at single-digit kilobytes retains full compatibility
+  headroom while removing the attack.
+- No backfill of pre-existing oversized rows is needed; the hourly cron and
+  read paths tolerate them today and they age out with retention.
+- The `GoalInput`/`GoalUpdate` `title` cap (200) already exists and is out of
+  scope; profile fields already enforce caps in `validateProfileInput`.
+- WakaTime compatibility is judged against the public API documentation
+  (which documents no limits), per the project's trademark/legal constraint
+  against reading WakaTime source code.

--- a/specs/158-input-maxlength/tasks.md
+++ b/specs/158-input-maxlength/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: Maximum lengths on write-input fields
+
+**Input**: Design documents from `specs/158-input-maxlength/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/openapi-diff.md, quickstart.md
+
+**Organization**: Phase 1 is PR1 (this branch — contract only); Phases 2+ are PR2 (enforcement, after PR1 merges). Tests are included per the spec's Independent Test criteria and the project testing baseline.
+
+## Phase 1: Setup — PR1, contract only (this branch)
+
+**Goal**: Land the documented caps (data-model.md table) with zero behavior change.
+
+- [ ] T001 Apply `specs/158-input-maxlength/contracts/openapi-diff.md` to the four schemas: `schemas/components/schemas/HeartbeatInput.yaml`, `CommitInput.yaml`, `ExternalDurationInput.yaml`, `CustomRuleInput.yaml` (maxLength/maxItems values from data-model.md). Run `npm run lint:api`. Commit the spec change on its own.
+- [ ] T002 Run `npm run generate`; verify via `git diff src/types/generated.ts` that the diff is empty or JSDoc-only (openapi-typescript does not encode maxLength). Commit any regenerated output separately.
+- [ ] T003 Run `npm run typecheck`; push branch `158-input-maxlength` and open PR1 targeting `develop`, referencing Issue #158 ("spec + types only, enforcement in PR2").
+
+**Checkpoint**: PR1 open and green. Phases below start after PR1 merges, on a fresh branch off `develop`.
+
+## Phase 2: Foundational — PR2 prerequisite (blocking all user stories)
+
+- [ ] T004 Create `src/utils/input-limits.ts`: exported `INPUT_LIMITS` constants matching data-model.md exactly (heartbeat entity 4096; name-like 255; userAgent 512; dependenciesString 8192; dependenciesItems 100; dependencyName 255; commit hash 64 / message 4096 / name 255 / email 254 / ref 255 / url 2048; externalId 255; meta 8192; ruleValue 1024) plus a `tooLong(value, cap)` helper. Include a doc comment pointing at the four schema files as the contract source (FR-007, research R-6).
+
+## Phase 3: User Story 1 — Oversized body fields rejected (P1) 🎯 MVP
+
+**Goal**: Every capped body field rejects at cap+1 with the endpoint's existing 400 format.
+
+**Independent Test**: Unit boundary tests per validator + heartbeat single/bulk integration cases.
+
+- [ ] T005 [US1] Enforce caps in `validateHeartbeatInput` (`src/routes/heartbeats.ts`): entity/project/branch/language/editor/operating_system/machine/user_agent body fields; dependencies string ≤8192 pre-split, array ≤100 items, each item ≤255 (validate the normalized items for both forms). Error strings in the existing voice ("entity must be at most 4096 characters").
+- [ ] T006 [P] [US1] Enforce caps in `src/utils/commit-input.ts` (hash/message/names/emails/ref/url) using `INPUT_LIMITS`.
+- [ ] T007 [P] [US1] Enforce caps in `src/utils/external-duration-input.ts` (external_id/entity/project/branch/language/meta) using `INPUT_LIMITS`.
+- [ ] T008 [P] [US1] Enforce caps in `src/utils/custom-rule-input.ts` (source_value/destination_value ≤1024) using `INPUT_LIMITS`.
+- [ ] T009 [P] [US1] Create `tests/security/input-limits.test.ts`: pin every `INPUT_LIMITS` constant to its documented value (FR-007) and cover `tooLong` (at cap → false; cap+1 → true).
+- [ ] T010 [US1] Add boundary cases to the validator unit tests (`tests/aggregation/commit-input.test.ts`, `tests/aggregation/external-duration-input.test.ts`, `tests/aggregation/custom-rules.test.ts`): one at-cap accept + one over-cap reject per representative field.
+- [ ] T011 [US1] Add integration cases to `tests/integration/heartbeats.test.ts`: single POST with >4096 entity → 400 naming the field, nothing stored; bulk POST mixing one oversized item with valid ones → per-item 400 + valid items persisted (existing partial-failure shape); dependencies >100 items → 400.
+
+## Phase 4: User Story 2 — Legitimate clients unaffected (P2)
+
+**Goal**: Existing corpus passes unmodified; at-cap values accepted.
+
+- [ ] T012 [US2] Verify the full pre-existing suite passes with zero test-file modifications other than additions (SC-002), and include at-cap acceptance cases (entity exactly 4096, project exactly 255) in the T011 integration additions (FR-003).
+
+## Phase 5: User Story 3 — Ambient headers truncate (P3)
+
+**Goal**: Oversized User-Agent / X-Machine-Name headers never fail a heartbeat; stored values are capped prefixes.
+
+- [ ] T013 [US3] Truncate in `src/utils/user-agent.ts` `resolveUserAgentId`: slice `value` to `INPUT_LIMITS.userAgent` before cache lookup/parse/upsert (covers header path; body path already validated).
+- [ ] T014 [US3] Truncate the header-sourced machine value in `src/routes/heartbeats.ts` (single + bulk paths) to `INPUT_LIMITS` name cap before `machineUpsertStmt`/insert binding.
+- [ ] T015 [US3] Integration cases in `tests/integration/heartbeats.test.ts`: >512-char User-Agent header → 201 and stored `user_agents.value` length 512; >255-char X-Machine-Name header → 201 and stored `machine_names.value` length 255; oversized **body** user_agent/machine → 400 (US1 contrast case).
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T016 Run `npm run typecheck && npm test`; open PR2 targeting `develop`, referencing Issue #158 and PR1.
+
+## Dependencies
+
+- T001 → T002 → T003 (commit order, Constitution I); PR1 merge gates the rest
+- T004 blocks T005–T009 (constants module)
+- T005 blocks T011/T015 (heartbeat validator first); T006/T007/T008/T009 parallel
+- T013/T014 independent of T005–T012 once T004 lands
+- T016 last
+
+## Parallel Example
+
+```text
+# After T004:
+Wave 1: T005 heartbeats | T006 commit-input | T007 external-duration | T008 custom-rule | T009 parity test
+Wave 2: T010 unit boundaries | T011 integration 400s | T013 UA truncation | T014 machine truncation
+Wave 3: T012 corpus check + T015 truncation integration → T016
+```
+
+## Implementation Strategy
+
+MVP = Phase 3 (US1): caps enforced everywhere a body can write. US2 is regression assurance (zero code), US3 is the truncation refinement. Ship PR2 as one focused PR; the constants module keeps the whole change reviewable against the data-model table.


### PR DESCRIPTION
## Summary

PR1 (Spec + Design) of the SpecKit 2-PR workflow for #158. **No enforcement code** — contract and design artifacts only; validators, header truncation, and tests follow in PR2.

Write-input schemas had no length bounds: string fields were limited only by the global 256 KB bodyLimit, letting an authenticated client persist multi-hundred-KB strings that then propagate into `summaries` group-by keys, `user_projects`, `user_agents.value`, `machine_names.value`, and KV caches (2026-06-10 security audit).

## Cap design (research-backed)

WakaTime''s public API documentation (checked 2026-06-10) documents the heartbeat fields but **no length limits** — only the 25-item bulk cap CloudTime already enforces — so caps are CloudTime''s own design, sized from platform invariants so no legitimate client can hit them (research R-1…R-4):

- **HeartbeatInput**: entity 4096 (Linux PATH_MAX; covers url/domain types) · name-like fields 255 · user_agent 512 · dependencies: string ≤8192, array ≤100 items × ≤255
- **CommitInput**: hash 64 (SHA-256 hex) · message 4096 · names 255 · emails 254 (RFC 5321) · ref 255 · url 2048
- **ExternalDurationInput**: external_id 255 · entity 4096 · dimensions 255 · meta 8192
- **CustomRuleInput**: source_value/destination_value 1024 (entity-prefix rules need long values)

Delivery rules fixed in the spec: body fields **reject** with the existing 400 formats; ambient header-derived values (User-Agent → 512, X-Machine-Name → 255) **truncate** instead (R-5). PR2 holds spec↔validator parity via a single constants module + pinning test (R-6), since openapi-typescript does not encode maxLength in TS types.

## Contents

- `specs/158-input-maxlength/` — spec (3 user stories, FR-001…FR-007), plan (constitution check all-PASS), research (R-1…R-7 with sources), data-model cap table, contract diff, quickstart, tasks (16)
- 4 schema files — additive `maxLength`/`maxItems` only; no operation/status/shape changes
- `src/types/generated.ts` — regenerated with an **empty content diff** (as predicted in the contract doc), hence no generate commit
- `CLAUDE.md` — SpecKit plan pointer updated

## Testing

- `npm run lint:api` valid · `npm run typecheck` clean · full suite unaffected (no behavior change)

Refs #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)