### PR TITLE
feat: rate-limit the verify route and public global stats (PR2)

### DIFF
--- a/docs/cloudflare-constraints.md
+++ b/docs/cloudflare-constraints.md
@@ -124,29 +124,48 @@ Queues are paid-only ($0.40/million messages) but provide reliable async process
 | Caching | KV for auth + status bar | KV for auth + status bar + heartbeat buffer |
 | CPU budget | Keep per-request under 10ms | 30s budget, more room |
 
-## Rate Limiting on OAuth Endpoints
+## Rate Limiting on Unauthenticated Endpoints
 
-Cloudflare Workers' native Rate Limiting binding protects the OAuth login surface
-from abuse (KV exhaustion, CPU floods). Two bindings are declared in `wrangler.toml`:
+Cloudflare Workers' native Rate Limiting binding protects the unauthenticated
+surface from abuse (KV exhaustion, CPU floods, anonymous D1 work). Four
+bindings are declared in `wrangler.toml`:
 
 | Binding | Endpoint | Limit | Window | Key |
 |---|---|---|---|---|
 | `RATE_LIMIT_OAUTH_INITIATE` | `GET /api/v1/auth/:provider` | 10 | 60s | client IP truncated to /24 (IPv4) or /48 (IPv6) |
 | `RATE_LIMIT_OAUTH_CALLBACK` | `GET /api/v1/auth/:provider/callback` | 5 | 60s | same key derivation |
+| `RATE_LIMIT_LINK_VERIFY` | `GET /api/v1/auth/link/verify/:token` | 5 | 60s | same key derivation |
+| `RATE_LIMIT_PUBLIC_STATS` | `GET /api/v1/stats/:range` | 30 | 60s | same key derivation |
 
 The middleware (`src/middleware/rate-limit.ts`) reads `CF-Connecting-IP`,
-falls back to `X-Forwarded-For` first hop, and finally to `"unknown"`. When the
-binding is unconfigured (typical for `wrangler dev --local`), the middleware
+falls back to `X-Forwarded-For` first hop, and finally to `"unknown"`. When a
+binding is unconfigured (typical for `wrangler dev --local`), the check
 fails open and emits a single warning per isolate.
+
+Evaluation-order guarantees (Issue #159): on the verify route the limiter
+runs after the free `405` method check (method probes never consume a real
+user's budget) and before any token/D1 work; on the public stats route the
+`PUBLIC_STATS = "false"` gate runs first, so a disabled instance answers a
+uniform `404`, never `429`, and spends no limiter budget.
 
 **Operator action before production deploy**: confirm the current Cloudflare
 plan supports the configured Rate Limiting bindings. The free tier includes
 a usage-capped allowance for the Workers Rate Limiting API; commercial
 deployments may need a paid plan. Adjust `limit`/`period` in `wrangler.toml`
-without code changes.
+without code changes (`period` must be 10 or 60; `namespace_id` values must
+stay unique per Cloudflare account).
 
-See `specs/058-oauth-rate-limiting/` for the full spec, design, and
-verification scenarios.
+**Why there is no blanket limiter on failed API-key auth (401s)**: the
+auth-failure path costs a single indexed D1 point-read; the binding counts
+per edge location and is intentionally approximate, which fits a
+low-and-slow distributed pattern across ~30 operations poorly; and wiring it
+into `authMiddleware` would add a `429` to every documented operation for
+marginal benefit. Operators who want broad-spectrum throttling should use
+zone-level WAF rate-limiting rules, which run before the Worker is invoked
+at all (see `specs/159-rate-limit-expansion/research.md` D-4).
+
+See `specs/058-oauth-rate-limiting/` and `specs/159-rate-limit-expansion/`
+for the full specs, designs, and verification scenarios.
 
 ## Implementation Notes
 

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,7 +1,9 @@
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { Env, RateLimit } from "../types";
 
 const warned = new WeakSet<object>();
+const warnedRules = new Set<string>();
 
 function stripIpDecoration(ip: string): string {
   const trimmed = ip.trim();
@@ -60,6 +62,44 @@ function getClientIp(headers: Headers): string {
   return "unknown";
 }
 
+/**
+ * Imperative form of the rate-limit check for handlers that need it inside
+ * an existing routing structure (Issue #159) — e.g. after a method check or
+ * the PUBLIC_STATS gate. Returns true when the request must be rejected with
+ * `tooManyRequests(c)`. Fails open (returns false) with one warning per rule
+ * when the binding is undefined, matching the middleware behavior.
+ */
+export async function rateLimitExceeded(
+  binding: RateLimit | undefined,
+  headers: Headers,
+  endpointName: string,
+  ruleName: string,
+): Promise<boolean> {
+  if (!binding) {
+    if (!warnedRules.has(ruleName)) {
+      warnedRules.add(ruleName);
+      console.warn(`[rate-limit] binding ${ruleName} is undefined; failing open for this isolate`);
+    }
+    return false;
+  }
+
+  const key = truncateIp(getClientIp(headers));
+  const { success } = await binding.limit({ key });
+  if (!success) {
+    console.warn(`[rate-limit] rejected endpoint=${endpointName} rule=${ruleName} key=${key}`);
+  }
+  return !success;
+}
+
+/** The shared 429 response shape used by every rate-limited endpoint. */
+export function tooManyRequests(c: Context): Response {
+  return c.json({ error: "Too many requests" }, 429, {
+    "Retry-After": "60",
+    "Cache-Control": "no-store",
+    Pragma: "no-cache",
+  });
+}
+
 export function rateLimitMiddleware(
   getBinding: (env: Env) => RateLimit | undefined,
   endpointName: string,
@@ -82,10 +122,6 @@ export function rateLimitMiddleware(
     if (success) return next();
 
     console.warn(`[rate-limit] rejected endpoint=${endpointName} rule=${ruleName} key=${key}`);
-    return c.json({ error: "Too many requests" }, 429, {
-      "Retry-After": "60",
-      "Cache-Control": "no-store",
-      Pragma: "no-cache",
-    });
+    return tooManyRequests(c);
   });
 }

--- a/src/routes/auth/link.ts
+++ b/src/routes/auth/link.ts
@@ -30,6 +30,7 @@ import {
   getStateCookie,
   clearStateCookie,
 } from "../../utils/session";
+import { rateLimitExceeded, tooManyRequests } from "../../middleware/rate-limit";
 import { type UserRow, USER_COLUMNS, rowToUser, normalizeDateTime } from "../../utils/user";
 import { sessionMw } from "./middleware";
 import { getRedirectUri, noCacheHeaders } from "./helpers";
@@ -59,6 +60,14 @@ link.all("/link/verify/:token", async (c) => {
       "Cache-Control": "no-store",
     });
   }
+
+  // Edge rate limit (Issue #159): after the free 405 branch — method probes
+  // must not consume the budget of a user's real click — and before any
+  // mode/token processing so rejected requests cost no D1 work.
+  if (await rateLimitExceeded(c.env.RATE_LIMIT_LINK_VERIFY, c.req.raw.headers, "link-verify", "RATE_LIMIT_LINK_VERIFY")) {
+    return tooManyRequests(c);
+  }
+
   if (c.env.INSTANCE_MODE !== "multi") {
     return c.json({ error: "Token not found" }, 410, noCacheHeaders());
   }

--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import type { components } from "../types/generated";
+import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
 import { EDITORS } from "../data/editors";
 import { LANGUAGES } from "../data/languages";
 import { resolveStatsRange } from "../utils/stats-range";
@@ -44,6 +45,13 @@ meta.get("/stats/:range", async (c) => {
   // distinguish "disabled" from "absent" and generates no load.
   if ((c.env.PUBLIC_STATS ?? "").trim().toLowerCase() === "false") {
     return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
+  }
+
+  // Edge rate limit (Issue #159): strictly after the disabled gate — a
+  // disabled instance never emits 429 and spends no limiter budget — and
+  // before range validation, the KV cache, and D1.
+  if (await rateLimitExceeded(c.env.RATE_LIMIT_PUBLIC_STATS, c.req.raw.headers, "global-stats", "RATE_LIMIT_PUBLIC_STATS")) {
+    return tooManyRequests(c);
   }
 
   const rangeParam = c.req.param("range");

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,10 @@ export interface Env {
   // Rate-limit bindings (optional — middleware fails open when undefined)
   RATE_LIMIT_OAUTH_INITIATE?: RateLimit;
   RATE_LIMIT_OAUTH_CALLBACK?: RateLimit;
+  // Issue #159: out-of-band verify route (5/60s) and public global stats
+  // (30/60s); see specs/159-rate-limit-expansion/.
+  RATE_LIMIT_LINK_VERIFY?: RateLimit;
+  RATE_LIMIT_PUBLIC_STATS?: RateLimit;
 
   // Email delivery (Issue #80). Required in multi-user mode for the
   // out-of-band PendingLink verification flow. Single-user mode does not

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -29,6 +29,8 @@ declare global {
       GOOGLE_HOSTED_DOMAIN?: string;
       RATE_LIMIT_OAUTH_INITIATE?: import("../src/types").RateLimit;
       RATE_LIMIT_OAUTH_CALLBACK?: import("../src/types").RateLimit;
+      RATE_LIMIT_LINK_VERIFY?: import("../src/types").RateLimit;
+      RATE_LIMIT_PUBLIC_STATS?: import("../src/types").RateLimit;
     }
   }
 }

--- a/tests/integration/global-stats.test.ts
+++ b/tests/integration/global-stats.test.ts
@@ -160,3 +160,41 @@ describe("PUBLIC_STATS instance switch (#156)", () => {
     }
   });
 });
+
+describe("rate limiting on GET /api/v1/stats/:range (#159)", () => {
+  it("returns 429 and does no cache/D1 work when the limiter rejects (US1)", async () => {
+    const res = await call("/api/v1/stats/last_7_days", {}, {
+      RATE_LIMIT_PUBLIC_STATS: { limit: async () => ({ success: false }) },
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(await res.json()).toEqual({ error: "Too many requests" });
+    expect(await env.KV.get("global-stats:last_7_days", "json")).toBeNull();
+  });
+
+  it("passes through unchanged when the limiter allows (US2)", async () => {
+    const res = await call("/api/v1/stats/last_7_days", {}, {
+      RATE_LIMIT_PUBLIC_STATS: { limit: async () => ({ success: true }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await env.KV.get("global-stats:last_7_days", "json")).not.toBeNull();
+  });
+
+  it("disabled instance: the 404 gate wins and the limiter is never consulted (US3/SC-004)", async () => {
+    let calls = 0;
+    const res = await call("/api/v1/stats/last_7_days", {}, {
+      PUBLIC_STATS: "false",
+      RATE_LIMIT_PUBLIC_STATS: {
+        limit: async () => {
+          calls++;
+          return { success: false };
+        },
+      },
+    });
+
+    expect(res.status).toBe(404);
+    expect(calls).toBe(0);
+  });
+});

--- a/tests/integration/pending-link-verify.test.ts
+++ b/tests/integration/pending-link-verify.test.ts
@@ -276,3 +276,53 @@ describe("POST /api/v1/auth/link/approve/:pending_link_id email-verification gat
     expect(await res.json()).toEqual({ error: "Email verification required" });
   });
 });
+
+describe("rate limiting on GET /api/v1/auth/link/verify/:token (#159)", () => {
+  const EXCEEDED = {
+    RATE_LIMIT_LINK_VERIFY: { limit: async () => ({ success: false }) },
+  };
+
+  it("returns 429 with Retry-After and does not consume the token (US1)", async () => {
+    const { pendingLinkId, token } = await seedPendingLink({ ownerId: owner.userId });
+
+    const res = await call(`/api/v1/auth/link/verify/${token}`, {}, EXCEEDED);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(await res.json()).toEqual({ error: "Too many requests" });
+    const row = await env.DB.prepare(
+      "SELECT email_verified_at FROM pending_links WHERE id = ?",
+    )
+      .bind(pendingLinkId)
+      .first<{ email_verified_at: string | null }>();
+    expect(row?.email_verified_at).toBeNull();
+  });
+
+  it("non-GET probes still get 405 without consuming limiter budget (research D-2)", async () => {
+    let calls = 0;
+    const spy = {
+      RATE_LIMIT_LINK_VERIFY: {
+        limit: async () => {
+          calls++;
+          return { success: false };
+        },
+      },
+    };
+
+    const res = await call("/api/v1/auth/link/verify/anything", { method: "POST" }, spy);
+
+    expect(res.status).toBe(405);
+    expect(calls).toBe(0);
+  });
+
+  it("passes through unchanged when the limiter allows (US2)", async () => {
+    const { token } = await seedPendingLink({ ownerId: owner.userId });
+    const ok = {
+      RATE_LIMIT_LINK_VERIFY: { limit: async () => ({ success: true }) },
+    };
+
+    const res = await call(`/api/v1/auth/link/verify/${token}`, {}, ok);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -85,3 +85,23 @@ namespace_id = "1002"
   [ratelimits.simple]
   limit = 5
   period = 60
+
+# Issue #159 — out-of-band email verification route (one click per emailed
+# link is the entire legitimate flow; mirrors the OAuth callback limit).
+[[ratelimits]]
+name = "RATE_LIMIT_LINK_VERIFY"
+namespace_id = "1003"
+  [ratelimits.simple]
+  limit = 5
+  period = 60
+
+# Issue #159 — public global stats (responses are KV-cached for 5 minutes;
+# 30/min absorbs dashboards/badges and NAT-aggregated networks). On
+# PUBLIC_STATS = "false" instances the 404 gate runs first and this limiter
+# is never consulted.
+[[ratelimits]]
+name = "RATE_LIMIT_PUBLIC_STATS"
+namespace_id = "1004"
+  [ratelimits.simple]
+  limit = 30
+  period = 60


### PR DESCRIPTION
## Summary

PR2 (Implementation) of the SpecKit 2-PR workflow for #159; the contract landed in #169. Implements tasks T004-T012 of `specs/159-rate-limit-expansion/tasks.md`.

Extends the 058 pattern to the two remaining unauthenticated D1-touching endpoints, with the evaluation-order guarantees fixed by the spec:

- **`GET /auth/link/verify/{token}`** — `RATE_LIMIT_LINK_VERIFY` (ns 1003, 5/60 s per truncated IP), placed **after the free 405 method branch** (method probes cannot starve a real click) and **before any mode/token/D1 work** (research D-2)
- **`GET /stats/{range}`** — `RATE_LIMIT_PUBLIC_STATS` (ns 1004, 30/60 s), placed **strictly after the `PUBLIC_STATS` disabled gate** (#156): a disabled instance answers a uniform 404, never 429, and spends no limiter budget (research D-3)

Both reuse the existing keying (/24 IPv4, /48 IPv6) and fail open with one warning when unbound — the default test pool and fresh deployments are unaffected.

## Changes

- `src/middleware/rate-limit.ts` — extracted imperative `rateLimitExceeded()` + `tooManyRequests()` (shared by the middleware, which is behaviorally unchanged for the OAuth routes)
- `src/routes/auth/link.ts`, `src/routes/meta.ts` — the two wiring points
- `wrangler.toml` — the two `[[ratelimits]]` blocks (operator action for release notes; D1/KV placeholder ids untouched)
- `src/types.ts`, `tests/env.d.ts` — bindings
- `tests/integration/pending-link-verify.test.ts` (+3), `tests/integration/global-stats.test.ts` (+3) — stub-binding cases: 429 + `Retry-After` without consuming the token / without cache work; 405 probes consume zero budget (spy); pass-through when allowed; disabled-stats spy proving the limiter is never consulted (SC-004)
- `docs/cloudflare-constraints.md` — four-namespace table, evaluation-order guarantees, and the recorded deferral of a blanket 401 limiter to zone-level WAF rules (FR-007, research D-4)

## Testing

- `npm run typecheck` clean
- `npm test`: full suite green (+6 new cases)

Closes #159. Refs #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)