### PR TITLE
docs: embeddable stat cards spec and contract (spec 160)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/159-rate-limit-expansion"
+  "feature_directory": "specs/160-embeddable-cards"
 }

--- a/schemas/components/schemas/EmbedSettings.yaml
+++ b/schemas/components/schemas/EmbedSettings.yaml
@@ -1,0 +1,29 @@
+type: object
+required:
+  - enabled
+  - freshness_minutes
+  - default_theme
+properties:
+  enabled:
+    type: boolean
+    description: Whether public embeddable cards may return coding stats.
+    default: false
+  freshness_minutes:
+    type: integer
+    description: Cache freshness window for rendered public cards.
+    minimum: 1
+    maximum: 1440
+    default: 15
+  default_theme:
+    type: string
+    description: Default built-in visual theme used when a card URL omits or provides an unknown theme.
+    minLength: 1
+    maxLength: 32
+    pattern: ^[a-z0-9_-]+$
+    default: default
+  created_at:
+    type: string
+    format: date-time
+  modified_at:
+    type: string
+    format: date-time

--- a/schemas/components/schemas/EmbedSettingsUpdate.yaml
+++ b/schemas/components/schemas/EmbedSettingsUpdate.yaml
@@ -1,0 +1,17 @@
+type: object
+minProperties: 1
+properties:
+  enabled:
+    type: boolean
+    description: Whether public embeddable cards may return coding stats.
+  freshness_minutes:
+    type: integer
+    description: Cache freshness window for rendered public cards.
+    minimum: 1
+    maximum: 1440
+  default_theme:
+    type: string
+    description: Default built-in visual theme used when a card URL omits or provides an unknown theme.
+    minLength: 1
+    maxLength: 32
+    pattern: ^[a-z0-9_-]+$

--- a/schemas/components/schemas/EmbedTemplate.yaml
+++ b/schemas/components/schemas/EmbedTemplate.yaml
@@ -1,0 +1,26 @@
+type: object
+required:
+  - id
+  - name
+  - template_svg
+  - created_at
+  - modified_at
+properties:
+  id:
+    type: string
+    format: uuid
+  name:
+    type: string
+    minLength: 1
+    maxLength: 64
+  template_svg:
+    type: string
+    description: Safe static SVG template containing recognized CloudTime placeholder tokens.
+    minLength: 1
+    maxLength: 20000
+  created_at:
+    type: string
+    format: date-time
+  modified_at:
+    type: string
+    format: date-time

--- a/schemas/components/schemas/EmbedTemplateInput.yaml
+++ b/schemas/components/schemas/EmbedTemplateInput.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - name
+  - template_svg
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 64
+  template_svg:
+    type: string
+    description: Safe static SVG template containing recognized CloudTime placeholder tokens.
+    minLength: 1
+    maxLength: 20000

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -52,6 +52,8 @@ tags:
     description: External time entries (calendar integrations)
   - name: commits
     description: Git commit time tracking
+  - name: embeddable_cards
+    description: Public SVG stat cards and authenticated embed configuration
   - name: orgs
     description: Organization and team management
   - name: meta
@@ -92,6 +94,14 @@ paths:
     $ref: paths/users/projects.yaml
   /users/current/data_dumps:
     $ref: paths/users/data-dumps.yaml
+  /users/{username}/cards/{card_type}.svg:
+    $ref: paths/cards/public-card.yaml
+  /users/current/embed_settings:
+    $ref: paths/cards/embed-settings.yaml
+  /users/current/embed_templates:
+    $ref: paths/cards/embed-templates.yaml
+  /users/current/embed_templates/{template_id}:
+    $ref: paths/cards/embed-template.yaml
 
   # --- heartbeats ---
   /users/current/heartbeats:

--- a/schemas/paths/cards/embed-settings.yaml
+++ b/schemas/paths/cards/embed-settings.yaml
@@ -1,0 +1,49 @@
+get:
+  operationId: getEmbedSettings
+  tags:
+    - embeddable_cards
+  summary: Get current user's embed settings
+  description: |
+    Returns the authenticated user's embeddable-card settings. When no stored
+    row exists, the server returns default-safe settings with embeds disabled.
+  responses:
+    '200':
+      description: Embed settings
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/EmbedSettings.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+patch:
+  operationId: updateEmbedSettings
+  tags:
+    - embeddable_cards
+  summary: Update current user's embed settings
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/EmbedSettingsUpdate.yaml
+  responses:
+    '200':
+      description: Embed settings updated
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/EmbedSettings.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/cards/embed-template.yaml
+++ b/schemas/paths/cards/embed-template.yaml
@@ -1,0 +1,84 @@
+parameters:
+  - name: template_id
+    in: path
+    required: true
+    description: Embed template id.
+    schema:
+      type: string
+      format: uuid
+get:
+  operationId: getEmbedTemplate
+  tags:
+    - embeddable_cards
+  summary: Get an embed template
+  responses:
+    '200':
+      description: Embed template
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/EmbedTemplate.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+patch:
+  operationId: updateEmbedTemplate
+  tags:
+    - embeddable_cards
+  summary: Update an embed template
+  description: |
+    Updates an owned template. If `template_svg` is supplied, it is validated
+    with the same safe-static-SVG policy as template creation before storage.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          minProperties: 1
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 64
+            template_svg:
+              type: string
+              description: Safe static SVG template containing recognized CloudTime placeholder tokens.
+              minLength: 1
+              maxLength: 20000
+  responses:
+    '200':
+      description: Embed template updated
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/EmbedTemplate.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+delete:
+  operationId: deleteEmbedTemplate
+  tags:
+    - embeddable_cards
+  summary: Delete an embed template
+  responses:
+    '204':
+      description: Embed template deleted
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml

--- a/schemas/paths/cards/embed-templates.yaml
+++ b/schemas/paths/cards/embed-templates.yaml
@@ -1,0 +1,53 @@
+get:
+  operationId: listEmbedTemplates
+  tags:
+    - embeddable_cards
+  summary: List current user's embed templates
+  responses:
+    '200':
+      description: List of embed templates
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../components/schemas/EmbedTemplate.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+post:
+  operationId: createEmbedTemplate
+  tags:
+    - embeddable_cards
+  summary: Create an embed template
+  description: |
+    Stores a user-defined SVG template after validating it as a safe static SVG
+    subset. Templates containing scripts, event-handler attributes,
+    `foreignObject`, external references, data URLs, remote fonts, malformed
+    SVG, or unknown placeholders return `400` and are not stored.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/EmbedTemplateInput.yaml
+  responses:
+    '201':
+      description: Embed template created
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/EmbedTemplate.yaml
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/cards/public-card.yaml
+++ b/schemas/paths/cards/public-card.yaml
@@ -1,0 +1,89 @@
+get:
+  operationId: getEmbeddableCard
+  tags:
+    - embeddable_cards
+  summary: Render a public embeddable stats card
+  description: |
+    Returns an SVG image suitable for embedding in a GitHub README or any
+    page that displays remote images. This operation is intentionally public
+    (`security: []`) and MUST NOT require or accept an API key in the URL.
+
+    The target user is selected by a non-secret username. If embeds are
+    disabled for that user, the user does not exist, or the requested template
+    is unavailable, the response is `404` and no cached card image is served.
+
+    Successful responses include explicit cache headers derived from the
+    user's freshness window. The optional `v` parameter participates in cache
+    keys so a user can force a refetch, but it never changes card data or
+    visibility.
+  security: []
+  parameters:
+    - name: username
+      in: path
+      required: true
+      description: Public CloudTime username identifying the card owner.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 64
+    - name: card_type
+      in: path
+      required: true
+      description: Card type to render.
+      schema:
+        type: string
+        enum:
+          - heatmap
+          - summary
+          - languages
+    - name: range
+      in: query
+      required: false
+      description: Optional stats range. Unsupported or missing values use the card's default range where allowed.
+      schema:
+        type: string
+        maxLength: 32
+    - name: theme
+      in: query
+      required: false
+      description: Built-in visual theme. Unknown themes fall back to the user's default theme.
+      schema:
+        type: string
+        maxLength: 32
+        pattern: ^[a-zA-Z0-9_-]+$
+    - name: template_id
+      in: query
+      required: false
+      description: Optional custom template owned by the target user.
+      schema:
+        type: string
+        format: uuid
+    - name: v
+      in: query
+      required: false
+      description: Optional cache-busting value. Changes the cache key only.
+      schema:
+        type: string
+        maxLength: 64
+  responses:
+    '200':
+      description: SVG card image
+      headers:
+        Cache-Control:
+          description: Public cache policy derived from the user's freshness window.
+          schema:
+            type: string
+        ETag:
+          description: Entity tag for the rendered SVG.
+          schema:
+            type: string
+      content:
+        image/svg+xml:
+          schema:
+            type: string
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+    '429':
+      $ref: ../../components/responses/TooManyRequests.yaml

--- a/specs/160-embeddable-cards/checklists/requirements.md
+++ b/specs/160-embeddable-cards/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Embeddable Stat Cards
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The previously open clarification (User Story 6 / FR-007) is resolved: the custom feature is
+  a **user-defined card template with placeholder tokens** that the system fills with the user's
+  stats, treated as untrusted content (size limits + safe-content policy, no scripts/external
+  references). Spec updated accordingly.
+- All other underspecified details were resolved with reasonable defaults recorded in the
+  Assumptions section.
+- All checklist items pass. Spec is ready for `/speckit-plan` (or `/speckit-clarify` if deeper
+  refinement is wanted first).

--- a/specs/160-embeddable-cards/contracts/openapi-diff.md
+++ b/specs/160-embeddable-cards/contracts/openapi-diff.md
@@ -1,0 +1,131 @@
+# OpenAPI Contract Diff: Embeddable Stat Cards
+
+**Branch**: `spec/160-embeddable-cards`
+**Files**:
+
+- `schemas/openapi.yaml`
+- `schemas/paths/cards/public-card.yaml`
+- `schemas/paths/cards/embed-settings.yaml`
+- `schemas/paths/cards/embed-templates.yaml`
+- `schemas/paths/cards/embed-template.yaml`
+- `schemas/components/schemas/EmbedSettings.yaml`
+- `schemas/components/schemas/EmbedSettingsUpdate.yaml`
+- `schemas/components/schemas/EmbedTemplate.yaml`
+- `schemas/components/schemas/EmbedTemplateInput.yaml`
+
+Additive only. No existing endpoint, parameter, schema, or response is changed.
+
+## 1. `schemas/openapi.yaml`
+
+- Add tag:
+
+  ```yaml
+  - name: embeddable_cards
+    description: Public SVG stat cards and authenticated embed configuration
+  ```
+
+- Add paths:
+
+  ```yaml
+  /users/{username}/cards/{card_type}.svg:
+    $ref: paths/cards/public-card.yaml
+  /users/current/embed_settings:
+    $ref: paths/cards/embed-settings.yaml
+  /users/current/embed_templates:
+    $ref: paths/cards/embed-templates.yaml
+  /users/current/embed_templates/{template_id}:
+    $ref: paths/cards/embed-template.yaml
+  ```
+
+## 2. Public card image
+
+`GET /users/{username}/cards/{card_type}.svg`
+
+- `security: []`
+- Path parameters:
+  - `username` string
+  - `card_type` enum: `heatmap`, `summary`, `languages`
+- Query parameters:
+  - `range` string (optional)
+  - `theme` string (optional)
+  - `template_id` string UUID (optional)
+  - `v` string cache-busting value (optional)
+- Responses:
+  - `200 image/svg+xml` string with `Cache-Control` and `ETag` headers
+  - `400` BadRequest for malformed options such as an invalid UUID
+  - `404` NotFound for disabled embeds, unknown user, unknown card type, or unavailable template
+  - `429` TooManyRequests for configured public-card rate limiting
+
+Contract notes:
+
+- The URL contains no API key and accepts no credentials.
+- Visibility OFF returns `404` before serving cached SVG.
+- `v` changes cache keys only; it does not select data.
+
+## 3. Embed settings
+
+`GET /users/current/embed_settings`
+
+- Authenticated through the global security schemes.
+- Response `200`:
+
+  ```yaml
+  data:
+    $ref: ../../components/schemas/EmbedSettings.yaml
+  ```
+
+`PATCH /users/current/embed_settings`
+
+- Request:
+
+  ```yaml
+  $ref: ../../components/schemas/EmbedSettingsUpdate.yaml
+  ```
+
+- Responses:
+  - `200` updated `EmbedSettings`
+  - `400` BadRequest
+  - `401` Unauthorized
+
+## 4. Embed templates
+
+`GET /users/current/embed_templates`
+
+- Response `200` list of `EmbedTemplate`.
+
+`POST /users/current/embed_templates`
+
+- Request `EmbedTemplateInput`.
+- Response `201` created `EmbedTemplate`.
+- Validation failures return `400`.
+
+`GET /users/current/embed_templates/{template_id}`
+
+- Response `200` `EmbedTemplate`.
+- Missing/cross-user template returns `404`.
+
+`PATCH /users/current/embed_templates/{template_id}`
+
+- Request object with partial `name` and/or `template_svg` fields.
+- Response `200` updated `EmbedTemplate`.
+- Validation failures return `400`.
+
+`DELETE /users/current/embed_templates/{template_id}`
+
+- Response `204`.
+- Missing/cross-user template returns `404`.
+
+## 5. Generated types impact
+
+`src/types/generated.ts` gains:
+
+- `paths["/users/{username}/cards/{card_type}.svg"]`
+- `paths["/users/current/embed_settings"]`
+- `paths["/users/current/embed_templates"]`
+- `paths["/users/current/embed_templates/{template_id}"]`
+- `components["schemas"]["EmbedSettings"]`
+- `components["schemas"]["EmbedSettingsUpdate"]`
+- `components["schemas"]["EmbedTemplate"]`
+- `components["schemas"]["EmbedTemplateInput"]`
+
+No existing generated member is removed or renamed.

--- a/specs/160-embeddable-cards/data-model.md
+++ b/specs/160-embeddable-cards/data-model.md
@@ -1,0 +1,125 @@
+# Data Model: Embeddable Stat Cards
+
+**Branch**: `spec/160-embeddable-cards` | **Date**: 2026-06-18
+
+## Persisted Data
+
+### Embed Settings
+
+One row per user. Defaults are applied when the row is absent.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `user_id` | text | Primary key; references `users.id`. |
+| `enabled` | integer boolean | Default `0` (OFF). Public cards return `404` unless enabled. |
+| `freshness_minutes` | integer | Default `15`; bounded by API validation. Drives `Cache-Control` and KV TTL. |
+| `default_theme` | text | Styling-only preset name; defaults to `default`. |
+| `created_at` | text datetime | Server timestamp. |
+| `modified_at` | text datetime | Updated on every settings change. |
+
+Rules:
+
+- Missing settings row means `{ enabled: false, freshness_minutes: 15,
+  default_theme: "default" }`.
+- Visibility OFF must be evaluated before rendered-card cache lookup.
+- `freshness_minutes` controls freshness only; it does not authorize or expose
+  any additional data.
+
+### Embed Template
+
+User-supplied safe SVG template for P3 customization.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | text UUID | Primary key. |
+| `user_id` | text | Required for all table rows; references `users.id`. |
+| `name` | text | User-visible label, max 64 chars. |
+| `template_svg` | text | Safe static SVG subset, max 20 KB in PR2. |
+| `created_at` | text datetime | Server timestamp. |
+| `modified_at` | text datetime | Updated on every template change. |
+
+Indexes:
+
+- `embed_templates(user_id, created_at DESC)` for list.
+- Unique `(user_id, name)` is optional; PR2 may allow duplicate names because
+  URLs reference `template_id`.
+
+Validation:
+
+- Reject malformed XML/SVG.
+- Reject scripts, event-handler attributes, `foreignObject`, external
+  references, remote fonts, data URLs, processing instructions, and unknown
+  placeholders.
+- Placeholder set is fixed in PR2 and documented from the renderer tests.
+- Revalidate on render as defense in depth; a stored template that fails
+  current validation is not rendered.
+
+## Derived Data
+
+### Embeddable Card
+
+Not persisted. A card render is derived from:
+
+- target user;
+- card type (`heatmap`, `summary`, `languages`);
+- range;
+- theme;
+- optional template id;
+- current embed settings;
+- aggregated summaries/hourly summaries plus current-day overlay.
+
+### Rendered Card Cache Entry
+
+Stored in KV, not D1.
+
+| Key Part | Notes |
+|----------|-------|
+| `user_id` | Internal user id resolved from the public username. |
+| `card_type` | `heatmap`, `summary`, or `languages`. |
+| `range` | Normalized range after fallback/defaulting. |
+| `theme` | Normalized theme after fallback/defaulting. |
+| `template_id` | Present only when a template is used. |
+| `v` | Optional caller-supplied cache-busting value. |
+| `settings.modified_at` | Included or otherwise invalidates cache after OFF/theme/freshness changes. |
+
+Value:
+
+- SVG string.
+- Render metadata such as generated time and ETag input hash.
+
+TTL:
+
+- `freshness_minutes * 60` seconds.
+- OFF responses are not cached as images and use `Cache-Control: no-store`.
+
+## State Transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Off: missing row or enabled=false
+    Off --> On: PATCH enabled=true
+    On --> Off: PATCH enabled=false
+    On --> On: update freshness/theme
+    On --> Rendered: public card request
+    Rendered --> On: cache expires or v changes
+```
+
+## Data Access Patterns
+
+- Public card request:
+  1. Resolve `username` to `users.id` and timezone.
+  2. Read embed settings or apply OFF defaults.
+  3. If OFF, return `404` before KV/D1 aggregate reads.
+  4. Check rate limit.
+  5. Check KV rendered-card cache.
+  6. On miss, read aggregates/current-day overlay and optional template.
+  7. Render SVG, store in KV, return with cache headers.
+
+- Settings request:
+  - Authenticated user only; reads/writes the single settings row for
+    `c.get("userId")`.
+
+- Template request:
+  - Authenticated user only; every operation includes `user_id = current user`.
+  - Deletes do not need to purge all KV entries immediately if cache keys include
+    template modified state; PR2 may additionally delete known keys best-effort.

--- a/specs/160-embeddable-cards/plan.md
+++ b/specs/160-embeddable-cards/plan.md
@@ -1,0 +1,140 @@
+# Implementation Plan: Embeddable Stat Cards
+
+**Branch**: `spec/160-embeddable-cards` | **Date**: 2026-06-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/160-embeddable-cards/spec.md`
+
+## Summary
+
+Add a public, read-only SVG card surface for CloudTime stats, plus
+authenticated settings and template-management endpoints. Public cards are
+addressed by a non-secret username and card type, respect an explicit per-user
+embed visibility switch that defaults OFF, and are cacheable with a short
+operator-configurable freshness window. The first implementation renders SVG
+from aggregated summaries with a current-day overlay, so a GitHub README image
+can stay current without commits or scheduled repository jobs.
+
+**PR1 (this PR)**: SpecKit artifacts + OpenAPI paths/components for the public
+SVG card endpoint, embed settings, and custom template CRUD + regenerated
+types. **No route handlers, migrations, bindings, or docs-behavior changes.**
+
+**PR2 (after PR1 merges)**: D1 schema, Hono routes, render/cache helpers,
+SVG-template validation, rate-limit binding, integration tests, and operator
+docs.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7; existing D1/KV bindings; existing
+generated OpenAPI types. No new rendering dependency is planned for P1/P2; P3
+template validation may add a small XML/SVG parser only if an allowlist parser
+cannot be implemented safely with platform APIs.
+**Storage**: D1 for per-user embed settings and custom templates; KV for
+short-lived rendered-card cache entries. Existing `summaries` and
+`hourly_summaries` remain the source of aggregate data. Raw heartbeats are read
+only for the current-day overlay within a bounded local-day window.
+**Testing**: Vitest + workers pool. Contract/integration tests cover public
+card visibility, no-auth/no-secret URLs, cache headers, invalid parameters,
+theme fallback, current-day overlay, zero-activity SVG, and unsafe template
+rejection.
+**Performance Goals**: Public card hit path returns from KV; cache misses stay
+within the Workers 10 ms CPU budget by reading pre-aggregates and at most the
+current local day of heartbeats. Popular embeds must not trigger one D1 render
+per view.
+**Constraints**: Visibility OFF returns `404` before cache lookup or data reads;
+public card routes are `security: []` and never accept API keys; SVG output must
+not contain user-supplied active content; cache-busting query values only affect
+cache keys, never authorization or data selection.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | PR1 updates OpenAPI before implementation and regenerates `src/types/generated.ts`; PR2 will use generated route types. |
+| II. Cloudflare-Native | PASS | Public rendering is cache-first in KV and reads pre-aggregates on miss; current-day work is bounded. OFF path performs no cache/D1 work. |
+| III. Type Safety | PASS | All new endpoint and schema shapes are generated from `schemas/openapi.yaml`; no hand-edits to generated types. |
+| IV. Legal/Trademark | PASS | The feature is original; references are limited to "WakaTime-compatible" docs wording and no WakaTime source or assets are consulted. |
+| V. Simplicity First | PASS | Three fixed card types, styling-only built-in themes, one settings resource, and template customization deferred to P3. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/160-embeddable-cards/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── contracts/
+│   └── openapi-diff.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/openapi.yaml                         # CHANGE: embeddable_cards tag and path refs
+schemas/paths/cards/public-card.yaml         # ADD: unauthenticated SVG card operation
+schemas/paths/cards/embed-settings.yaml      # ADD: authenticated settings get/patch
+schemas/paths/cards/embed-templates.yaml     # ADD: authenticated template list/create
+schemas/paths/cards/embed-template.yaml      # ADD: authenticated template get/patch/delete
+schemas/components/schemas/EmbedSettings.yaml
+schemas/components/schemas/EmbedSettingsUpdate.yaml
+schemas/components/schemas/EmbedTemplate.yaml
+schemas/components/schemas/EmbedTemplateInput.yaml
+src/types/generated.ts                       # REGENERATED
+
+# PR2 (after PR1 merges)
+src/db/schema.sql                            # CHANGE: embed_settings, embed_templates
+src/types.ts                                 # CHANGE: optional RATE_LIMIT_EMBED_CARDS binding if configured
+src/index.ts                                 # CHANGE: mount public/authenticated card routes
+src/routes/cards.ts                          # ADD: public SVG + settings/templates handlers
+src/utils/cards/cache.ts                     # ADD: normalized cache keys and TTL policy
+src/utils/cards/data.ts                      # ADD: aggregate reads + current-day overlay
+src/utils/cards/render.ts                    # ADD: built-in SVG renderers
+src/utils/cards/templates.ts                 # ADD: placeholder substitution + safe SVG validation
+tests/integration/embeddable-cards.test.ts   # ADD: route and privacy contract tests
+tests/unit/cards-render.test.ts              # ADD: renderer/template unit tests
+docs/deployment-guide.md                     # CHANGE: embed privacy and freshness settings
+docs/cloudflare-constraints.md               # CHANGE: cache/rate-limit notes for public card traffic
+wrangler.toml                                # CHANGE: commented RATE_LIMIT_EMBED_CARDS block
+```
+
+**Structure Decision**: Use one `src/routes/cards.ts` sub-app mounted in two
+places: a public route under `/api/v1/users/{username}/cards/{card_type}.svg`
+with `security: []`, and authenticated management routes under
+`/api/v1/users/current`. The public handler begins with username/settings
+lookup and the OFF gate, then rate limiting, then KV cache, then bounded D1
+reads/rendering. Template upload is authenticated and validates/rejects unsafe
+SVG at write time so public rendering never evaluates untrusted active content.
+
+## Phases
+
+- **PR1 - Spec + Design (this PR)**: complete SpecKit artifacts; add OpenAPI
+  contract; run `npm run generate`; run API lint/typecheck.
+- **PR2 - Implementation**: add storage, routes, renderer/cache helpers,
+  template validation, tests, and docs; run `npm run typecheck && npm test`;
+  open PR targeting `develop` referencing PR1.
+
+## Risks & Mitigations
+
+- **GitHub image proxy keeps a stale image longer than CloudTime's TTL** -> send
+  explicit `Cache-Control`/`ETag`, document the configured freshness as the
+  server guarantee, and provide `v` cache-busting for immediate refresh.
+- **Embeds accidentally leak private stats** -> default OFF, `404` before cache
+  lookup or data reads, no API-key query parameters, integration tests for OFF
+  with a warm cache.
+- **Popular README causes per-view D1 work** -> KV-rendered SVG cache keyed by
+  normalized card options and freshness window; rate-limit binding for misses
+  and abusive clients.
+- **Unsafe user SVG executes when opened directly** -> reject unsafe constructs
+  at template write time and revalidate before render; never rely only on image
+  context restrictions.
+- **Current-day overlay scans too much raw heartbeat data** -> limit overlay to
+  the target user's current local day and reuse existing timeout/date helpers;
+  if the bounded query exceeds budget, fall back to the latest aggregate and
+  mark the renderer as pending in PR2 tests.

--- a/specs/160-embeddable-cards/quickstart.md
+++ b/specs/160-embeddable-cards/quickstart.md
@@ -1,0 +1,132 @@
+# Quickstart: Embeddable Stat Cards
+
+**Branch**: `spec/160-embeddable-cards` | **Scope**: PR2 behavior (PR1 ships contract only)
+
+## Prerequisites
+
+- Deployed or local Worker with the PR2 migration applied.
+- One authenticated CloudTime user with an API key or session.
+- At least one day of seeded summaries/heartbeats for visible non-empty cards.
+
+## 1. Confirm embeds default OFF
+
+Request a public card before enabling embeds:
+
+```bash
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg"
+```
+
+Expected:
+
+- `HTTP/1.1 404 Not Found`
+- no SVG body containing coding stats
+- `Cache-Control: no-store`
+
+## 2. Enable embeds and set freshness
+
+```bash
+curl -X PATCH "https://time.example.com/api/v1/users/current/embed_settings" \
+  -H "Authorization: Bearer $CLOUDTIME_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"enabled":true,"freshness_minutes":15,"default_theme":"default"}'
+```
+
+Expected JSON response includes:
+
+- `data.enabled: true`
+- `data.freshness_minutes: 15`
+
+## 3. Render the heatmap card
+
+```bash
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?theme=default"
+```
+
+Expected:
+
+- `HTTP/1.1 200 OK`
+- `Content-Type: image/svg+xml`
+- `Cache-Control` max-age derived from the freshness window
+- SVG contains no API key or secret
+- image renders in a browser and in Markdown:
+
+```markdown
+![CloudTime coding heatmap](https://time.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?theme=default)
+```
+
+## 4. Verify current-day freshness
+
+1. Record new coding activity for today.
+2. Wait for the configured freshness window, or change `v`:
+
+```bash
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?v=manual-1"
+```
+
+Expected: the card reflects today's additional activity without editing the
+host page beyond the optional `v` value.
+
+## 5. Verify card variants
+
+```bash
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?range=last_7_days&theme=dark"
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/languages.svg?range=last_30_days&theme=unknown"
+```
+
+Expected:
+
+- summary and language card totals match aggregated stats for the range
+- unknown theme falls back to the user's default theme
+- zero-activity ranges still return a valid readable SVG
+
+## 6. Verify custom template rejection
+
+```bash
+curl -X POST "https://time.example.com/api/v1/users/current/embed_templates" \
+  -H "Authorization: Bearer $CLOUDTIME_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"bad","template_svg":"<svg><script>alert(1)</script></svg>"}'
+```
+
+Expected:
+
+- `HTTP/1.1 400 Bad Request`
+- clear validation error
+- no template is created
+
+Repeat with event handlers, external `href`, `foreignObject`, data URLs, and an
+unknown placeholder token; all must be rejected.
+
+## 7. Turn embeds OFF with a warm cache
+
+1. Request a card successfully.
+2. Disable embeds:
+
+```bash
+curl -X PATCH "https://time.example.com/api/v1/users/current/embed_settings" \
+  -H "Authorization: Bearer $CLOUDTIME_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"enabled":false}'
+```
+
+3. Request the same card URL again.
+
+Expected:
+
+- `404 Not Found`
+- no stale SVG served from KV
+
+## Automated Validation
+
+Run:
+
+```bash
+npm run lint:api
+npm run typecheck
+npm test
+```
+
+The PR2 test suite should include integration coverage for default OFF, ON
+rendering, cache headers, cache-busting, unsupported range fallback, invalid
+card type, theme fallback, zero activity, unsafe template rejection, and OFF
+with a pre-existing cached render.

--- a/specs/160-embeddable-cards/research.md
+++ b/specs/160-embeddable-cards/research.md
@@ -1,0 +1,135 @@
+# Research: Embeddable Stat Cards
+
+**Branch**: `spec/160-embeddable-cards` | **Date**: 2026-06-18
+
+Sources consulted (2026-06-18):
+
+- GitHub Docs: Basic writing and formatting syntax - image embeds in Markdown
+  (`docs.github.com/.../basic-writing-and-formatting-syntax`)
+- GitHub Docs: About anonymized URLs - remote image cache behavior and Camo
+  cache purge guidance
+- GitHub Docs: Working with non-code files - GitHub image/SVG display support
+- Cloudflare Docs: Workers Cache API - cache headers respected by `cache.put`
+  and per-data-center cache behavior
+- Cloudflare Docs: Origin Cache Control - `Cache-Control` directives define
+  cache lifetime for intermediaries
+- MDN: SVG as an image - image-context restrictions and direct-view caveat
+- OpenAPI Specification 3.1 - media type content and binary/text response
+  description
+
+## D-1: Public URL shape and authentication
+
+**Decision**: Use
+`GET /api/v1/users/{username}/cards/{card_type}.svg` with `security: []`.
+`username` is a non-secret stable identifier; `card_type` is one of
+`heatmap`, `summary`, or `languages`. Optional query parameters select
+`range`, `theme`, `template_id`, and `v` cache-busting.
+
+**Why**: GitHub Markdown supports online image URLs, and a README image cannot
+send CloudTime API keys or session cookies. A username path keeps the URL stable
+for single-user mode while preserving the future multi-user route shape. The
+`.svg` suffix makes the image media type obvious to GitHub, browsers, and
+humans inspecting the embed.
+
+**Alternatives considered**: `/cards/{type}.svg` without a user identifier was
+rejected because it bakes in single-user addressing and would need a breaking
+URL later. `api_key` query parameters were rejected because FR-009 forbids
+secrets in embed URLs and README pages are public.
+
+## D-2: Visibility default and disabled behavior
+
+**Decision**: Per-user embed visibility defaults to OFF. When OFF, the public
+card endpoint returns `404 Not Found` before cache lookup, rate-limit budget,
+or any data read.
+
+**Why**: Public cards expose personal coding aggregates without authentication.
+The existing public-stats opt-out design (#156) already uses `404` to avoid
+confirming that a private endpoint exists. Reusing that privacy posture avoids
+a new observable and prevents stale cached SVGs from leaking after a user turns
+embeds OFF.
+
+**Alternatives considered**: `403 Forbidden` was rejected because it confirms a
+guarded resource exists. Returning a neutral SVG was rejected because a stale
+or incorrectly cached image response would still be a data-shaped response and
+would make OFF less auditable.
+
+## D-3: Freshness and cache strategy
+
+**Decision**: Card responses carry explicit `Cache-Control` derived from the
+per-user freshness window (default 15 minutes) and an `ETag`. The Worker also
+uses KV for rendered SVG cache entries keyed by normalized user/card/options
+plus the optional `v` parameter. Changing `v` forces a new cache key but does
+not affect authorization, visibility, or stats.
+
+**Why**: GitHub documents that remote images may be served through an
+anonymizing image proxy and that stale images should be diagnosed by checking
+`Cache-Control`; Cloudflare documents that cache behavior is controlled by
+response cache directives. A freshness window is therefore the right server
+contract, while `v` gives users a practical escape hatch when an intermediate
+proxy holds onto an older URL.
+
+**Alternatives considered**: `Cache-Control: no-store` was rejected for normal
+ON responses because popular README views would trigger D1/render work on every
+view. Permanent immutable caching was rejected because it contradicts the core
+"always-current" value. Purging Camo was rejected for routine operation because
+GitHub documents purge as a sparing fallback, not a refresh mechanism.
+
+## D-4: Current-day overlay
+
+**Decision**: Renderers read existing `summaries`/`hourly_summaries` for the
+requested range and compute only the current local day on demand from bounded
+raw heartbeat data since the local day start (and the previous heartbeat needed
+for timeout continuity). The rendered result is cached for the freshness
+window.
+
+**Why**: The cron aggregator is incremental and may not have processed today's
+latest heartbeats yet, but the card must include today's activity. Recomputing
+an entire range from raw heartbeats would violate the Workers CPU budget; a
+current-day overlay keeps the miss path bounded and makes cache hits cheap.
+
+**Alternatives considered**: Waiting for Cron was rejected because it violates
+FR-002. Updating summaries inside a card request was rejected because public
+GET image requests must be read-only and high-volume-safe.
+
+## D-5: SVG template safety
+
+**Decision**: User templates are accepted only as a safe static SVG subset.
+Reject scripts, event-handler attributes, `foreignObject`, external
+`href`/`xlink:href` references, remote fonts, data URLs, processing
+instructions, and unknown placeholder tokens. Validate on write and revalidate
+before render.
+
+**Why**: MDN documents that SVGs used as images have restrictions, but those
+restrictions do not apply when the same SVG is viewed directly or embedded as a
+document. GitHub also notes limitations around SVG scripting/animation. The
+server cannot rely on client or proxy sanitization; it must reject active
+content itself.
+
+**Alternatives considered**: Stripping unsafe nodes was rejected for PR2 because
+it can silently change user art and is easier to get wrong. Rejecting with a
+clear validation error is simpler and safer.
+
+## D-6: OpenAPI representation for SVG images
+
+**Decision**: Document SVG card responses under `content:
+image/svg+xml` with a string schema. Authenticated settings and template
+management use ordinary JSON schemas.
+
+**Why**: OpenAPI 3.1 models responses by media type. SVG is XML text, so a
+string schema under `image/svg+xml` describes the response without pretending it
+is JSON. Generated TypeScript clients will still see the non-JSON content type
+distinctly.
+
+**Alternatives considered**: `application/json` wrappers were rejected because
+README embeds need an actual image response. PNG output was rejected for first
+version because SVG is lighter and easier to generate at the edge.
+
+## D-7: Trademark and originality boundary
+
+**Decision**: The user-facing docs may say "WakaTime-compatible" where needed,
+but code identifiers, file names, card branding, and OpenAPI paths use only
+CloudTime terms. No WakaTime source, visual assets, logos, or documentation
+copy are used.
+
+**Why**: This follows the repository's legal/trademark rule and keeps the
+implementation original while still explaining compatibility context in docs.

--- a/specs/160-embeddable-cards/spec.md
+++ b/specs/160-embeddable-cards/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Embeddable Stat Cards
+
+**Feature Branch**: `spec/160-embeddable-cards`
+
+**Created**: 2026-06-18
+
+**Status**: Draft
+
+**Input**: User description: "Embeddable stat cards — continuously-updated dynamic image cards that a user embeds in their GitHub profile README (and other sites), inspired by WakaTime-compatible embeddable charts. Card types: coding-time heatmap, stats summary, top-languages. Multiple selectable themes. User-supplied custom template/background. Public ON/OFF toggle. Short configurable freshness window so the image stays current."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Embed an always-current coding-time heatmap (Priority: P1)
+
+A user wants to showcase their coding activity on their GitHub profile README. They copy a single image URL from CloudTime and paste it into their README as an image. From then on, the image shows a contribution-graph-style heatmap of their daily coding time that keeps itself up to date — including today's activity — with no further action, no scheduled job, and no commits pushed to their repository.
+
+**Why this priority**: This is the core motivation for the feature and the reason CloudTime is hosted on an edge platform — a self-updating image that reflects current coding activity. It delivers value on its own: a single embeddable heatmap is a complete, demonstrable MVP.
+
+**Independent Test**: Embed the heatmap URL on a page, record some coding activity, and confirm the image reflects the new activity within the freshness window without editing the embed or the host page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with recorded coding activity, **When** the heatmap image URL is requested, **Then** an image is returned showing daily coding-time intensity over a trailing period, including the current day.
+2. **Given** the user records additional coding time, **When** the image is requested again after the freshness window elapses, **Then** the heatmap reflects the new activity without any manual refresh or repository commit.
+3. **Given** the image is embedded in a GitHub README, **When** a visitor views the README, **Then** the heatmap renders inline as an image.
+
+---
+
+### User Story 2 - Control whether cards are publicly visible (Priority: P1)
+
+The person operating the CloudTime instance decides whether their coding stats may be served as public embeddable cards at all. They can turn embeds OFF entirely (the default-safe stance), in which case no card URL returns any data.
+
+**Why this priority**: Cards are served without authentication so they can be embedded on public pages; therefore the ability to keep them private is a prerequisite for shipping the feature safely. It must land together with the first card.
+
+**Independent Test**: Toggle embeds OFF and confirm every card URL returns a non-data response (403/404); toggle ON and confirm cards render.
+
+**Acceptance Scenarios**:
+
+1. **Given** embeds are turned OFF, **When** any card URL is requested, **Then** no coding data is returned (the request is refused).
+2. **Given** embeds are turned ON, **When** a card URL is requested, **Then** the card renders normally.
+3. **Given** any card URL, **When** it is inspected, **Then** it contains no API key or secret credential.
+
+---
+
+### User Story 3 - Embed a stats summary card (Priority: P2)
+
+A user embeds a compact card summarizing their coding totals — total time, daily average, best day, and top language — for a selectable time range (e.g. last 7 days, last 30 days, all time).
+
+**Why this priority**: A second card type that broadens the feature's appeal once the foundation (US1/US2) exists. Independently valuable but not required for the MVP.
+
+**Independent Test**: Request the summary card for a range and confirm the displayed totals match the user's aggregated stats for that range.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with activity over a range, **When** the summary card is requested for that range, **Then** the card shows total time, daily average, best day, and top language for that range.
+2. **Given** an unsupported or missing range, **When** the card is requested, **Then** a sensible default range is used.
+
+---
+
+### User Story 4 - Embed a top-languages card (Priority: P2)
+
+A user embeds a card showing the share of their coding time per language as a bar or pie representation.
+
+**Why this priority**: A third card type. Reuses the same foundation and language data already available; independently valuable.
+
+**Independent Test**: Request the languages card and confirm the language shares match the user's aggregated language breakdown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with multi-language activity, **When** the languages card is requested, **Then** the card shows each top language with its relative share.
+
+---
+
+### User Story 5 - Choose a visual theme (Priority: P2)
+
+A user picks from several built-in visual themes (for example a dark and a light theme plus additional presets) so the card matches their README's look. Switching theme requires only changing the embed URL.
+
+**Why this priority**: Theming materially affects adoption (cards must blend into a README) but is styling-only and applies across all card types, so it follows the card types themselves.
+
+**Independent Test**: Request the same card with two different theme selections and confirm only the visual styling differs while the data is identical; request an unknown theme and confirm it falls back to the default.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid theme selection, **When** a card is requested with that theme, **Then** the card renders with that theme's colors/typography and unchanged data.
+2. **Given** an unknown or invalid theme selection, **When** a card is requested, **Then** the card renders with the default theme rather than failing.
+
+---
+
+### User Story 6 - Define a custom card template (Priority: P3)
+
+Beyond the built-in presets, a user supplies their own card template containing placeholder tokens (a marked-up vector template). The system fills the placeholders with the user's current stats and serves the result as a card, giving the user full control over layout and styling.
+
+**Why this priority**: A personalization layer on top of the established card + theme system. It carries the highest complexity and the strictest safety requirements because the template is untrusted user content, so it ships last.
+
+**Independent Test**: Supply a template with placeholders, request a card that uses it, and confirm the placeholders are replaced with the user's current stats and the result renders as a valid image.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has supplied a valid template with recognized placeholder tokens, **When** a card is requested referencing it, **Then** the placeholders are replaced with the user's current stats and a valid image is returned.
+2. **Given** a template that exceeds size limits, contains unsupported/unsafe content (scripts or external resource references), or uses unknown placeholder tokens, **When** it is supplied, **Then** it is rejected with a clear reason and no card is produced from it.
+
+---
+
+### Edge Cases
+
+- **Embeds OFF**: every card URL must refuse to return data (no leak), not merely hide the link.
+- **No activity / new user**: cards must render a valid, readable "no activity yet" state — never a broken image.
+- **Invalid theme name**: fall back to the default theme instead of erroring.
+- **Today not yet aggregated**: today's column/number must still reflect activity recorded since the last aggregation run (freshness must not depend solely on the periodic aggregation cadence).
+- **Timezone**: day boundaries (which day a heartbeat counts toward, "best day", today's column) must use the user's configured timezone.
+- **Image proxy caching**: consumers like GitHub proxy and cache embedded images; the freshness window must be expressible so the proxy refetches on a reasonable cadence, while accepting the proxy's own cache as a best-effort upper bound on staleness.
+- **High view volume**: a popular README can drive many image requests; cards must be cacheable and rate-limitable so the instance stays within edge-platform limits.
+- **Oversized/malformed custom base**: must be validated and rejected within size limits.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST serve each card as an image that renders inline when embedded in a GitHub README or any site that embeds images by URL.
+- **FR-002**: Card images MUST reflect the user's latest coding activity — including the current day — without requiring any manual refresh, scheduled job, or commit to the user's repository.
+- **FR-003**: System MUST provide a **coding-time heatmap** card showing daily coding-time intensity over a trailing period in a contribution-graph style.
+- **FR-004**: System MUST provide a **stats summary** card showing total time, daily average, best day, and top language for a selectable time range.
+- **FR-005**: System MUST provide a **top-languages** card showing each top language and its relative share of coding time.
+- **FR-006**: Users MUST be able to select among multiple built-in visual themes; an unknown or invalid theme MUST fall back to a default theme rather than fail.
+- **FR-007**: Users MUST be able to supply a custom card template containing recognized placeholder tokens; the system MUST fill those placeholders with the user's current stats and MUST reject templates that exceed size limits or contain unsupported/unsafe content (scripts, external resource references, or unknown placeholder tokens).
+- **FR-008**: Operators MUST be able to turn embeddable cards ON or OFF; when OFF, every card URL MUST refuse to return any coding data.
+- **FR-009**: Card URLs MUST NOT require, contain, or expose the user's API key or any secret credential.
+- **FR-010**: System MUST provide a configurable freshness window controlling how current an embedded image is, so operators can trade staleness against load.
+- **FR-011**: Cards MUST NOT expose data the operator has chosen to keep private; visibility settings MUST be honored consistently across all card types.
+- **FR-012**: Cards MUST render a valid, readable result when the user has zero recorded activity (no broken image).
+- **FR-013**: All day-boundary and time-of-day calculations underlying a card MUST use the user's configured timezone.
+- **FR-014**: Card data and any custom base MUST be scoped to a specific user, preserving the path to multi-user support even though single-user is the default.
+- **FR-015**: System MUST allow a card to be re-fetched on demand bypassing cached copies (e.g. via a changeable URL parameter) so a user can force an immediate update when needed.
+
+### Key Entities *(include if feature involves data)*
+
+- **Embeddable Card**: a rendered image of a user's coding stats. Attributes: card type (heatmap / summary / top-languages), selected theme, time range, target user, and freshness metadata. Derived from aggregated data; not stored as user-editable content.
+- **Theme**: a named visual preset defining colors and typography only — never which data is shown.
+- **Custom Card Template**: a user-supplied template containing placeholder tokens for stat values. Scoped to a user; subject to size limits and a safe-content policy (no scripts or external references); only a defined set of placeholder tokens is recognized and substituted.
+- **Embed Visibility Setting**: configuration controlling whether cards are publicly retrievable for a user/instance.
+- **Aggregated Activity (existing)**: the daily/hourly coding-time summaries and commit data already maintained by CloudTime; the source of every number a card displays.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After a one-time embed, a card stays current with no further user action — 0 manual steps and 0 repository commits are required to keep it updated.
+- **SC-002**: After a user records new coding activity, the embedded card reflects it within the configured freshness window (target: 15 minutes by default).
+- **SC-003**: A card image is returned to a viewer in under 2 seconds at typical view volumes.
+- **SC-004**: Changing a card's theme or range requires editing only the embed URL — no re-setup or re-upload.
+- **SC-005**: When embeds are turned OFF, 100% of card requests return no coding data.
+- **SC-006**: No card URL exposes an API key or secret credential (verifiable by inspection of any generated URL).
+- **SC-007**: Cards render a valid image in 100% of cases including zero-activity users (no broken images).
+- **SC-008**: A user can force an immediate refresh of a card and see updated data on the next view.
+
+## Assumptions
+
+- Cards intentionally present **aggregated** stats (totals, per-day intensity, per-language share), never raw individual heartbeats.
+- The data source is CloudTime's **existing aggregated summaries, hourly summaries, and commit data**; the current day is computed on demand so freshness does not depend solely on the periodic aggregation cadence.
+- **Single-user mode is the default**; user scoping is retained throughout for a future multi-user upgrade, but no multi-user logic is built now (per constitution Principle V).
+- The default **freshness window is short** (assumed ~15 minutes) and is configurable; an external image proxy's own caching is accepted as a best-effort upper bound on staleness, mitigated by a force-refresh mechanism (FR-015).
+- Cards are delivered as **vector images** suitable for README embedding; raster (PNG/JPG) output is out of scope for the first version.
+- **Themes are styling-only** (colors/typography) and apply uniformly across card types.
+- A user-supplied custom template is stored using the project's **existing object-storage capability** and is treated as untrusted input: only a defined set of stat placeholder tokens is substituted, and scripts/external references are stripped or rejected to satisfy image-proxy sanitization constraints.
+- Access to cards is **read-only**; cards never mutate data.
+
+## Dependencies
+
+- Existing aggregation pipeline (daily/hourly summaries) and commit data.
+- Existing per-user settings (timezone) and public-visibility settings.
+- Existing object storage for user-supplied custom templates.

--- a/specs/160-embeddable-cards/spec.md
+++ b/specs/160-embeddable-cards/spec.md
@@ -8,6 +8,28 @@
 
 **Input**: User description: "Embeddable stat cards — continuously-updated dynamic image cards that a user embeds in their GitHub profile README (and other sites), inspired by WakaTime-compatible embeddable charts. Card types: coding-time heatmap, stats summary, top-languages. Multiple selectable themes. User-supplied custom template/background. Public ON/OFF toggle. Short configurable freshness window so the image stays current."
 
+## Background
+
+CloudTime already stores aggregated daily and hourly coding summaries and runs
+incremental aggregation from raw heartbeats. Embeddable cards expose a narrow,
+read-only public image surface over that aggregated data so the instance owner
+can place current stats in a GitHub profile README or another page that embeds
+remote images.
+
+GitHub supports Markdown image embeds from online image URLs, but remote images
+may be fetched through GitHub's anonymizing image proxy and cached independently
+from the viewer's browser. Therefore, freshness is a best-effort contract: the
+card response must publish explicit cache headers, the server must be able to
+serve a current image after the configured freshness window, and the URL must
+support a caller-changeable cache-busting parameter for immediate refreshes
+when a proxy keeps an older copy.
+
+The first implementation delivers SVG cards because GitHub displays SVG images
+and SVG keeps edge rendering lightweight. User-defined templates are treated as
+untrusted SVG input and must be constrained to a safe static subset; image
+context restrictions are not enough by themselves because a card URL can also
+be opened directly.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Embed an always-current coding-time heatmap (Priority: P1)
@@ -32,11 +54,11 @@ The person operating the CloudTime instance decides whether their coding stats m
 
 **Why this priority**: Cards are served without authentication so they can be embedded on public pages; therefore the ability to keep them private is a prerequisite for shipping the feature safely. It must land together with the first card.
 
-**Independent Test**: Toggle embeds OFF and confirm every card URL returns a non-data response (403/404); toggle ON and confirm cards render.
+**Independent Test**: Toggle embeds OFF and confirm every card URL returns `404` with no coding data and no cached card image; toggle ON and confirm cards render.
 
 **Acceptance Scenarios**:
 
-1. **Given** embeds are turned OFF, **When** any card URL is requested, **Then** no coding data is returned (the request is refused).
+1. **Given** embeds are turned OFF, **When** any card URL is requested, **Then** the response is `404 Not Found` with no coding data.
 2. **Given** embeds are turned ON, **When** a card URL is requested, **Then** the card renders normally.
 3. **Given** any card URL, **When** it is inspected, **Then** it contains no API key or secret credential.
 
@@ -103,14 +125,15 @@ Beyond the built-in presets, a user supplies their own card template containing 
 
 ### Edge Cases
 
-- **Embeds OFF**: every card URL must refuse to return data (no leak), not merely hide the link.
+- **Embeds OFF**: every card URL must return `404` before cache lookup or data reads (no leak), not merely hide the link.
 - **No activity / new user**: cards must render a valid, readable "no activity yet" state — never a broken image.
 - **Invalid theme name**: fall back to the default theme instead of erroring.
 - **Today not yet aggregated**: today's column/number must still reflect activity recorded since the last aggregation run (freshness must not depend solely on the periodic aggregation cadence).
 - **Timezone**: day boundaries (which day a heartbeat counts toward, "best day", today's column) must use the user's configured timezone.
 - **Image proxy caching**: consumers like GitHub proxy and cache embedded images; the freshness window must be expressible so the proxy refetches on a reasonable cadence, while accepting the proxy's own cache as a best-effort upper bound on staleness.
 - **High view volume**: a popular README can drive many image requests; cards must be cacheable and rate-limitable so the instance stays within edge-platform limits.
-- **Oversized/malformed custom base**: must be validated and rejected within size limits.
+- **Oversized/malformed custom template or background**: must be validated and rejected within size limits.
+- **Direct SVG access**: opening the SVG URL directly must not execute user-supplied scripts or load user-supplied external resources.
 
 ## Requirements *(mandatory)*
 
@@ -122,19 +145,23 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **FR-004**: System MUST provide a **stats summary** card showing total time, daily average, best day, and top language for a selectable time range.
 - **FR-005**: System MUST provide a **top-languages** card showing each top language and its relative share of coding time.
 - **FR-006**: Users MUST be able to select among multiple built-in visual themes; an unknown or invalid theme MUST fall back to a default theme rather than fail.
-- **FR-007**: Users MUST be able to supply a custom card template containing recognized placeholder tokens; the system MUST fill those placeholders with the user's current stats and MUST reject templates that exceed size limits or contain unsupported/unsafe content (scripts, external resource references, or unknown placeholder tokens).
-- **FR-008**: Operators MUST be able to turn embeddable cards ON or OFF; when OFF, every card URL MUST refuse to return any coding data.
+- **FR-007**: Users MUST be able to supply a custom card template containing recognized placeholder tokens; the system MUST fill those placeholders with the user's current stats and MUST reject templates that exceed size limits or contain unsupported/unsafe content (scripts, event-handler attributes, external resource references, active document features, or unknown placeholder tokens).
+- **FR-008**: Operators MUST be able to turn embeddable cards ON or OFF; the default MUST be OFF, and when OFF every card URL MUST return `404` before any cached image or coding data can be returned.
 - **FR-009**: Card URLs MUST NOT require, contain, or expose the user's API key or any secret credential.
-- **FR-010**: System MUST provide a configurable freshness window controlling how current an embedded image is, so operators can trade staleness against load.
+- **FR-010**: System MUST provide a configurable freshness window controlling response cache directives and server-side card cache TTL, so operators can trade staleness against load.
 - **FR-011**: Cards MUST NOT expose data the operator has chosen to keep private; visibility settings MUST be honored consistently across all card types.
 - **FR-012**: Cards MUST render a valid, readable result when the user has zero recorded activity (no broken image).
 - **FR-013**: All day-boundary and time-of-day calculations underlying a card MUST use the user's configured timezone.
-- **FR-014**: Card data and any custom base MUST be scoped to a specific user, preserving the path to multi-user support even though single-user is the default.
-- **FR-015**: System MUST allow a card to be re-fetched on demand bypassing cached copies (e.g. via a changeable URL parameter) so a user can force an immediate update when needed.
+- **FR-014**: Card data and any custom template MUST be scoped to a specific user, preserving the path to multi-user support even though single-user is the default.
+- **FR-015**: System MUST allow a card to be re-fetched on demand bypassing cached copies via a changeable URL parameter that participates in cache keys but does not change the card's data or visibility.
+- **FR-016**: Public card responses MUST be valid SVG images served with an image media type, explicit cache headers derived from the freshness window, and no cookies or user-private headers.
+- **FR-017**: Custom templates MUST be restricted to a safe static SVG subset; the rendered SVG MUST NOT contain scripts, event-handler attributes, `foreignObject`, external `href`/`xlink:href` references, remote fonts, or data URLs supplied by the user.
+- **FR-018**: Public card URLs MUST identify the target user with a non-secret stable identifier, not with an API key or session-bound value.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Embeddable Card**: a rendered image of a user's coding stats. Attributes: card type (heatmap / summary / top-languages), selected theme, time range, target user, and freshness metadata. Derived from aggregated data; not stored as user-editable content.
+- **Embed Settings**: per-user settings controlling public card visibility, freshness window, and default theme.
 - **Theme**: a named visual preset defining colors and typography only — never which data is shown.
 - **Custom Card Template**: a user-supplied template containing placeholder tokens for stat values. Scoped to a user; subject to size limits and a safe-content policy (no scripts or external references); only a defined set of placeholder tokens is recognized and substituted.
 - **Embed Visibility Setting**: configuration controlling whether cards are publicly retrievable for a user/instance.
@@ -152,20 +179,21 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **SC-006**: No card URL exposes an API key or secret credential (verifiable by inspection of any generated URL).
 - **SC-007**: Cards render a valid image in 100% of cases including zero-activity users (no broken images).
 - **SC-008**: A user can force an immediate refresh of a card and see updated data on the next view.
+- **SC-009**: A supplied unsafe template (script, event handler, external reference, `foreignObject`, data URL, or unknown placeholder) is rejected 100% of the time before it can be rendered.
 
 ## Assumptions
 
 - Cards intentionally present **aggregated** stats (totals, per-day intensity, per-language share), never raw individual heartbeats.
 - The data source is CloudTime's **existing aggregated summaries, hourly summaries, and commit data**; the current day is computed on demand so freshness does not depend solely on the periodic aggregation cadence.
 - **Single-user mode is the default**; user scoping is retained throughout for a future multi-user upgrade, but no multi-user logic is built now (per constitution Principle V).
-- The default **freshness window is short** (assumed ~15 minutes) and is configurable; an external image proxy's own caching is accepted as a best-effort upper bound on staleness, mitigated by a force-refresh mechanism (FR-015).
-- Cards are delivered as **vector images** suitable for README embedding; raster (PNG/JPG) output is out of scope for the first version.
+- The default **freshness window is short** (15 minutes) and is configurable; an external image proxy's own caching is accepted as a best-effort upper bound on staleness, mitigated by a force-refresh mechanism (FR-015).
+- Cards are delivered as **SVG vector images** suitable for README embedding; raster (PNG/JPG) output is out of scope for the first version.
 - **Themes are styling-only** (colors/typography) and apply uniformly across card types.
-- A user-supplied custom template is stored using the project's **existing object-storage capability** and is treated as untrusted input: only a defined set of stat placeholder tokens is substituted, and scripts/external references are stripped or rejected to satisfy image-proxy sanitization constraints.
+- A user-supplied custom template is durable user data managed by CloudTime and is treated as untrusted input: only a defined set of stat placeholder tokens is substituted, and unsafe SVG constructs are rejected before storage or rendering.
 - Access to cards is **read-only**; cards never mutate data.
 
 ## Dependencies
 
 - Existing aggregation pipeline (daily/hourly summaries) and commit data.
 - Existing per-user settings (timezone) and public-visibility settings.
-- Existing object storage for user-supplied custom templates.
+- Durable per-user storage for embed settings and user-supplied custom templates.

--- a/specs/160-embeddable-cards/tasks.md
+++ b/specs/160-embeddable-cards/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: Embeddable Stat Cards
+
+**Input**: Design documents from `/specs/160-embeddable-cards/`
+
+**Organization**: PR1 is complete in this branch. PR2 tasks are grouped by
+priority so the P1 heatmap + visibility switch can ship independently before
+P2/P3.
+
+## Phase 1: PR1 - Spec + Contract
+
+- [x] T001 Update `specs/160-embeddable-cards/spec.md` with cache, visibility, and SVG-template safety requirements.
+- [x] T002 Add `specs/160-embeddable-cards/research.md` documenting GitHub image embeds/Camo cache, Cloudflare cache behavior, SVG safety, and OpenAPI media-type decisions.
+- [x] T003 Add `specs/160-embeddable-cards/data-model.md` for embed settings, templates, and rendered-card cache entries.
+- [x] T004 Add `specs/160-embeddable-cards/quickstart.md` for PR2 manual validation.
+- [x] T005 Add `specs/160-embeddable-cards/contracts/openapi-diff.md`.
+- [x] T006 Update OpenAPI paths/components for public SVG cards, embed settings, and template CRUD.
+- [ ] T007 Run `npm run generate` and commit regenerated `src/types/generated.ts`.
+- [ ] T008 Run `npm run lint:api` and `npm run typecheck`.
+
+---
+
+## Phase 2: PR2 - Foundational
+
+- [ ] T101 Add `embed_settings` and `embed_templates` D1 tables to `src/db/schema.sql`, including `user_id` on every new table and indexes from `data-model.md`.
+- [ ] T102 Add optional `RATE_LIMIT_EMBED_CARDS?: RateLimit` to `src/types.ts` and `tests/env.d.ts`.
+- [ ] T103 Add a commented `[[ratelimits]]` block for `RATE_LIMIT_EMBED_CARDS` to `wrangler.toml`, continuing the namespace-id sequence.
+- [ ] T104 Create `src/routes/cards.ts` and mount public/authenticated card routes in `src/index.ts`.
+- [ ] T105 Add `src/utils/cards/cache.ts` for normalized cache keys, ETag generation, and `Cache-Control` policy.
+- [ ] T106 Add `src/utils/cards/data.ts` for aggregate reads and current-day overlay using existing timezone/timeout helpers.
+- [ ] T107 Add `src/utils/cards/render.ts` for built-in heatmap, summary, and languages SVG renderers.
+- [ ] T108 Add `src/utils/cards/templates.ts` for placeholder substitution and safe SVG validation.
+
+**Checkpoint**: Storage, route mount, cache policy, data builders, renderers, and validators exist before user-story behavior lands.
+
+---
+
+## Phase 3: User Story 1 - Public heatmap + visibility (P1 MVP)
+
+**Goal**: A user can enable public embeds and serve a current heatmap SVG; when
+disabled, every card URL returns `404` before cache/data access.
+
+**Independent Test**: Toggle OFF/ON, request
+`/api/v1/users/{username}/cards/heatmap.svg`, and verify OFF `404`, ON SVG,
+cache headers, no secret URL, current-day overlay, and zero-activity SVG.
+
+- [ ] T201 [P] Add integration tests in `tests/integration/embeddable-cards.test.ts` for default OFF, explicit OFF with warm cache, ON heatmap SVG, no API key in URL/body, and `Cache-Control`/`ETag` headers.
+- [ ] T202 [P] Add unit tests in `tests/unit/cards-render.test.ts` for heatmap SVG shape, escaping, and zero-activity rendering.
+- [ ] T203 Implement authenticated `GET/PATCH /users/current/embed_settings` using generated `EmbedSettings` types.
+- [ ] T204 Implement public username lookup and OFF `404` gate before rate-limit/cache/data work.
+- [ ] T205 Implement heatmap aggregate read + current-day overlay.
+- [ ] T206 Implement heatmap SVG rendering and KV cache write/read.
+- [ ] T207 Wire optional `RATE_LIMIT_EMBED_CARDS` on public card requests after the OFF gate and before cache misses.
+
+**Checkpoint**: P1 is independently usable and safe to demo.
+
+---
+
+## Phase 4: User Stories 3-5 - Summary, languages, themes (P2)
+
+**Goal**: Summary and top-language cards render from the same foundation, with
+styling-only theme selection and fallback.
+
+**Independent Test**: Request summary/languages cards for ranges and verify
+values match existing stats aggregates; invalid theme falls back to default.
+
+- [ ] T301 [P] Add integration tests for `summary.svg` and `languages.svg` ranges, unsupported range fallback, invalid card type `404`, and theme fallback.
+- [ ] T302 [P] Add renderer unit tests for built-in themes and SVG escaping.
+- [ ] T303 Implement summary-card data builder and renderer.
+- [ ] T304 Implement languages-card data builder and renderer.
+- [ ] T305 Implement theme normalization and default-theme fallback across all card types.
+
+**Checkpoint**: P1 and P2 card types share settings, cache, and visibility behavior.
+
+---
+
+## Phase 5: User Story 6 - Custom templates (P3)
+
+**Goal**: A user can store a safe SVG template with placeholders and render a
+card through that template.
+
+**Independent Test**: Valid template placeholders are substituted; unsafe or
+unknown-placeholder templates return `400` and are never rendered.
+
+- [ ] T401 [P] Add integration tests for template list/create/get/patch/delete, user scoping, 404 cross-user access, and validation failures.
+- [ ] T402 [P] Add unit tests for safe SVG validation: script, event handler, `foreignObject`, external href, remote font, data URL, processing instruction, malformed SVG, oversized input, and unknown placeholder.
+- [ ] T403 Implement authenticated template CRUD with generated `EmbedTemplate` types.
+- [ ] T404 Implement placeholder substitution with XML/text escaping.
+- [ ] T405 Implement template-backed rendering on public card requests with template revalidation before render.
+
+**Checkpoint**: P3 customization works without weakening public-route safety.
+
+---
+
+## Phase 6: Docs and Validation
+
+- [ ] T501 Update `docs/deployment-guide.md` with embed visibility, freshness, and force-refresh guidance.
+- [ ] T502 Update `docs/cloudflare-constraints.md` with public card cache/rate-limit behavior.
+- [ ] T503 Run `npm run generate` if PR2 changes OpenAPI further, then `npm run lint:api`.
+- [ ] T504 Run `npm run typecheck && npm test`.
+- [ ] T505 Open PR2 targeting `develop`, referencing PR1 and noting that embeds default OFF.
+
+## Dependencies
+
+- T101-T108 block all user-story implementation.
+- P1 (T201-T207) must land before P2 and P3 because it establishes public
+  visibility, cache, and renderer foundations.
+- P2 can proceed after P1.
+- P3 can proceed after P1 and can run in parallel with P2 only if template
+  routing does not change shared renderer interfaces.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -504,6 +504,109 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/{username}/cards/{card_type}.svg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Render a public embeddable stats card
+         * @description Returns an SVG image suitable for embedding in a GitHub README or any
+         *     page that displays remote images. This operation is intentionally public
+         *     (`security: []`) and MUST NOT require or accept an API key in the URL.
+         *
+         *     The target user is selected by a non-secret username. If embeds are
+         *     disabled for that user, the user does not exist, or the requested template
+         *     is unavailable, the response is `404` and no cached card image is served.
+         *
+         *     Successful responses include explicit cache headers derived from the
+         *     user's freshness window. The optional `v` parameter participates in cache
+         *     keys so a user can force a refetch, but it never changes card data or
+         *     visibility.
+         */
+        get: operations["getEmbeddableCard"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/current/embed_settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get current user's embed settings
+         * @description Returns the authenticated user's embeddable-card settings. When no stored
+         *     row exists, the server returns default-safe settings with embeds disabled.
+         */
+        get: operations["getEmbedSettings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update current user's embed settings */
+        patch: operations["updateEmbedSettings"];
+        trace?: never;
+    };
+    "/users/current/embed_templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List current user's embed templates */
+        get: operations["listEmbedTemplates"];
+        put?: never;
+        /**
+         * Create an embed template
+         * @description Stores a user-defined SVG template after validating it as a safe static SVG
+         *     subset. Templates containing scripts, event-handler attributes,
+         *     `foreignObject`, external references, data URLs, remote fonts, malformed
+         *     SVG, or unknown placeholders return `400` and are not stored.
+         */
+        post: operations["createEmbedTemplate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/current/embed_templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Embed template id. */
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        /** Get an embed template */
+        get: operations["getEmbedTemplate"];
+        put?: never;
+        post?: never;
+        /** Delete an embed template */
+        delete: operations["deleteEmbedTemplate"];
+        options?: never;
+        head?: never;
+        /**
+         * Update an embed template
+         * @description Updates an owned template. If `template_svg` is supplied, it is validated
+         *     with the same safe-static-SVG policy as template creation before storage.
+         */
+        patch: operations["updateEmbedTemplate"];
+        trace?: never;
+    };
     "/users/current/heartbeats": {
         parameters: {
             query?: never;
@@ -1362,6 +1465,51 @@ export interface components {
              * @description When the dump (and its stored object) is purged. Defaults to 7 days after creation.
              */
             expires_at?: string;
+        };
+        EmbedSettings: {
+            /**
+             * @description Whether public embeddable cards may return coding stats.
+             * @default false
+             */
+            enabled: boolean;
+            /**
+             * @description Cache freshness window for rendered public cards.
+             * @default 15
+             */
+            freshness_minutes: number;
+            /**
+             * @description Default built-in visual theme used when a card URL omits or provides an unknown theme.
+             * @default default
+             */
+            default_theme: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            modified_at?: string;
+        };
+        EmbedSettingsUpdate: {
+            /** @description Whether public embeddable cards may return coding stats. */
+            enabled?: boolean;
+            /** @description Cache freshness window for rendered public cards. */
+            freshness_minutes?: number;
+            /** @description Default built-in visual theme used when a card URL omits or provides an unknown theme. */
+            default_theme?: string;
+        };
+        EmbedTemplate: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @description Safe static SVG template containing recognized CloudTime placeholder tokens. */
+            template_svg: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            modified_at: string;
+        };
+        EmbedTemplateInput: {
+            name: string;
+            /** @description Safe static SVG template containing recognized CloudTime placeholder tokens. */
+            template_svg: string;
         };
         /** @enum {string} */
         Category: "coding" | "building" | "indexing" | "debugging" | "browsing" | "running tests" | "writing tests" | "manual testing" | "writing docs" | "communicating" | "code reviewing" | "notes" | "researching" | "learning" | "designing" | "ai coding" | "advising" | "meeting" | "planning" | "supporting" | "translating";
@@ -2636,6 +2784,235 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getEmbeddableCard: {
+        parameters: {
+            query?: {
+                /** @description Optional stats range. Unsupported or missing values use the card's default range where allowed. */
+                range?: string;
+                /** @description Built-in visual theme. Unknown themes fall back to the user's default theme. */
+                theme?: string;
+                /** @description Optional custom template owned by the target user. */
+                template_id?: string;
+                /** @description Optional cache-busting value. Changes the cache key only. */
+                v?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Public CloudTime username identifying the card owner. */
+                username: string;
+                /** @description Card type to render. */
+                card_type: "heatmap" | "summary" | "languages";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description SVG card image */
+            200: {
+                headers: {
+                    /** @description Public cache policy derived from the user's freshness window. */
+                    "Cache-Control"?: string;
+                    /** @description Entity tag for the rendered SVG. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/svg+xml": string;
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            429: components["responses"]["TooManyRequests"];
+        };
+    };
+    getEmbedSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Embed settings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedSettings"];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    updateEmbedSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmbedSettingsUpdate"];
+            };
+        };
+        responses: {
+            /** @description Embed settings updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedSettings"];
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    listEmbedTemplates: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of embed templates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedTemplate"][];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    createEmbedTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmbedTemplateInput"];
+            };
+        };
+        responses: {
+            /** @description Embed template created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedTemplate"];
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getEmbedTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Embed template id. */
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Embed template */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedTemplate"];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteEmbedTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Embed template id. */
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Embed template deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateEmbedTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Embed template id. */
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    /** @description Safe static SVG template containing recognized CloudTime placeholder tokens. */
+                    template_svg?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Embed template updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["EmbedTemplate"];
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
         };
     };
     getHeartbeats: {


### PR DESCRIPTION
## Summary

Completes PR1 for **Embeddable Stat Cards**: dynamic SVG cards a user can embed in a GitHub profile README or another page, with a default-OFF public visibility switch and explicit freshness/cache handling.

This PR now includes the full spec/design track and OpenAPI contract before implementation:

- SpecKit artifacts: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`, and `contracts/openapi-diff.md`
- OpenAPI additions for public SVG cards, authenticated embed settings, and authenticated template CRUD
- Regenerated `src/types/generated.ts`

## Scope (prioritized)

- **P1** - Coding-time heatmap SVG card + public embed ON/OFF setting. Embeds default OFF; OFF returns `404` before cache or data reads.
- **P2** - Stats summary card, top-languages card, built-in themes, invalid-theme fallback.
- **P3** - User-defined safe SVG templates with placeholder substitution; unsafe SVG constructs are rejected.

## Review updates

- Verified GitHub README image embedding and remote image cache behavior against GitHub Docs.
- Verified Cloudflare cache/header behavior against Cloudflare Workers/Cache docs.
- Verified SVG safety assumptions against MDN/GitHub SVG documentation; the spec now requires a safe static SVG subset and does not rely only on image-context restrictions.
- Added `Cache-Control`, `ETag`, and `v` cache-busting requirements for image-proxy freshness.
- Replaced the vague OFF behavior with a fixed `404` privacy contract.
- Removed the incorrect storage assumption and modeled durable per-user settings/templates explicitly.

## Workflow

This remains the **PR1 (Spec + Design)** part of the SpecKit 2-PR workflow and contains **no implementation code**. Route handlers, migrations, bindings, tests for runtime behavior, and operator docs are planned for PR2 after this contract lands.

## Verification

- `npm run generate`
- `npm run lint:api`
- `npm run typecheck`
- `npm test` (34 files, 374 tests)