### PR TITLE
spec: rate limiting beyond the OAuth endpoints (PR1)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/158-input-maxlength"
+  "feature_directory": "specs/159-rate-limit-expansion"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,5 +50,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/158-input-maxlength/plan.md`
+`specs/159-rate-limit-expansion/plan.md`
 <!-- SPECKIT END -->

--- a/schemas/paths/auth/link-verify-token.yaml
+++ b/schemas/paths/auth/link-verify-token.yaml
@@ -21,6 +21,10 @@ get:
     behaviour is documented in the operator runbook).
 
     See specs/080-out-of-band-email-verification/.
+
+    Rate limited at the edge (5 requests per 60-second window per truncated
+    client IP, /24 IPv4 or /48 IPv6) after the method check and before any
+    token processing (#159).
   security: []
   parameters:
     - name: token
@@ -45,3 +49,5 @@ get:
       description: Method Not Allowed — verify endpoint only accepts GET.
     '410':
       $ref: ../../components/responses/Gone.yaml
+    '429':
+      $ref: ../../components/responses/TooManyRequests.yaml

--- a/schemas/paths/meta/global-stats.yaml
+++ b/schemas/paths/meta/global-stats.yaml
@@ -14,6 +14,10 @@ get:
     Operators can disable this endpoint entirely by setting the instance
     variable `PUBLIC_STATS` to `false`; a disabled instance responds `404`
     to every request, regardless of the range value (#156).
+
+    Rate limited at the edge (30 requests per 60-second window per truncated
+    client IP); on instances with `PUBLIC_STATS=false` the disabled `404`
+    takes precedence and the limiter is never consulted (#159).
   security: []
   parameters:
     - name: range
@@ -51,3 +55,5 @@ get:
       $ref: ../../components/responses/BadRequest.yaml
     '404':
       $ref: ../../components/responses/NotFound.yaml
+    '429':
+      $ref: ../../components/responses/TooManyRequests.yaml

--- a/specs/159-rate-limit-expansion/checklists/requirements.md
+++ b/specs/159-rate-limit-expansion/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Rate limiting beyond the OAuth endpoints
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- House style: Background locates existing behavior with concrete
+  endpoint/spec references; limits and ordering rules were fixed by Issue
+  #159 plus the 2026-06-10 Cloudflare-docs research pass, so no
+  [NEEDS CLARIFICATION] markers were required.
+- The deliberate deferral (unauthenticated-401 limiter → zone-level WAF) is
+  in scope as documentation (FR-007), keeping the issue fully resolved.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/159-rate-limit-expansion/contracts/openapi-diff.md
+++ b/specs/159-rate-limit-expansion/contracts/openapi-diff.md
@@ -1,0 +1,40 @@
+# OpenAPI Contract Diff: rate limiting beyond OAuth
+
+**Branch**: `159-rate-limit-expansion`
+**Files**: `schemas/paths/auth/link-verify-token.yaml` (verify operation), `schemas/paths/meta/global-stats.yaml` (`getGlobalStats`)
+
+Additive only: one new documented response per operation (`'429': $ref`
+shared `TooManyRequests` component, exactly as the OAuth operations document
+it) plus a rate-limit sentence in each description. No parameter, schema, or
+existing-response changes.
+
+## 1. link-verify-token.yaml
+
+- Responses: add
+  ```yaml
+  '429':
+    $ref: ../../components/responses/TooManyRequests.yaml
+  ```
+- Description: append one sentence —
+  "Rate limited at the edge (5 requests per 60-second window per truncated
+  client IP, /24 IPv4 or /48 IPv6) after the method check and before any
+  token processing (#159)."
+
+## 2. global-stats.yaml
+
+- Responses: add
+  ```yaml
+  '429':
+    $ref: ../../components/responses/TooManyRequests.yaml
+  ```
+- Description: append one sentence —
+  "Rate limited at the edge (30 requests per 60-second window per truncated
+  client IP); on instances with `PUBLIC_STATS=false` the disabled `404`
+  takes precedence and the limiter is never consulted (#159)."
+
+## Generated types impact
+
+- `src/types/generated.ts`: the two operations' `responses` maps each gain a
+  `429: components["responses"]["TooManyRequests"]` entry, plus updated
+  description JSDoc. No existing member changes.
+- Verified by `npm run generate` + reviewing the diff.

--- a/specs/159-rate-limit-expansion/data-model.md
+++ b/specs/159-rate-limit-expansion/data-model.md
@@ -1,0 +1,26 @@
+# Data Model: Rate limiting beyond the OAuth endpoints
+
+**Branch**: `159-rate-limit-expansion` | **Date**: 2026-06-10
+
+**No persisted data changes** — no D1/KV writes are added; rejected requests
+do strictly less storage work than today.
+
+## Rate-limiter namespaces (configuration-only)
+
+| Binding | Namespace | Limit | Period | Key | Guards |
+|---|---|---|---|---|---|
+| `RATE_LIMIT_OAUTH_INITIATE` (existing) | 1001 | 10 | 60 s | truncated IP | `GET /auth/{provider}` |
+| `RATE_LIMIT_OAUTH_CALLBACK` (existing) | 1002 | 5 | 60 s | truncated IP | `GET /auth/{provider}/callback` |
+| `RATE_LIMIT_LINK_VERIFY` (new) | 1003 | 5 | 60 s | truncated IP | `GET /auth/link/verify/{token}` |
+| `RATE_LIMIT_PUBLIC_STATS` (new) | 1004 | 30 | 60 s | truncated IP | `GET /stats/{range}` |
+
+Key truncation: /24 for IPv4, /48 for IPv6 (`src/middleware/rate-limit.ts`,
+unchanged). Counters are per edge location per key (platform semantics,
+research header). Namespace ids continue the account-unique sequence.
+
+## Evaluation order (contract)
+
+- Verify route: `405 method check → limiter → INSTANCE_MODE check → token
+  format check (#152) → D1` (research D-2).
+- Stats route: `PUBLIC_STATS disabled gate (#156, 404) → limiter → range
+  validation → KV cache → D1` (research D-3).

--- a/specs/159-rate-limit-expansion/plan.md
+++ b/specs/159-rate-limit-expansion/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Rate limiting beyond the OAuth endpoints
+
+**Branch**: `159-rate-limit-expansion` | **Date**: 2026-06-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/159-rate-limit-expansion/spec.md`
+
+## Summary
+
+Extend the 058 rate-limiting pattern to the two remaining unauthenticated D1-touching endpoints: `GET /auth/link/verify/{token}` (5/60 s, namespace 1003) and `GET /stats/{range}` (30/60 s, namespace 1004), both keyed by the existing truncated-IP scheme and failing open with one warning when unbound. The `PUBLIC_STATS` disabled gate (#156) stays ahead of the stats limiter (404 always, never 429, zero budget spent). The issue's optional unauthenticated-401 limiter is deferred to zone-level WAF with recorded rationale (research D-4). Closes Issue #159.
+
+**PR1 (this PR)**: SpecKit artifacts + `429` (`$ref` shared `TooManyRequests`) on the two operations + regenerated types. **No bindings, wiring, or behavior changes.**
+
+**PR2 (after PR1 merges)**: two `[[ratelimits]]` blocks in `wrangler.toml`; `RATE_LIMIT_LINK_VERIFY`/`RATE_LIMIT_PUBLIC_STATS` on `Env`; `rateLimitMiddleware` wiring on the verify route and inside `getGlobalStats` after the #156 gate; integration tests with stubbed bindings; `docs/cloudflare-constraints.md` note on the deferred 401 limiter.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7; Workers Rate Limiting binding (GA since 2025-09; `[[ratelimits]]` syntax current; `period` ∈ {10, 60}; namespace ids account-unique; per-colo approximate counting)
+**Storage**: none — configuration + middleware only.
+**Testing**: Vitest + workers pool. Bindings are absent in the test pool, so the default suite exercises fail-open (zero change). Binding-present behavior is tested by passing a stub `{ limit: async () => ({ success: false }) }` (and a success stub) via env overrides — the same per-request override pattern used across the integration suite. `tests/security/rate-limit.test.ts` already unit-tests the keying.
+**Performance Goals**: <10ms CPU — one binding call per limited request; rejected requests do strictly less work than today.
+**Constraints**: gate ordering on stats (`PUBLIC_STATS` 404 gate → limiter → handler, FR-002/SC-004); verify limiter runs before token work but after the 405 method check (a 405 probe is static and free; spending limiter budget on it would let method probes exhaust the budget of a user's real click — research D-2); fail-open semantics unchanged (FR-004).
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | `429` documented on both operations first (PR1, additive, shared component); bindings/wiring follow (PR2). |
+| II. Cloudflare-Native | PASS | Uses the platform's GA rate-limiting binding exactly as 058 does; rejected requests cost no D1/KV. Per-colo approximation accepted and documented. |
+| III. Type Safety | PASS | `Env` additions live in the manual bindings file (PR2); generated types regenerated for the response-map changes. |
+| IV. Legal/Trademark | PASS | Platform feature; no third-party behavior consulted beyond Cloudflare's own docs. |
+| V. Simplicity First | PASS | Reuses `rateLimitMiddleware` unchanged; two bindings, two wiring points, no new abstractions. The 401-limiter is deferred rather than half-built. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/159-rate-limit-expansion/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/paths/auth/link-verify-token.yaml  # CHANGE: add '429' ($ref TooManyRequests) + description note
+schemas/paths/meta/global-stats.yaml       # CHANGE: add '429' ($ref TooManyRequests) + description note
+src/types/generated.ts                     # REGENERATED (429 entries on the two operations)
+
+# PR2 (after PR1 merges)
+wrangler.toml                              # CHANGE: [[ratelimits]] RATE_LIMIT_LINK_VERIFY (1003, 5/60) + RATE_LIMIT_PUBLIC_STATS (1004, 30/60)
+src/types.ts                               # CHANGE: RATE_LIMIT_LINK_VERIFY?/RATE_LIMIT_PUBLIC_STATS?: RateLimit on Env
+src/routes/auth/link.ts                    # CHANGE: limiter on the verify route after the 405 method check, before INSTANCE_MODE/token work
+src/routes/meta.ts                         # CHANGE: limiter call inside getGlobalStats after the PUBLIC_STATS gate, before range validation
+tests/env.d.ts                             # CHANGE: the two bindings on the test Env augmentation
+tests/integration/pending-link-verify.test.ts  # CHANGE: stub-binding 429 case + fail-open case
+tests/integration/global-stats.test.ts     # CHANGE: stub-binding 429 case; PUBLIC_STATS=false + exceeded limiter → still 404, limiter not consulted
+docs/cloudflare-constraints.md             # CHANGE: rate-limit section — new namespaces + deferred-401-limiter rationale (zone WAF pointer)
+```
+
+**Structure Decision**: The verify route is a single `link.all(...)` handler, so its limiter cannot be route-level middleware without catching non-GET probes — instead the `rateLimitMiddleware` factory's inner check is invoked from within the handler right after the 405 branch (or the route is split GET/all — decided in PR2 for the smallest diff; the contract is only "before token work, after method check"). On stats, `getGlobalStats` already begins with the #156 gate; the limiter call follows it inline (the middleware factory is reusable as a plain function by invoking it with a no-op `next`, but the simplest correct form is hoisting the gate check into a tiny wrapper — PR2 picks the smaller diff while preserving FR-002 ordering, with the integration tests pinning the observable contract: disabled ⇒ 404 + zero budget; enabled+exceeded ⇒ 429 before cache/D1).
+
+## Phases
+
+- **PR1 — Spec + Design (this PR)**: author the SpecKit set; add `429` to the two operations; `npm run generate`; `npm run lint:api`; `npm run typecheck`.
+- **PR2 — Implementation**: bindings + Env + wiring + tests + docs; `npm test` green; PR referencing #159 and PR1.
+
+## Risks & Mitigations
+
+- **Legitimate traffic catches a 429** → limits sized against real flows (one click per email; 5-min-cached stats), documented as operator-tunable defaults; `Retry-After: 60` keeps clients polite.
+- **NAT aggregation (/24 keying)** → accepted 058 tradeoff, restated in docs; stats limit is 6× the verify limit for this reason.
+- **Gate-ordering regression on stats (429 leaking from a disabled instance)** → integration test forces an always-exceeded stub with `PUBLIC_STATS="false"` and asserts 404 + limiter never called (spy stub).
+- **Namespace collision** → 1003/1004 continue the account-unique sequence; documented in wrangler.toml beside the existing caveat comment.
+- **Test pool has no real bindings** → by design: default suite = fail-open path; stub bindings cover both outcomes deterministically.

--- a/specs/159-rate-limit-expansion/quickstart.md
+++ b/specs/159-rate-limit-expansion/quickstart.md
@@ -1,0 +1,50 @@
+# Quickstart: validating the expanded rate limits
+
+**Branch**: `159-rate-limit-expansion` | **Scope**: PR2 behavior (PR1 ships contract only)
+
+## Prerequisites
+
+- Deployed Worker with the two new `[[ratelimits]]` blocks (PR2's
+  `wrangler.toml`), or the automated tests (stub bindings)
+- Note: `wrangler dev` simulates rate-limit bindings locally; production
+  behavior is per edge location and approximate (research header)
+
+## Scenario 1 — flood is damped (User Story 1)
+
+```bash
+for i in $(seq 1 10); do curl -s -o /dev/null -w "%{http_code}\n" \
+  https://your-worker.example.com/api/v1/auth/link/verify/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA; done
+```
+
+**Expected**: the first ~5 answer `410` (unknown token), the rest `429`
+with `Retry-After: 60`. Similarly, >30 stats requests in a minute from one
+network start returning `429`.
+
+## Scenario 2 — legitimate flows unaffected (User Story 2)
+
+One verification click per emailed link and dashboard polling at the
+cache's 5-minute granularity never approach the limits. With the bindings
+absent (e.g. an operator who hasn't added the blocks), both endpoints
+behave exactly as before, logging one `[rate-limit] … failing open`
+warning per isolate.
+
+## Scenario 3 — disabled stats stay uniform 404 (User Story 3)
+
+With `PUBLIC_STATS = "false"`, any request volume to
+`/api/v1/stats/{range}` returns `404` — never `429` (the gate precedes the
+limiter and spends no budget).
+
+## Automated validation (PR2)
+
+Integration tests inject stub bindings via env overrides:
+`{ limit: async () => ({ success: false }) }` → 429 path; success stub →
+pass-through; a call-recording spy + `PUBLIC_STATS="false"` → 404 with the
+limiter never consulted. Default suite (no bindings) pins fail-open.
+
+```bash
+npm run typecheck && npm test
+```
+
+Contract: [contracts/openapi-diff.md](./contracts/openapi-diff.md) ·
+namespaces/order: [data-model.md](./data-model.md) · decisions:
+[research.md](./research.md)

--- a/specs/159-rate-limit-expansion/research.md
+++ b/specs/159-rate-limit-expansion/research.md
@@ -1,0 +1,106 @@
+# Research: Rate limiting beyond the OAuth endpoints
+
+**Branch**: `159-rate-limit-expansion` | **Date**: 2026-06-10
+
+Sources consulted (2026-06-10): Cloudflare official documentation —
+Workers Rate Limiting binding (`developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/`)
+and the 2025-09-19 changelog entry announcing GA. Key platform facts:
+
+- The `ratelimit` binding is **GA** (since 2025-09-19); the `[[ratelimits]]`
+  configuration syntax used by this repo is the current, stable one.
+- `period` must be **10 or 60** seconds; `limit` is a positive integer.
+- `namespace_id` is a positive-integer string **unique per Cloudflare
+  account**; bindings sharing a namespace share counters even across
+  Workers. Existing: 1001 (OAuth initiate), 1002 (OAuth callback).
+- Counting is **per edge location per key** and intentionally approximate
+  ("not … an accurate accounting system").
+- Cloudflare recommends non-IP keys (API keys, user ids) where available.
+
+## D-1: Two new limiters, mirroring the 058 pattern
+
+**Decision**: `RATE_LIMIT_LINK_VERIFY` (namespace 1003, 5/60 s) on
+`GET /auth/link/verify/{token}`; `RATE_LIMIT_PUBLIC_STATS` (namespace 1004,
+30/60 s) on `GET /stats/{range}`. Both reuse `rateLimitMiddleware`'s
+truncated-IP keying (/24 v4, /48 v6) and fail-open-with-warning behavior.
+
+**Rationale**: these are the only remaining unauthenticated endpoints that
+convert anonymous requests into D1 work (verify: UPDATE+SELECT per
+well-formed token; stats: 5-statement batch per cache miss, cache-key
+rotation via the range param). 5/60 mirrors the OAuth callback limit
+guarding the same email-click journey; 30/60 is 6× more generous because
+dashboards/badges poll stats and NAT aggregation hits read endpoints
+hardest — while still bounding a flood to ≤30 cache-missable reads per
+network per minute per location. Non-IP keys are unavailable before
+authentication, so the documented IP-key caveat is accepted exactly as 058
+accepted it.
+
+**Alternatives considered**: keying stats by `range` instead of IP —
+rejected: a single attacker would exhaust the budget for everyone (global
+denial); 10-second periods — rejected: same average rate with burstier
+allowance and no operator benefit; tighter stats limit (10/60) — rejected:
+public dashboards refreshing several widgets could plausibly burst past it.
+
+## D-2: Verify limiter placement — after the 405 method check, before token work
+
+**Decision**: the limiter runs after the method check (non-GET still gets
+the clean, free 405) and before the `INSTANCE_MODE` check and all token
+processing.
+
+**Rationale**: the 405 branch is static — no D1, no token handling; making
+method probes consume limiter budget would let an attacker POST-spam to
+starve a legitimate user's single real click. Everything that can touch
+the database sits behind the limiter.
+
+**Alternatives considered**: route-level middleware ahead of the handler —
+rejected: the route is a single `all()` handler so route middleware would
+also meter non-GET probes; limiter before the method check — rejected per
+the starvation argument above.
+
+## D-3: Stats limiter placement — after the PUBLIC_STATS gate
+
+**Decision**: on `getGlobalStats`, the #156 disabled gate stays first; the
+limiter runs second; range validation, KV, and D1 follow.
+
+**Rationale**: #156's contract is that a disabled instance is
+indistinguishable from an absent endpoint — a `429` would be a new
+observable revealing both existence and rate-limiting, and would spend
+budget on an endpoint that costs nothing when disabled. SC-004/FR-002.
+
+**Alternatives considered**: limiter first (uniform with other endpoints) —
+rejected: leaks existence on disabled instances and wastes budget.
+
+## D-4: The unauthenticated-401 blanket limiter is deferred to zone-level WAF
+
+**Decision**: do not implement the issue's optional "coarse limiter for
+unauthenticated 401s" as a Worker binding; document zone-level WAF
+rate-limiting rules as the recommended tool instead
+(`docs/cloudflare-constraints.md`, PR2).
+
+**Rationale**: (1) the auth-failure path costs one indexed D1 point-read —
+two orders of magnitude cheaper than the endpoints limited here; (2) the
+binding is per-colo and approximate, a poor fit for a low-and-slow
+distributed pattern across ~30 operations; (3) wiring a limiter into
+`authMiddleware` would add a binding call to every failed request on every
+endpoint and a `429` to every documented operation's contract — large
+contract surface for marginal benefit; (4) zone-level WAF rate-limiting
+rules operate before the Worker runs (no Worker invocation cost at all)
+and operators can deploy them without code changes. This resolves the
+issue's optional item by documented decision rather than code.
+
+**Alternatives considered**: implementing it anyway — rejected per the
+cost/benefit above; leaving it silently unaddressed — rejected: the issue
+explicitly listed it, so the deferral must be recorded and documented.
+
+## D-5: Testing strategy without real bindings
+
+**Decision**: the workers test pool has no rate-limit bindings, so the
+default suite exercises the fail-open path unchanged (SC-002). Limiter
+behavior is tested with stub bindings injected via the established
+per-request env-override pattern: `{ limit: async () => ({ success: false }) }`
+for the 429 path, a success stub for pass-through, and a call-recording spy
+to assert the disabled-stats gate never consults the limiter (D-3).
+
+**Rationale**: deterministic, no new infrastructure, and matches how
+`tests/security/rate-limit.test.ts` already unit-tests keying while
+integration code relies on the `RateLimit` interface shape
+(`src/types.ts`).

--- a/specs/159-rate-limit-expansion/spec.md
+++ b/specs/159-rate-limit-expansion/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Rate limiting beyond the OAuth endpoints
+
+**Feature Branch**: `159-rate-limit-expansion`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: GitHub Issue #159. Only the OAuth initiate/callback endpoints carry rate-limit bindings today (`specs/058-oauth-rate-limiting/`). Two other unauthenticated-reachable paths remain unthrottled at the application layer and each costs database work per request. Found in the 2026-06-10 security audit.
+
+## Background
+
+Two endpoints can be driven by anyone who knows the instance URL:
+
+- **`GET /api/v1/auth/link/verify/{token}`** — the out-of-band email
+  verification route. The #152 format pre-check rejects malformed tokens
+  before any database access, but every *well-formed* unknown token still
+  costs a database write attempt plus a follow-up read. Legitimate usage is
+  one click per emailed link.
+- **`GET /api/v1/stats/{range}`** — the public global stats endpoint. A
+  cache miss fans out to a five-statement database batch, and each distinct
+  range value owns its own five-minute cache entry, so an attacker can
+  rotate ranges to dodge the cache.
+
+This feature extends the existing edge rate-limiting pattern (same
+middleware, same truncated-IP keying, same fail-open-with-warning behavior
+when a binding is missing) to those two endpoints:
+
+| Endpoint | Limit | Basis |
+|---|---|---|
+| `GET /auth/link/verify/{token}` | 5 / 60 s per client network | mirrors the OAuth callback limit; one click per email is the entire legitimate flow |
+| `GET /stats/{range}` | 30 / 60 s per client network | generous for dashboards/badges polling a 5-minute-cached endpoint |
+
+Verified against the platform's official documentation (2026-06-10, recorded
+in `research.md`): the rate-limiting binding is generally available, periods
+of 60 seconds are supported, limits are approximate and scoped per
+edge location per key — adequate for abuse damping, not precise accounting.
+
+The issue's optional third item — a coarse limiter for unauthenticated `401`
+responses across all API-key endpoints — is **deferred** with recorded
+rationale (research D-4): the auth-failure path costs only one indexed
+point-read, the binding's per-location approximation fits poorly over
+dozens of operations, and broad-spectrum throttling is the job of zone-level
+WAF rules, which operators can layer on without code changes.
+
+Ordering rule fixed by design: on the public stats endpoint, the
+`PUBLIC_STATS=false` disabled gate (#156) runs **before** the limiter — a
+disabled instance answers `404` always (never `429`) and spends nothing.
+
+This spec covers PR1 of the SpecKit 2-PR workflow: specification artifacts
+plus the documented `429` response on the two operations and regenerated
+types. Bindings and wiring follow in PR2.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Abusive request floods are damped (Priority: P1)
+
+As an instance operator, I want repeated anonymous hammering of the verify
+and public-stats endpoints to be rejected at the edge so it cannot translate
+into unbounded database work.
+
+**Why this priority**: This is the audit finding — both endpoints turn
+anonymous requests into database operations.
+
+**Independent Test**: With a binding configured (or stubbed in tests),
+requests beyond the limit receive `429` with a `Retry-After` header and
+perform no database or cache work.
+
+**Acceptance Scenarios**:
+
+1. **Given** the verify endpoint's limiter reports the limit exceeded, **When** a request arrives, **Then** the response is `429` (standard error body + `Retry-After`) and no token lookup occurs.
+2. **Given** the public-stats limiter reports the limit exceeded, **When** a request arrives, **Then** the response is `429` and neither the cache nor the database is touched.
+3. **Given** the limiter reports success, **When** a request arrives, **Then** the endpoint behaves exactly as today.
+
+---
+
+### User Story 2 - Legitimate flows never hit the limits (Priority: P2)
+
+As a user clicking my verification email once, or a dashboard polling
+public stats at a sane interval, I never see a `429`.
+
+**Why this priority**: Rate limits that catch real traffic are a regression;
+the limits were sized so real flows sit far below them.
+
+**Independent Test**: One verify click per link and stats polling at the
+cache's own 5-minute granularity stay well under 5/60 s and 30/60 s
+respectively; the full existing test corpus passes unmodified (bindings are
+absent in the test pool, where the middleware fails open by design).
+
+**Acceptance Scenarios**:
+
+1. **Given** an instance without the new bindings configured, **When** either endpoint is used, **Then** behavior is unchanged (fail-open with a single operator warning — the existing pattern).
+2. **Given** normal usage volumes, **When** the bindings are configured at the documented limits, **Then** legitimate flows complete without ever seeing `429`.
+
+---
+
+### User Story 3 - The disabled-stats gate stays first (Priority: P3)
+
+As an operator who disabled public stats (#156), I want a disabled instance
+to keep answering a uniform `404` — never a `429` that reveals the endpoint
+exists and is rate-limited.
+
+**Why this priority**: #156's design goal is that probing reveals nothing;
+the limiter must not create a new observable.
+
+**Independent Test**: With `PUBLIC_STATS="false"` and the limiter forced to
+"exceeded", requests still receive `404` (the gate short-circuits before the
+limiter) and consume no rate-limit budget.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PUBLIC_STATS="false"`, **When** any volume of requests arrives, **Then** every response is the #156 `404` and the limiter is never consulted.
+
+---
+
+### Edge Cases
+
+- **Binding not configured** (fresh deployments, test pool): fail open with
+  one warning per isolate — identical to the OAuth limiters; operators who
+  skip the wrangler.toml blocks lose damping but nothing breaks.
+- **Shared office/CGNAT networks**: keying is per truncated client network
+  (/24 IPv4, /48 IPv6), so a large NAT could aggregate users; the stats
+  limit (30/60 s) absorbs this; the verify limit matches the OAuth callback
+  limit that already governs the same user journey.
+- **Per-location scoping**: limits apply per edge location per key
+  (documented platform behavior) — a distributed attacker gets the limit at
+  each location, which still bounds total throughput per location and is the
+  accepted platform semantic (same as 058).
+- **Rate-limited verify clicks**: a real user re-clicking an email link
+  more than 5 times in a minute briefly sees `429` with `Retry-After: 60`;
+  the token remains valid — no data loss, retry succeeds.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `GET /api/v1/auth/link/verify/{token}` MUST be rate-limited at 5 requests per 60 seconds per truncated client network, evaluated before any token processing or database access.
+- **FR-002**: `GET /api/v1/stats/{range}` MUST be rate-limited at 30 requests per 60 seconds per truncated client network, evaluated before range validation, cache access, and database access — but **after** the `PUBLIC_STATS` disabled gate (#156), which MUST keep returning `404` without consuming limiter budget.
+- **FR-003**: Limited requests MUST receive the standard `429` error body with a `Retry-After` header, identical in shape to the existing OAuth limiter responses.
+- **FR-004**: When a binding is not configured, the endpoint MUST fail open with the existing one-warning-per-isolate behavior; no other behavior may change.
+- **FR-005**: Both operations MUST document the `429` response in the API contract (reusing the existing shared `TooManyRequests` response).
+- **FR-006**: The two new limiter namespaces MUST NOT collide with existing ones (account-unique namespace identifiers, continuing from the OAuth pair).
+- **FR-007**: Operator documentation MUST cover the new configuration blocks and record why a blanket unauthenticated-401 limiter is deferred to zone-level tooling.
+
+### Key Entities
+
+No persisted data. Two new edge rate-limiter namespaces (configuration-only).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With bindings configured, anonymous request floods against either endpoint are capped at the documented per-network rates; database work per network is bounded at ≤5 verify lookups and ≤30 stats reads per minute per location.
+- **SC-002**: Zero behavior change when bindings are absent; the full pre-existing test corpus passes unmodified.
+- **SC-003**: Legitimate flows (one verify click; dashboard polling at or above the cache's 5-minute granularity) never observe `429` at the documented limits.
+- **SC-004**: A disabled-stats instance never emits `429` from this feature (the #156 `404` remains the uniform response).
+
+## Assumptions
+
+- The truncated-IP keying from `specs/058-oauth-rate-limiting/` remains the
+  right key for unauthenticated endpoints (nothing better exists before
+  auth); its known NAT-aggregation tradeoff is accepted and documented.
+- The platform's approximate, per-location semantics are sufficient: the
+  goal is abuse damping, not exact quotas (matches 058's accepted semantics).
+- Limits are operator-tunable by editing the configuration blocks; the
+  documented values are defaults, not contract.
+- The deferred 401-path limiter remains tracked by this issue's research
+  notes and operator docs rather than a code path; zone-level WAF rules are
+  the recommended tool for broad-spectrum throttling.

--- a/specs/159-rate-limit-expansion/tasks.md
+++ b/specs/159-rate-limit-expansion/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Rate limiting beyond the OAuth endpoints
+
+**Input**: Design documents from `specs/159-rate-limit-expansion/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/openapi-diff.md, quickstart.md
+
+**Organization**: Phase 1 is PR1 (this branch — contract only; submit after #158 PR1 merges and rebase, to avoid SpecKit-pointer conflicts); Phases 2+ are PR2 (after PR1 merges). Tests included per the spec's Independent Test criteria.
+
+## Phase 1: Setup — PR1, contract only (this branch)
+
+- [ ] T001 Apply `specs/159-rate-limit-expansion/contracts/openapi-diff.md`: add `'429': $ref ../../components/responses/TooManyRequests.yaml` plus the description sentence to `schemas/paths/auth/link-verify-token.yaml` and `schemas/paths/meta/global-stats.yaml`. Run `npm run lint:api`. Commit the spec change on its own (SpecKit artifacts committed first).
+- [ ] T002 Run `npm run generate`; verify the `src/types/generated.ts` diff is exactly the two additive 429 entries + JSDoc. Commit separately.
+- [ ] T003 Rebase onto `develop` (after #158 PR1 merges, resolving the `.specify/feature.json` / `CLAUDE.md` pointer to 159), run `npm run typecheck`, push `159-rate-limit-expansion`, open PR1 targeting `develop` referencing Issue #159.
+
+**Checkpoint**: PR1 merged. Phases below on a fresh branch off `develop`.
+
+## Phase 2: Foundational — PR2 prerequisites
+
+- [ ] T004 [P] Add the two `[[ratelimits]]` blocks to `wrangler.toml` (RATE_LIMIT_LINK_VERIFY ns "1003" limit 5 period 60; RATE_LIMIT_PUBLIC_STATS ns "1004" limit 30 period 60) below the existing pair, keeping the plan-limits caveat comment. CRITICAL: commit with the D1/KV placeholder ids intact.
+- [ ] T005 [P] Add `RATE_LIMIT_LINK_VERIFY?: RateLimit` and `RATE_LIMIT_PUBLIC_STATS?: RateLimit` to `Env` in `src/types.ts`, and to the test augmentation in `tests/env.d.ts`.
+
+## Phase 3: User Story 1 — Floods damped (P1) 🎯 MVP
+
+**Goal**: Exceeded limiters yield 429 before any token/cache/D1 work.
+
+- [ ] T006 [US1] Wire the verify limiter in `src/routes/auth/link.ts`: inside the `all("/link/verify/:token")` handler, after the 405 method branch and before the `INSTANCE_MODE` check, consult `c.env.RATE_LIMIT_LINK_VERIFY` with the truncated-IP key (reuse the keying/fail-open/429 shape of `src/middleware/rate-limit.ts` — extract a callable helper from the middleware factory if needed so the single-`all()` route can use it inline; keep one warning per isolate on missing binding) (research D-2).
+- [ ] T007 [US1] Wire the stats limiter in `src/routes/meta.ts` `getGlobalStats`: after the `PUBLIC_STATS` disabled gate, before range validation/KV/D1, same helper, binding `RATE_LIMIT_PUBLIC_STATS` (research D-3).
+- [ ] T008 [US1] Integration tests with stub bindings via env overrides: `tests/integration/pending-link-verify.test.ts` — always-exceeded stub → 429 + `Retry-After: 60` and the seeded token is NOT consumed; `tests/integration/global-stats.test.ts` — always-exceeded stub → 429 and no KV write.
+
+## Phase 4: User Story 2 — Legitimate flows unaffected (P2)
+
+- [ ] T009 [P] [US2] Add pass-through cases: success-returning stub → endpoints behave exactly as today (verify consumes token / stats 200 + cache write); absent binding (default pool) → existing cases pass unmodified, fail-open warning path covered.
+
+## Phase 5: User Story 3 — Disabled stats stay 404 (P3)
+
+- [ ] T010 [P] [US3] Add to `tests/integration/global-stats.test.ts`: `PUBLIC_STATS="false"` + call-recording always-exceeded stub → response 404 and the stub was never invoked (SC-004, research D-3).
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T011 [P] Update `docs/cloudflare-constraints.md`: document the four limiter namespaces and record the deferred unauthenticated-401 limiter decision with the zone-level WAF recommendation (FR-007, research D-4).
+- [ ] T012 Run `npm run typecheck && npm test`; open PR2 targeting `develop` referencing Issue #159 and PR1. PR body notes operator action (new wrangler.toml blocks) for release notes.
+
+## Dependencies
+
+- T001 → T002 → T003; PR1 merge gates the rest
+- T004/T005 parallel; both block T006/T007
+- T006 blocks the verify half of T008; T007 blocks the stats half and T010
+- T009/T010/T011 parallel after T006+T007; T012 last
+
+## Parallel Example
+
+```text
+Wave 1: T004 wrangler.toml | T005 Env types
+Wave 2: T006 verify wiring | T007 stats wiring | T011 docs
+Wave 3: T008 429 cases | T009 pass-through | T010 disabled-gate spy → T012
+```
+
+## Implementation Strategy
+
+MVP = Phase 3 (US1). US2 is regression assurance, US3 pins the #156 interaction. One small PR2; the only operator-visible artifact is the two wrangler.toml blocks (release-notes callout in T012).

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -252,6 +252,10 @@ export interface paths {
          *     behaviour is documented in the operator runbook).
          *
          *     See specs/080-out-of-band-email-verification/.
+         *
+         *     Rate limited at the edge (5 requests per 60-second window per truncated
+         *     client IP, /24 IPv4 or /48 IPv6) after the method check and before any
+         *     token processing (#159).
          */
         get: operations["verifyLinkEmailToken"];
         put?: never;
@@ -1206,6 +1210,7 @@ export interface paths {
          * Aggregate stats of all users
          * @description Aggregates activity across all users over the requested range. This endpoint is unauthenticated and **always aggregates in UTC** — it does not accept a timezone. Fixing UTC keeps the response cacheable under a single key per range (a client-supplied timezone would otherwise fragment the cache on an unauthenticated endpoint) and avoids ambiguous cross-user date boundaries when `summaries.date` is bucketed per user timezone (#29).
          *     Operators can disable this endpoint entirely by setting the instance variable `PUBLIC_STATS` to `false`; a disabled instance responds `404` to every request, regardless of the range value (#156).
+         *     Rate limited at the edge (30 requests per 60-second window per truncated client IP); on instances with `PUBLIC_STATS=false` the disabled `404` takes precedence and the limiter is never consulted (#159).
          */
         get: operations["getGlobalStats"];
         put?: never;
@@ -2288,6 +2293,7 @@ export interface operations {
                 content?: never;
             };
             410: components["responses"]["Gone"];
+            429: components["responses"]["TooManyRequests"];
         };
     };
     getLinkedProviders: {
@@ -3754,6 +3760,7 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             404: components["responses"]["NotFound"];
+            429: components["responses"]["TooManyRequests"];
         };
     };
 }


### PR DESCRIPTION
## Summary

PR1 (Spec + Design) of the SpecKit 2-PR workflow for #159. **No bindings, wiring, or behavior changes** — contract and design artifacts only; implementation follows in PR2.

Two unauthenticated endpoints still convert anonymous requests into D1 work: `GET /auth/link/verify/{token}` (UPDATE + SELECT per well-formed unknown token, even after the #152 format pre-check) and `GET /stats/{range}` (5-statement batch per cache miss, cache-key rotation via the range param). This feature extends the 058 rate-limiting pattern to both.

## Design (research-backed, Cloudflare official docs 2026-06-10)

- Workers Rate Limiting binding is **GA** (2025-09); `[[ratelimits]]` syntax current; `period` ∈ {10, 60}; `namespace_id` account-unique (1001/1002 taken → 1003/1004); counting per edge location, approximate (research header + D-1).
- **RATE_LIMIT_LINK_VERIFY** ns 1003, **5/60 s** per truncated IP — mirrors the OAuth callback limit guarding the same email-click journey; placed after the free 405 method check so method probes cannot starve a real click (D-2).
- **RATE_LIMIT_PUBLIC_STATS** ns 1004, **30/60 s** per truncated IP — generous for dashboards polling a 5-min-cached endpoint; the `PUBLIC_STATS=false` gate (#156) stays FIRST: a disabled instance answers 404 always, never 429, and spends no limiter budget (D-3).
- The issue''s optional unauthenticated-401 blanket limiter is **deferred by documented decision** (D-4): the auth-failure path costs one indexed point-read, per-colo approximation fits ~30 operations poorly, and zone-level WAF rules do this before the Worker even runs — to be recorded in `docs/cloudflare-constraints.md` in PR2.

## Contents

- `specs/159-rate-limit-expansion/` — spec (3 user stories, FR-001…FR-007), plan (constitution all-PASS), research (D-1…D-5 with platform facts), data-model (namespace table + evaluation-order contract), contract diff, quickstart, tasks (12)
- `schemas/paths/auth/link-verify-token.yaml`, `schemas/paths/meta/global-stats.yaml` — additive `429` ($ref shared `TooManyRequests`) + description notes
- `src/types/generated.ts` — regenerated; diff is the two additive 429 entries + JSDoc (7 lines)
- `.specify/feature.json` / `CLAUDE.md` — SpecKit pointers (rebased over #168''s)

## Testing

- `npm run lint:api` valid · `npm run typecheck` clean · suite unaffected (no behavior change)

Refs #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)