### PR TITLE
docs: add language guidance note to top of CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+Think in English, interact with the user in Japanese.
+
 # CloudTime - Development Rules
 
 - All code, comments, commit messages, docs, and PR descriptions must be in English


### PR DESCRIPTION
Add a one-line guidance note at the very top of CLAUDE.md:

> Think in English, interact with the user in Japanese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)