### PR TITLE
feat: enforce write-input length caps (PR2)

### DIFF
--- a/src/routes/heartbeats.ts
+++ b/src/routes/heartbeats.ts
@@ -5,6 +5,7 @@ import { authMiddleware, getUserTimeout, getUserTimezone } from "../middleware/a
 import { getEpochBoundsForDate } from "../utils/time-format";
 import { resolveUserAgentId } from "../utils/user-agent";
 import { applyRules, loadRules } from "../utils/custom-rules";
+import { INPUT_LIMITS, tooLong, truncateTo } from "../utils/input-limits";
 import { machineUpsertStmt } from "../utils/machine";
 
 type HeartbeatInput = components["schemas"]["HeartbeatInput"];
@@ -137,7 +138,12 @@ heartbeats.post("/heartbeats", async (c) => {
     return c.json({ error: err }, 400);
   }
 
-  const machine = input.machine ?? c.req.header("X-Machine-Name") ?? undefined;
+  // Header-derived ambient values truncate to the contract caps instead of
+  // failing the heartbeat (Issue #158, research R-5); body values were
+  // validated above. The User-Agent value is capped inside resolveUserAgentId.
+  const rawHeaderMachine = c.req.header("X-Machine-Name");
+  const machine = input.machine
+    ?? (rawHeaderMachine !== undefined ? truncateTo(rawHeaderMachine, INPUT_LIMITS.name) : undefined);
   const userAgent = input.user_agent ?? c.req.header("User-Agent") ?? undefined;
   const ip = c.req.header("CF-Connecting-IP") ?? null;
 
@@ -176,8 +182,13 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
     return c.json({ error: "Maximum 25 heartbeats per request" }, 400);
   }
 
-  // Resolve machine/user_agent: body field > header > undefined
-  const headerMachine = c.req.header("X-Machine-Name") ?? undefined;
+  // Resolve machine/user_agent: body field > header > undefined.
+  // Header values truncate to the contract caps (Issue #158, research R-5);
+  // the User-Agent value is capped inside resolveUserAgentId.
+  const rawHeaderMachine = c.req.header("X-Machine-Name");
+  const headerMachine = rawHeaderMachine !== undefined
+    ? truncateTo(rawHeaderMachine, INPUT_LIMITS.name)
+    : undefined;
   const headerUserAgent = c.req.header("User-Agent") ?? undefined;
   const ip = c.req.header("CF-Connecting-IP") ?? null;
   const now = new Date().toISOString();
@@ -386,10 +397,33 @@ function normalizeDependencies(deps: string | string[] | undefined): string | nu
 function validateHeartbeatInput(input: HeartbeatInput): string | null {
   if (!input || typeof input !== "object") return "must be an object";
   if (typeof input.entity !== "string" || input.entity.length === 0) return "entity is required";
+  if (tooLong(input.entity, INPUT_LIMITS.entity)) {
+    return `entity must be at most ${INPUT_LIMITS.entity} characters`;
+  }
   if (!VALID_TYPES.has(input.type)) return `type must be one of: ${[...VALID_TYPES].join(", ")}`;
   if (typeof input.time !== "number" || !Number.isFinite(input.time)) return "time must be a valid number";
   if (input.category !== undefined && !VALID_CATEGORIES.has(input.category)) {
     return `category must be one of: ${[...VALID_CATEGORIES].join(", ")}`;
+  }
+
+  // Length caps on optional body string fields (Issue #158; values from
+  // src/utils/input-limits.ts, mirroring the OpenAPI maxLength constraints).
+  // Header-derived machine/user_agent values are truncated at ingestion
+  // instead — these checks cover only what the client put in the body.
+  const cappedFields = [
+    ["project", INPUT_LIMITS.name],
+    ["branch", INPUT_LIMITS.name],
+    ["language", INPUT_LIMITS.name],
+    ["editor", INPUT_LIMITS.name],
+    ["operating_system", INPUT_LIMITS.name],
+    ["machine", INPUT_LIMITS.name],
+    ["user_agent", INPUT_LIMITS.userAgent],
+  ] as const;
+  for (const [field, cap] of cappedFields) {
+    const val = input[field];
+    if (val === undefined || val === null) continue;
+    if (typeof val !== "string") return `${field} must be a string`;
+    if (tooLong(val, cap)) return `${field} must be at most ${cap} characters`;
   }
 
   // Validate optional numeric fields when present
@@ -405,10 +439,28 @@ function validateHeartbeatInput(input: HeartbeatInput): string | null {
     return "is_write must be a boolean";
   }
 
-  if (input.dependencies !== undefined
-      && typeof input.dependencies !== "string"
-      && !Array.isArray(input.dependencies)) {
-    return "dependencies must be a string or array of strings";
+  if (input.dependencies !== undefined) {
+    const isString = typeof input.dependencies === "string";
+    if (!isString && !Array.isArray(input.dependencies)) {
+      return "dependencies must be a string or array of strings";
+    }
+    if (isString && tooLong(input.dependencies as string, INPUT_LIMITS.dependenciesString)) {
+      return `dependencies must be at most ${INPUT_LIMITS.dependenciesString} characters`;
+    }
+    // Both forms normalize to a list (see normalizeDependencies); the count
+    // and per-item caps apply to that result (FR-005).
+    const items = isString
+      ? (input.dependencies as string).split(",").map((s) => s.trim()).filter(Boolean)
+      : (input.dependencies as unknown[]);
+    if (items.length > INPUT_LIMITS.dependenciesItems) {
+      return `dependencies must have at most ${INPUT_LIMITS.dependenciesItems} items`;
+    }
+    for (const dep of items) {
+      if (typeof dep !== "string") return "dependencies must be a string or array of strings";
+      if (tooLong(dep, INPUT_LIMITS.dependencyName)) {
+        return `each dependency must be at most ${INPUT_LIMITS.dependencyName} characters`;
+      }
+    }
   }
 
   return null;

--- a/src/utils/commit-input.ts
+++ b/src/utils/commit-input.ts
@@ -6,6 +6,7 @@
  * path by the route, not the body. Dates are normalised to the same SQLite
  * datetime format `created_at` uses, so the read path renders them schema-valid.
  */
+import { INPUT_LIMITS, tooLong } from "./input-limits";
 import { toSqliteDateTime } from "./user";
 
 export interface ValidatedCommit {
@@ -84,6 +85,9 @@ export function validateCommitInput(body: unknown): ValidationResult<ValidatedCo
   if (typeof r.hash !== "string" || r.hash.length === 0) {
     return fail("hash is required and must be a non-empty string");
   }
+  if (tooLong(r.hash, INPUT_LIMITS.commitHash)) {
+    return fail(`hash must be at most ${INPUT_LIMITS.commitHash} characters`);
+  }
 
   if (r.total_seconds !== undefined && r.total_seconds !== null) {
     if (typeof r.total_seconds !== "number" || !Number.isFinite(r.total_seconds) || r.total_seconds < 0) {
@@ -91,9 +95,25 @@ export function validateCommitInput(body: unknown): ValidationResult<ValidatedCo
     }
   }
 
+  // Length caps mirror the OpenAPI maxLength constraints (Issue #158;
+  // values from src/utils/input-limits.ts).
+  const caps = {
+    message: INPUT_LIMITS.commitMessage,
+    author_name: INPUT_LIMITS.name,
+    author_email: INPUT_LIMITS.email,
+    committer_name: INPUT_LIMITS.name,
+    committer_email: INPUT_LIMITS.email,
+    ref: INPUT_LIMITS.name,
+    url: INPUT_LIMITS.url,
+  } as const;
   for (const field of ["message", "author_name", "author_email", "committer_name", "committer_email", "ref", "url"] as const) {
-    if (r[field] !== undefined && r[field] !== null && typeof r[field] !== "string") {
+    const val = r[field];
+    if (val === undefined || val === null) continue;
+    if (typeof val !== "string") {
       return fail(`${field} must be a string`);
+    }
+    if (tooLong(val, caps[field])) {
+      return fail(`${field} must be at most ${caps[field]} characters`);
     }
   }
 

--- a/src/utils/custom-rule-input.ts
+++ b/src/utils/custom-rule-input.ts
@@ -13,6 +13,7 @@ import {
   type RuleField,
   type RuleOperation,
 } from "./custom-rules";
+import { INPUT_LIMITS, tooLong } from "./input-limits";
 
 export const MAX_RULES = 50;
 
@@ -71,6 +72,9 @@ export function validateCustomRules(body: unknown): ValidationResult<ValidatedRu
     if (typeof r.source_value !== "string" || r.source_value.length === 0) {
       return fail(`${at}.source_value must be a non-empty string`);
     }
+    if (tooLong(r.source_value, INPUT_LIMITS.ruleValue)) {
+      return fail(`${at}.source_value must be at most ${INPUT_LIMITS.ruleValue} characters`);
+    }
 
     const action = r.action as RuleAction;
     let destination: RuleField | "" = "";
@@ -81,6 +85,9 @@ export function validateCustomRules(body: unknown): ValidationResult<ValidatedRu
       }
       if (typeof r.destination_value !== "string" || r.destination_value.length === 0) {
         return fail(`${at}.destination_value must be a non-empty string for a change rule`);
+      }
+      if (tooLong(r.destination_value, INPUT_LIMITS.ruleValue)) {
+        return fail(`${at}.destination_value must be at most ${INPUT_LIMITS.ruleValue} characters`);
       }
       destination = r.destination as RuleField;
       destinationValue = r.destination_value;

--- a/src/utils/external-duration-input.ts
+++ b/src/utils/external-duration-input.ts
@@ -5,6 +5,7 @@
  * upsert, or a 400-worthy error. No D1, no I/O.
  */
 import type { components } from "../types/generated";
+import { INPUT_LIMITS, tooLong } from "./input-limits";
 
 export type ExternalDurationType = "file" | "app" | "domain";
 type Category = components["schemas"]["Category"];
@@ -68,8 +69,14 @@ export function validateExternalDuration(body: unknown): ValidationResult<Valida
   if (typeof r.external_id !== "string" || r.external_id.length === 0) {
     return fail("external_id is required and must be a non-empty string");
   }
+  if (tooLong(r.external_id, INPUT_LIMITS.externalId)) {
+    return fail(`external_id must be at most ${INPUT_LIMITS.externalId} characters`);
+  }
   if (typeof r.entity !== "string" || r.entity.length === 0) {
     return fail("entity is required and must be a non-empty string");
+  }
+  if (tooLong(r.entity, INPUT_LIMITS.entity)) {
+    return fail(`entity must be at most ${INPUT_LIMITS.entity} characters`);
   }
   if (!TYPES.has(r.type as string)) {
     return fail("type must be one of file, app, domain");
@@ -91,9 +98,22 @@ export function validateExternalDuration(body: unknown): ValidationResult<Valida
       return fail(`category must be one of: ${[...VALID_CATEGORIES].join(", ")}`);
     }
   }
+  // Length caps mirror the OpenAPI maxLength constraints (Issue #158;
+  // values from src/utils/input-limits.ts).
+  const caps = {
+    project: INPUT_LIMITS.name,
+    branch: INPUT_LIMITS.name,
+    language: INPUT_LIMITS.name,
+    meta: INPUT_LIMITS.meta,
+  } as const;
   for (const field of ["project", "branch", "language", "meta"] as const) {
-    if (r[field] !== undefined && r[field] !== null && typeof r[field] !== "string") {
+    const val = r[field];
+    if (val === undefined || val === null) continue;
+    if (typeof val !== "string") {
       return fail(`${field} must be a string`);
+    }
+    if (tooLong(val, caps[field])) {
+      return fail(`${field} must be at most ${caps[field]} characters`);
     }
   }
 

--- a/src/utils/input-limits.ts
+++ b/src/utils/input-limits.ts
@@ -1,0 +1,40 @@
+/**
+ * Write-input length caps (Issue #158, specs/158-input-maxlength/).
+ *
+ * Single source of truth for the values declared as maxLength/maxItems in
+ * the OpenAPI schemas (schemas/components/schemas/HeartbeatInput.yaml,
+ * CommitInput.yaml, ExternalDurationInput.yaml, CustomRuleInput.yaml).
+ * openapi-typescript does not surface these constraints in generated types,
+ * so the four validators import from here and a pinning unit test
+ * (tests/security/input-limits.test.ts) holds spec<->validator parity
+ * (FR-007, research R-6). Caps are inclusive and count UTF-16 code units.
+ */
+export const INPUT_LIMITS = {
+  // HeartbeatInput / ExternalDurationInput shared dimensions
+  entity: 4096, // Linux PATH_MAX; also covers url/domain entities
+  name: 255, // project, branch, language, editor, operating_system, machine
+  userAgent: 512,
+  dependenciesString: 8192, // comma-separated form, pre-split
+  dependenciesItems: 100,
+  dependencyName: 255,
+  // CommitInput
+  commitHash: 64, // SHA-256 hex width
+  commitMessage: 4096,
+  email: 254, // RFC 5321 maximum address length
+  url: 2048,
+  // ExternalDurationInput
+  externalId: 255,
+  meta: 8192,
+  // CustomRuleInput
+  ruleValue: 1024, // entity-prefix rules may carry long path prefixes
+} as const;
+
+/** Inclusive cap check: true when the value exceeds the cap. */
+export function tooLong(value: string, cap: number): boolean {
+  return value.length > cap;
+}
+
+/** Truncate an ambient (header-derived) value to its cap (research R-5). */
+export function truncateTo(value: string, cap: number): string {
+  return value.length > cap ? value.slice(0, cap) : value;
+}

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -13,6 +13,8 @@
  * shapes leave the optional columns NULL.
  */
 
+import { INPUT_LIMITS, truncateTo } from "./input-limits";
+
 export interface ParsedUserAgent {
   /** Editor or plugin name (e.g. "vscode-wakatime"). Best-effort. */
   editor: string | null;
@@ -87,6 +89,10 @@ export async function resolveUserAgentId(
   cache?: Map<string, string>,
 ): Promise<string | null> {
   if (!value) return null;
+  // Ambient User-Agent headers may exceed the contract cap; truncate rather
+  // than reject (Issue #158, research R-5). Body-supplied values are
+  // validated upstream, so this is a no-op for them.
+  value = truncateTo(value, INPUT_LIMITS.userAgent);
   const cached = cache?.get(value);
   if (cached) return cached;
 

--- a/tests/aggregation/input-limit-boundaries.test.ts
+++ b/tests/aggregation/input-limit-boundaries.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Boundary tests for the write-input length caps (Issue #158, FR-002/FR-003):
+ * one at-cap accept and one over-cap reject per representative field of each
+ * pure validator. The heartbeat validator's boundaries are covered by the
+ * endpoint integration tests (tests/integration/heartbeats.test.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { INPUT_LIMITS } from "../../src/utils/input-limits";
+import { validateCommitInput } from "../../src/utils/commit-input";
+import { validateExternalDuration } from "../../src/utils/external-duration-input";
+import { validateCustomRules } from "../../src/utils/custom-rule-input";
+
+describe("commit input caps (#158)", () => {
+  it("accepts at-cap values", () => {
+    const result = validateCommitInput({
+      hash: "a".repeat(INPUT_LIMITS.commitHash),
+      message: "m".repeat(INPUT_LIMITS.commitMessage),
+      author_email: "e".repeat(INPUT_LIMITS.email),
+      url: "u".repeat(INPUT_LIMITS.url),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects over-cap values naming the field", () => {
+    const hash = validateCommitInput({ hash: "a".repeat(INPUT_LIMITS.commitHash + 1) });
+    expect(hash).toEqual({ ok: false, error: `hash must be at most ${INPUT_LIMITS.commitHash} characters` });
+
+    const ref = validateCommitInput({ hash: "abc", ref: "r".repeat(INPUT_LIMITS.name + 1) });
+    expect(ref).toEqual({ ok: false, error: `ref must be at most ${INPUT_LIMITS.name} characters` });
+  });
+});
+
+describe("external duration input caps (#158)", () => {
+  const base = {
+    external_id: "evt-1",
+    entity: "Meeting",
+    type: "app",
+    start_time: 1_750_000_000,
+    end_time: 1_750_000_600,
+  };
+
+  it("accepts at-cap values", () => {
+    const result = validateExternalDuration({
+      ...base,
+      external_id: "i".repeat(INPUT_LIMITS.externalId),
+      entity: "e".repeat(INPUT_LIMITS.entity),
+      meta: "m".repeat(INPUT_LIMITS.meta),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects over-cap values naming the field", () => {
+    const entity = validateExternalDuration({ ...base, entity: "e".repeat(INPUT_LIMITS.entity + 1) });
+    expect(entity).toEqual({ ok: false, error: `entity must be at most ${INPUT_LIMITS.entity} characters` });
+
+    const meta = validateExternalDuration({ ...base, meta: "m".repeat(INPUT_LIMITS.meta + 1) });
+    expect(meta).toEqual({ ok: false, error: `meta must be at most ${INPUT_LIMITS.meta} characters` });
+  });
+});
+
+describe("custom rule input caps (#158)", () => {
+  it("accepts at-cap rule values", () => {
+    const result = validateCustomRules([
+      {
+        action: "change",
+        source: "entity",
+        operation: "starts_with",
+        source_value: "s".repeat(INPUT_LIMITS.ruleValue),
+        destination: "project",
+        destination_value: "d".repeat(INPUT_LIMITS.ruleValue),
+      },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects over-cap rule values naming the field", () => {
+    const source = validateCustomRules([
+      { action: "hide", source: "entity", operation: "contains", source_value: "s".repeat(INPUT_LIMITS.ruleValue + 1) },
+    ]);
+    expect(source).toEqual({
+      ok: false,
+      error: `rule[0].source_value must be at most ${INPUT_LIMITS.ruleValue} characters`,
+    });
+
+    const destination = validateCustomRules([
+      {
+        action: "change",
+        source: "project",
+        operation: "equals",
+        source_value: "p",
+        destination: "project",
+        destination_value: "d".repeat(INPUT_LIMITS.ruleValue + 1),
+      },
+    ]);
+    expect(destination).toEqual({
+      ok: false,
+      error: `rule[0].destination_value must be at most ${INPUT_LIMITS.ruleValue} characters`,
+    });
+  });
+});

--- a/tests/integration/heartbeats.test.ts
+++ b/tests/integration/heartbeats.test.ts
@@ -249,3 +249,99 @@ describe("GET /api/v1/users/current/heartbeats", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("write-input length caps (#158)", () => {
+  afterEach(async () => {
+    await truncate("machine_names", "user_agents");
+  });
+
+  const base = { type: "file" as const, time: TIME_2026_03_14_10_00_UTC };
+
+  function post(body: unknown, headers: Record<string, string> = {}): Promise<Response> {
+    return callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader(user.apiKey), ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function heartbeatCount(): Promise<number> {
+    const row = await env.DB.prepare("SELECT COUNT(*) AS c FROM heartbeats").first<{ c: number }>();
+    return row?.c ?? 0;
+  }
+
+  it("rejects an oversized entity with 400 and stores nothing (US1)", async () => {
+    const res = await post({ ...base, entity: "x".repeat(4097) });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("entity must be at most 4096 characters");
+    expect(await heartbeatCount()).toBe(0);
+  });
+
+  it("accepts values at exactly the cap — limits are inclusive (FR-003)", async () => {
+    const res = await post({
+      ...base,
+      entity: "x".repeat(4096),
+      project: "p".repeat(255),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("bulk: an oversized item reports its per-item 400 while valid items persist (US1)", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader(user.apiKey) },
+      body: JSON.stringify([
+        { ...base, entity: "ok.ts" },
+        { ...base, entity: "big.ts", branch: "b".repeat(256) },
+      ]),
+    });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { responses: [{ data: unknown; error: string | null }, number][] };
+    expect(body.responses[0][1]).toBe(201);
+    expect(body.responses[1][1]).toBe(400);
+    expect(body.responses[1][0].error).toBe("branch must be at most 255 characters");
+    expect(await heartbeatCount()).toBe(1);
+  });
+
+  it("rejects dependencies beyond the item/count caps (FR-005)", async () => {
+    const tooMany = await post({
+      ...base,
+      entity: "a.ts",
+      dependencies: Array.from({ length: 101 }, (_, i) => `dep${i}`),
+    });
+    expect(tooMany.status).toBe(400);
+
+    const tooLongItem = await post({
+      ...base,
+      entity: "a.ts",
+      dependencies: ["d".repeat(256)],
+    });
+    expect(tooLongItem.status).toBe(400);
+  });
+
+  it("truncates an oversized User-Agent header and accepts the heartbeat (US3)", async () => {
+    const res = await post({ ...base, entity: "a.ts" }, { "User-Agent": "u".repeat(600) });
+    expect(res.status).toBe(201);
+    const row = await env.DB.prepare(
+      "SELECT value FROM user_agents WHERE user_id = ?",
+    ).bind(user.userId).first<{ value: string }>();
+    expect(row?.value).toHaveLength(512);
+  });
+
+  it("truncates an oversized X-Machine-Name header and accepts the heartbeat (US3)", async () => {
+    const res = await post({ ...base, entity: "a.ts" }, { "X-Machine-Name": "m".repeat(300) });
+    expect(res.status).toBe(201);
+    const row = await env.DB.prepare(
+      "SELECT value FROM machine_names WHERE user_id = ?",
+    ).bind(user.userId).first<{ value: string }>();
+    expect(row?.value).toHaveLength(255);
+  });
+
+  it("rejects oversized body user_agent and machine with 400 (US3 contrast)", async () => {
+    const ua = await post({ ...base, entity: "a.ts", user_agent: "u".repeat(513) });
+    expect(ua.status).toBe(400);
+    const machine = await post({ ...base, entity: "a.ts", machine: "m".repeat(256) });
+    expect(machine.status).toBe(400);
+  });
+});

--- a/tests/security/input-limits.test.ts
+++ b/tests/security/input-limits.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Pins the write-input caps to the values documented in the OpenAPI schemas
+ * and specs/158-input-maxlength/data-model.md (FR-007, research R-6).
+ * openapi-typescript does not surface maxLength in generated types, so this
+ * test is the drift guard between contract and validators.
+ */
+import { describe, expect, it } from "vitest";
+import { INPUT_LIMITS, tooLong, truncateTo } from "../../src/utils/input-limits";
+
+describe("INPUT_LIMITS parity with the OpenAPI contract (#158)", () => {
+  it("matches the documented cap table exactly", () => {
+    expect(INPUT_LIMITS).toEqual({
+      entity: 4096,
+      name: 255,
+      userAgent: 512,
+      dependenciesString: 8192,
+      dependenciesItems: 100,
+      dependencyName: 255,
+      commitHash: 64,
+      commitMessage: 4096,
+      email: 254,
+      url: 2048,
+      externalId: 255,
+      meta: 8192,
+      ruleValue: 1024,
+    });
+  });
+});
+
+describe("tooLong / truncateTo", () => {
+  it("caps are inclusive: at-cap passes, cap+1 fails (FR-003)", () => {
+    expect(tooLong("x".repeat(255), 255)).toBe(false);
+    expect(tooLong("x".repeat(256), 255)).toBe(true);
+    expect(tooLong("", 255)).toBe(false);
+  });
+
+  it("truncateTo returns the capped prefix and leaves short values untouched", () => {
+    expect(truncateTo("x".repeat(600), 512)).toHaveLength(512);
+    expect(truncateTo("short", 512)).toBe("short");
+    expect(truncateTo("x".repeat(512), 512)).toHaveLength(512);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -32,5 +32,9 @@ export default defineConfig({
   ],
   test: {
     setupFiles: ["./tests/setup.ts"],
+    // Agent worktrees under .claude/worktrees/ contain a full repo copy;
+    // without this exclude vitest discovers their tests too and runs the
+    // whole suite twice (against potentially stale sources).
+    exclude: ["**/node_modules/**", "**/.claude/**"],
   },
 });


### PR DESCRIPTION
## Summary

PR2 (Implementation) of the SpecKit 2-PR workflow for #158; the contract landed in #168. Implements tasks T004-T016 of `specs/158-input-maxlength/tasks.md`.

Body fields exceeding their documented caps now reject with the endpoints'' existing 400 formats (per-item on bulk heartbeats, all-or-nothing on bulk external durations — unchanged shapes); ambient header-derived values truncate instead of failing the write (User-Agent → 512 in `resolveUserAgentId`, X-Machine-Name → 255 at both heartbeat ingestion paths), per research R-5.

## Changes

- `src/utils/input-limits.ts` — NEW: `INPUT_LIMITS` constants (single source mirroring the OpenAPI maxLength values), `tooLong`, `truncateTo` (R-6)
- `src/routes/heartbeats.ts` — length checks in `validateHeartbeatInput` (incl. both dependency forms validated post-normalization: string ≤8192, ≤100 items, items ≤255) + header-machine truncation in single & bulk paths
- `src/utils/user-agent.ts` — UA truncation at `resolveUserAgentId` entry (covers header + cache paths; no-op for validated body values)
- `src/utils/commit-input.ts`, `src/utils/external-duration-input.ts`, `src/utils/custom-rule-input.ts` — caps from `INPUT_LIMITS`, error strings in each validator''s existing voice
- `tests/security/input-limits.test.ts` — parity pinning (FR-007) + helper behavior
- `tests/aggregation/input-limit-boundaries.test.ts` — at-cap accept / over-cap reject per validator
- `tests/integration/heartbeats.test.ts` — 7 endpoint cases (oversized 400 + nothing stored, inclusive boundary accept, bulk per-item shape, dependency caps, UA/machine header truncation, body-field contrast)
- `vitest.config.mts` — exclude `**/.claude/**` from test discovery (agent worktrees contain a full repo copy and were doubling the suite locally; CI unaffected)

## Testing

- `npm run typecheck` clean
- `npm test`: 34 files / 368 tests passed (352 baseline + 16 new); existing corpus unmodified (SC-002)

Closes #158. Refs #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)