### PR TITLE
feat: embeddable coding-time heatmap cards + embed settings (spec 160, P1)

### DIFF
--- a/migrations/0004_embed_settings.sql
+++ b/migrations/0004_embed_settings.sql
@@ -9,9 +9,9 @@
 
 CREATE TABLE IF NOT EXISTS embed_settings (
   user_id TEXT PRIMARY KEY,
-  enabled INTEGER NOT NULL DEFAULT 0,
-  freshness_minutes INTEGER NOT NULL DEFAULT 15,
-  default_theme TEXT NOT NULL DEFAULT 'default',
+  enabled INTEGER NOT NULL DEFAULT 0 CHECK (enabled IN (0, 1)),
+  freshness_minutes INTEGER NOT NULL DEFAULT 15 CHECK (freshness_minutes BETWEEN 1 AND 1440),
+  default_theme TEXT NOT NULL DEFAULT 'default' CHECK (length(default_theme) BETWEEN 1 AND 32),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   modified_at TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/migrations/0004_embed_settings.sql
+++ b/migrations/0004_embed_settings.sql
@@ -1,0 +1,18 @@
+-- Per-user embeddable-card settings (spec 160-embeddable-cards).
+-- Kept in sync with src/db/schema.sql so existing D1 databases can migrate and
+-- fresh deployments via `npm run db:init` get the same shape.
+--
+-- One row per user. An absent row means embeds are OFF (default-safe): public
+-- cards return 404 unless `enabled = 1`. `freshness_minutes` drives both the
+-- response Cache-Control max-age and the KV rendered-card TTL. `default_theme`
+-- is a styling-only preset used when a card URL omits or gives an unknown theme.
+
+CREATE TABLE IF NOT EXISTS embed_settings (
+  user_id TEXT PRIMARY KEY,
+  enabled INTEGER NOT NULL DEFAULT 0,
+  freshness_minutes INTEGER NOT NULL DEFAULT 15,
+  default_theme TEXT NOT NULL DEFAULT 'default',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -391,9 +391,9 @@ CREATE TABLE IF NOT EXISTS meta (
 -- ============================================================
 CREATE TABLE IF NOT EXISTS embed_settings (
   user_id TEXT PRIMARY KEY,
-  enabled INTEGER NOT NULL DEFAULT 0,
-  freshness_minutes INTEGER NOT NULL DEFAULT 15,
-  default_theme TEXT NOT NULL DEFAULT 'default',
+  enabled INTEGER NOT NULL DEFAULT 0 CHECK (enabled IN (0, 1)),
+  freshness_minutes INTEGER NOT NULL DEFAULT 15 CHECK (freshness_minutes BETWEEN 1 AND 1440),
+  default_theme TEXT NOT NULL DEFAULT 'default' CHECK (length(default_theme) BETWEEN 1 AND 32),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   modified_at TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -380,3 +380,21 @@ CREATE TABLE IF NOT EXISTS meta (
   key   TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+
+-- ============================================================
+-- Embed Settings (per-user embeddable stat cards, spec 160)
+-- One row per user. An absent row means embeds are OFF (default-safe):
+-- public cards return 404 unless `enabled = 1`. `freshness_minutes` drives
+-- both the response Cache-Control max-age and the KV rendered-card TTL.
+-- `default_theme` is a styling-only preset used when a card URL omits or
+-- gives an unknown theme.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS embed_settings (
+  user_id TEXT PRIMARY KEY,
+  enabled INTEGER NOT NULL DEFAULT 0,
+  freshness_minutes INTEGER NOT NULL DEFAULT 15,
+  default_theme TEXT NOT NULL DEFAULT 'default',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import commits from "./routes/commits";
 import dataDumps from "./routes/data-dumps";
 import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
+import { cardsPublic, cardsSettings } from "./routes/cards";
 import { aggregateHeartbeats } from "./cron/aggregate";
 import { parseRetentionDays, purgeOldHeartbeats } from "./cron/purge";
 import { processPendingDumps, purgeExpiredDumps } from "./cron/data-dumps";
@@ -137,6 +138,9 @@ app.get("/api/v1/health", (c) => c.json({ status: "ok" }));
 // Meta routes (public, no auth — /meta, /editors, /program_languages, /stats/:range)
 app.route("/api/v1", meta);
 
+// Public embeddable card images (no auth — /users/:username/cards/:type.svg, spec 160)
+app.route("/api/v1", cardsPublic);
+
 // Auth routes (OAuth, sessions, providers — before other authenticated routes)
 app.route("/api/v1/auth", auth);
 
@@ -175,6 +179,9 @@ app.route("/api/v1/users/current", machines);
 
 // User agents routes (mounted at /users/current, sub-app defines /user_agents)
 app.route("/api/v1/users/current", userAgents);
+
+// Embed settings routes (mounted at /users/current, sub-app defines /embed_settings, spec 160)
+app.route("/api/v1/users/current", cardsSettings);
 
 // Cron trigger handler for periodic aggregation + session cleanup
 export default {

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -1,0 +1,237 @@
+import { Hono } from "hono";
+import type { AuthEnv, Env } from "../types";
+import type { components } from "../types/generated";
+import type { Context } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
+import { getHeatmapData } from "../utils/cards/data";
+import { renderHeatmapSvg, resolveThemeName } from "../utils/cards/render";
+import {
+  buildCardCacheKey,
+  cardCacheControl,
+  cardCacheTtlSeconds,
+  computeCardEtag,
+  type CardCacheValue,
+} from "../utils/cards/cache";
+
+type EmbedSettings = components["schemas"]["EmbedSettings"];
+type EmbedSettingsUpdate = components["schemas"]["EmbedSettingsUpdate"];
+
+// Defaults applied when a user has no embed_settings row (default-safe: OFF).
+const DEFAULT_SETTINGS: EmbedSettings = {
+  enabled: false,
+  freshness_minutes: 15,
+  default_theme: "default",
+};
+
+const FRESHNESS_MIN = 1;
+const FRESHNESS_MAX = 1440; // one day
+const THEME_NAME_MAX = 32;
+
+interface SettingsRow {
+  enabled: number;
+  freshness_minutes: number;
+  default_theme: string;
+  created_at: string;
+  modified_at: string;
+}
+
+async function loadEmbedSettings(db: D1Database, userId: string): Promise<EmbedSettings> {
+  const row = await db
+    .prepare(
+      "SELECT enabled, freshness_minutes, default_theme, created_at, modified_at FROM embed_settings WHERE user_id = ?",
+    )
+    .bind(userId)
+    .first<SettingsRow>();
+  if (!row) return { ...DEFAULT_SETTINGS };
+  return {
+    enabled: row.enabled === 1,
+    freshness_minutes: row.freshness_minutes,
+    default_theme: row.default_theme,
+    created_at: row.created_at,
+    modified_at: row.modified_at,
+  };
+}
+
+// ============================================================
+// Authenticated settings: /users/current/embed_settings
+// ============================================================
+
+export const cardsSettings = new Hono<AuthEnv>();
+
+cardsSettings.use("/*", authMiddleware);
+
+cardsSettings.get("/embed_settings", async (c) => {
+  const userId = c.get("userId");
+  const settings = await loadEmbedSettings(c.env.DB, userId);
+  return c.json({ data: settings });
+});
+
+cardsSettings.patch("/embed_settings", async (c) => {
+  const userId = c.get("userId");
+  const body = (await c.req.json().catch(() => null)) as EmbedSettingsUpdate | null;
+  if (!body || typeof body !== "object") {
+    return c.json({ error: "Invalid request body" }, 400);
+  }
+
+  const current = await loadEmbedSettings(c.env.DB, userId);
+  const next: EmbedSettings = { ...current };
+
+  if ("enabled" in body) {
+    if (typeof body.enabled !== "boolean") {
+      return c.json({ error: "enabled must be a boolean" }, 400);
+    }
+    next.enabled = body.enabled;
+  }
+  if ("freshness_minutes" in body) {
+    const n = body.freshness_minutes;
+    if (
+      typeof n !== "number" ||
+      !Number.isInteger(n) ||
+      n < FRESHNESS_MIN ||
+      n > FRESHNESS_MAX
+    ) {
+      return c.json(
+        { error: `freshness_minutes must be an integer between ${FRESHNESS_MIN} and ${FRESHNESS_MAX}` },
+        400,
+      );
+    }
+    next.freshness_minutes = n;
+  }
+  if ("default_theme" in body) {
+    const t = body.default_theme;
+    if (typeof t !== "string" || t.length < 1 || t.length > THEME_NAME_MAX) {
+      return c.json({ error: `default_theme must be a string of 1-${THEME_NAME_MAX} characters` }, 400);
+    }
+    next.default_theme = t;
+  }
+
+  await c.env.DB
+    .prepare(
+      `INSERT INTO embed_settings (user_id, enabled, freshness_minutes, default_theme, created_at, modified_at)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+       ON CONFLICT(user_id) DO UPDATE SET
+         enabled = excluded.enabled,
+         freshness_minutes = excluded.freshness_minutes,
+         default_theme = excluded.default_theme,
+         modified_at = datetime('now')`,
+    )
+    .bind(userId, next.enabled ? 1 : 0, next.freshness_minutes, next.default_theme)
+    .run();
+
+  const updated = await loadEmbedSettings(c.env.DB, userId);
+  return c.json({ data: updated });
+});
+
+// ============================================================
+// Public cards: /users/{username}/cards/{card_type}.svg
+// Unauthenticated (security: []). The visibility OFF gate runs before any
+// rate-limit budget, cache lookup, or aggregate read so a private profile
+// cannot be probed and generates no load (FR-008).
+// ============================================================
+
+export const cardsPublic = new Hono<{ Bindings: Env }>();
+
+// P1 ships the heatmap. summary/languages are valid in the contract but land in
+// P2; until then they are reported as not found.
+const IMPLEMENTED_CARD_TYPES = new Set(["heatmap"]);
+
+function notFound(c: Context): Response {
+  return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
+}
+
+interface PublicUserRow {
+  id: string;
+  username: string;
+  timezone: string;
+  timeout: number;
+}
+
+cardsPublic.get("/users/:username/cards/:file", async (c) => {
+  const username = c.req.param("username");
+  const file = c.req.param("file");
+  if (!file.endsWith(".svg")) return notFound(c);
+  const cardType = file.slice(0, -".svg".length);
+  if (!IMPLEMENTED_CARD_TYPES.has(cardType)) return notFound(c);
+
+  const user = await c.env.DB
+    .prepare("SELECT id, username, timezone, timeout FROM users WHERE username = ?")
+    .bind(username)
+    .first<PublicUserRow>();
+  if (!user) return notFound(c);
+
+  const settings = await loadEmbedSettings(c.env.DB, user.id);
+  if (!settings.enabled) return notFound(c);
+
+  // Rate limit only reachable profiles, after the OFF gate (FR-008) and before
+  // the cache/render work a miss would trigger.
+  if (
+    await rateLimitExceeded(
+      c.env.RATE_LIMIT_EMBED_CARDS,
+      c.req.raw.headers,
+      `embed-cards:${user.id}`,
+      "RATE_LIMIT_EMBED_CARDS",
+    )
+  ) {
+    return tooManyRequests(c);
+  }
+
+  const themeName = resolveThemeName(c.req.query("theme") ?? settings.default_theme);
+  const v = c.req.query("v") ?? "";
+  const ifNoneMatch = c.req.raw.headers.get("If-None-Match");
+
+  const cacheKey = buildCardCacheKey({
+    userId: user.id,
+    cardType,
+    range: "year",
+    theme: themeName,
+    templateId: "",
+    v,
+    settingsModifiedAt: settings.modified_at ?? "",
+  });
+
+  const cached = (await c.env.KV.get(cacheKey, "json")) as CardCacheValue | null;
+  if (cached) {
+    return svgResponse(cached.svg, cached.etag, settings.freshness_minutes, ifNoneMatch);
+  }
+
+  const data = await getHeatmapData(c.env.DB, user.id, user.timezone, user.timeout);
+  const svg = renderHeatmapSvg({
+    username: user.username,
+    dayTotals: data.dayTotals,
+    todayStr: data.todayStr,
+    totalSeconds: data.totalSeconds,
+    theme: themeName,
+  });
+  const etag = await computeCardEtag(svg);
+
+  const value: CardCacheValue = { svg, etag, generated_at: new Date().toISOString() };
+  await c.env.KV.put(cacheKey, JSON.stringify(value), {
+    expirationTtl: cardCacheTtlSeconds(settings.freshness_minutes),
+  });
+
+  return svgResponse(svg, etag, settings.freshness_minutes, ifNoneMatch);
+});
+
+function svgResponse(
+  svg: string,
+  etag: string,
+  freshnessMinutes: number,
+  ifNoneMatch: string | null,
+): Response {
+  const cacheControl = cardCacheControl(freshnessMinutes);
+  if (ifNoneMatch && ifNoneMatch === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { ETag: etag, "Cache-Control": cacheControl },
+    });
+  }
+  return new Response(svg, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": cacheControl,
+      ETag: etag,
+    },
+  });
+}

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -27,6 +27,9 @@ const DEFAULT_SETTINGS: EmbedSettings = {
 const FRESHNESS_MIN = 1;
 const FRESHNESS_MAX = 1440; // one day
 const THEME_NAME_MAX = 32;
+const THEME_NAME_RE = /^[a-z0-9_-]+$/;
+const USERNAME_MAX = 64;
+const CACHE_BUSTER_MAX = 64;
 
 interface SettingsRow {
   enabled: number;
@@ -70,18 +73,20 @@ cardsSettings.get("/embed_settings", async (c) => {
 cardsSettings.patch("/embed_settings", async (c) => {
   const userId = c.get("userId");
   const body = (await c.req.json().catch(() => null)) as EmbedSettingsUpdate | null;
-  if (!body || typeof body !== "object") {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
     return c.json({ error: "Invalid request body" }, 400);
   }
 
   const current = await loadEmbedSettings(c.env.DB, userId);
   const next: EmbedSettings = { ...current };
+  let updates = 0;
 
   if ("enabled" in body) {
     if (typeof body.enabled !== "boolean") {
       return c.json({ error: "enabled must be a boolean" }, 400);
     }
     next.enabled = body.enabled;
+    updates++;
   }
   if ("freshness_minutes" in body) {
     const n = body.freshness_minutes;
@@ -97,13 +102,26 @@ cardsSettings.patch("/embed_settings", async (c) => {
       );
     }
     next.freshness_minutes = n;
+    updates++;
   }
   if ("default_theme" in body) {
     const t = body.default_theme;
-    if (typeof t !== "string" || t.length < 1 || t.length > THEME_NAME_MAX) {
-      return c.json({ error: `default_theme must be a string of 1-${THEME_NAME_MAX} characters` }, 400);
+    if (
+      typeof t !== "string" ||
+      t.length < 1 ||
+      t.length > THEME_NAME_MAX ||
+      !THEME_NAME_RE.test(t)
+    ) {
+      return c.json(
+        { error: `default_theme must be 1-${THEME_NAME_MAX} lowercase letters, numbers, hyphens, or underscores` },
+        400,
+      );
     }
-    next.default_theme = t;
+    next.default_theme = resolveThemeName(t);
+    updates++;
+  }
+  if (updates === 0) {
+    return c.json({ error: "No fields to update" }, 400);
   }
 
   await c.env.DB
@@ -140,6 +158,10 @@ function notFound(c: Context): Response {
   return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
 }
 
+function badRequest(c: Context, error: string): Response {
+  return c.json({ error }, 400);
+}
+
 interface PublicUserRow {
   id: string;
   username: string;
@@ -150,6 +172,9 @@ interface PublicUserRow {
 cardsPublic.get("/users/:username/cards/:file", async (c) => {
   const username = c.req.param("username");
   const file = c.req.param("file");
+  if (username.length < 1 || username.length > USERNAME_MAX) {
+    return badRequest(c, `username must be 1-${USERNAME_MAX} characters`);
+  }
   if (!file.endsWith(".svg")) return notFound(c);
   const cardType = file.slice(0, -".svg".length);
   if (!IMPLEMENTED_CARD_TYPES.has(cardType)) return notFound(c);
@@ -178,6 +203,9 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
 
   const themeName = resolveThemeName(c.req.query("theme") ?? settings.default_theme);
   const v = c.req.query("v") ?? "";
+  if (v.length > CACHE_BUSTER_MAX) {
+    return badRequest(c, `v must be at most ${CACHE_BUSTER_MAX} characters`);
+  }
   const ifNoneMatch = c.req.raw.headers.get("If-None-Match");
 
   const cacheKey = buildCardCacheKey({
@@ -220,7 +248,7 @@ function svgResponse(
   ifNoneMatch: string | null,
 ): Response {
   const cacheControl = cardCacheControl(freshnessMinutes);
-  if (ifNoneMatch && ifNoneMatch === etag) {
+  if (ifNoneMatch && etagMatches(ifNoneMatch, etag)) {
     return new Response(null, {
       status: 304,
       headers: { ETag: etag, "Cache-Control": cacheControl },
@@ -234,4 +262,19 @@ function svgResponse(
       ETag: etag,
     },
   });
+}
+
+function normalizeEtagForComparison(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith("W/") ? trimmed.slice(2).trim() : trimmed;
+}
+
+function etagMatches(ifNoneMatch: string, etag: string): boolean {
+  const current = normalizeEtagForComparison(etag);
+  return ifNoneMatch
+    .split(",")
+    .some((candidate) => {
+      const normalized = normalizeEtagForComparison(candidate);
+      return normalized === "*" || normalized === current;
+    });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,9 @@ export interface Env {
   // (30/60s); see specs/159-rate-limit-expansion/.
   RATE_LIMIT_LINK_VERIFY?: RateLimit;
   RATE_LIMIT_PUBLIC_STATS?: RateLimit;
+  // Spec 160: unauthenticated public embeddable-card route. Optional —
+  // rate-limit middleware fails open when undefined.
+  RATE_LIMIT_EMBED_CARDS?: RateLimit;
 
   // Email delivery (Issue #80). Required in multi-user mode for the
   // out-of-band PendingLink verification flow. Single-user mode does not

--- a/src/utils/cards/cache.ts
+++ b/src/utils/cards/cache.ts
@@ -1,0 +1,58 @@
+// Cache helpers for rendered embeddable cards (spec 160).
+//
+// Public cards are served cache-first from KV. The cache key folds in every
+// option that changes the rendered bytes plus the settings `modified_at`, so a
+// visibility/theme/freshness change invalidates old entries without an explicit
+// purge. The caller-supplied `v` participates in the key only (FR-015) — it
+// never selects data or affects authorization.
+
+import { sha256Hex } from "../crypto";
+
+export interface CardCacheValue {
+  svg: string;
+  etag: string;
+  generated_at: string;
+}
+
+export interface CardCacheKeyParts {
+  userId: string;
+  cardType: string;
+  range: string;
+  theme: string;
+  templateId: string;
+  v: string;
+  settingsModifiedAt: string;
+}
+
+export function buildCardCacheKey(p: CardCacheKeyParts): string {
+  return [
+    "embed-card",
+    p.userId,
+    p.cardType,
+    p.range,
+    p.theme,
+    p.templateId,
+    p.v,
+    p.settingsModifiedAt,
+  ].join(":");
+}
+
+// Translate the per-user freshness window into a Cache-Control directive. Used
+// for both the response header (so GitHub's image proxy refetches on cadence)
+// and the KV TTL. Clamped to a 60s floor so a misconfigured 0 cannot disable
+// caching entirely and hammer the origin.
+export function cardCacheTtlSeconds(freshnessMinutes: number): number {
+  const minutes = Number.isFinite(freshnessMinutes) ? freshnessMinutes : 15;
+  return Math.max(60, Math.floor(minutes * 60));
+}
+
+export function cardCacheControl(freshnessMinutes: number): string {
+  const sec = cardCacheTtlSeconds(freshnessMinutes);
+  return `public, max-age=${sec}, s-maxage=${sec}`;
+}
+
+// Strong ETag derived from the exact rendered bytes.
+export async function computeCardEtag(svg: string): Promise<string> {
+  const hash = await sha256Hex(svg);
+  return `"${hash.slice(0, 32)}"`;
+}

--- a/src/utils/cards/data.ts
+++ b/src/utils/cards/data.ts
@@ -1,0 +1,81 @@
+// Data builders for embeddable cards (spec 160).
+//
+// Past days are read from the pre-aggregated daily `summaries` (cheap, indexed).
+// The current local day is computed on demand from raw heartbeats so the latest
+// cell reflects activity recorded since the last hourly aggregation run
+// (FR-002), bounded to one local day to stay within the Workers CPU budget.
+
+import { addDays, formatDate, getEpochBoundsForDate, getToday } from "../time-format";
+
+export interface HeatmapData {
+  /** date (YYYY-MM-DD in the user's timezone) -> coding seconds */
+  dayTotals: Map<string, number>;
+  todayStr: string;
+  totalSeconds: number;
+}
+
+// 53 columns covers a full trailing year plus the current partial week, matching
+// a contribution-graph layout.
+const HEATMAP_WEEKS = 53;
+
+export async function getHeatmapData(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  timeoutMinutes: number,
+): Promise<HeatmapData> {
+  const today = getToday(tz);
+  const todayStr = formatDate(today);
+  const todayDow = today.getUTCDay(); // 0=Sun..6=Sat
+  const totalDays = (HEATMAP_WEEKS - 1) * 7 + todayDow + 1;
+  const startStr = formatDate(addDays(today, -(totalDays - 1)));
+
+  const { results } = await db
+    .prepare(
+      "SELECT date, SUM(total_seconds) AS seconds FROM summaries WHERE user_id = ? AND date >= ? AND date < ? GROUP BY date",
+    )
+    .bind(userId, startStr, todayStr)
+    .all<{ date: string; seconds: number }>();
+
+  const dayTotals = new Map<string, number>();
+  let totalSeconds = 0;
+  for (const row of results) {
+    dayTotals.set(row.date, row.seconds);
+    totalSeconds += row.seconds;
+  }
+
+  const todaySeconds = await computeTodaySeconds(db, userId, tz, todayStr, timeoutMinutes);
+  if (todaySeconds > 0) {
+    dayTotals.set(todayStr, todaySeconds);
+    totalSeconds += todaySeconds;
+  }
+
+  return { dayTotals, todayStr, totalSeconds };
+}
+
+// Sum coding seconds for the user's current local day directly from heartbeats,
+// joining gaps shorter than the user's timeout (mirrors the duration logic used
+// by /durations and the cron aggregator).
+async function computeTodaySeconds(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  todayStr: string,
+  timeoutMinutes: number,
+): Promise<number> {
+  const { start, end } = getEpochBoundsForDate(todayStr, tz);
+  const { results } = await db
+    .prepare(
+      "SELECT time FROM heartbeats WHERE user_id = ? AND time >= ? AND time < ? ORDER BY time ASC",
+    )
+    .bind(userId, start, end)
+    .all<{ time: number }>();
+
+  const timeout = timeoutMinutes * 60;
+  let total = 0;
+  for (let i = 1; i < results.length; i++) {
+    const gap = results[i].time - results[i - 1].time;
+    if (gap > 0 && gap <= timeout) total += gap;
+  }
+  return total;
+}

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -1,0 +1,153 @@
+// Built-in SVG renderers for embeddable cards (spec 160).
+//
+// SVG is produced as plain strings (no rendering dependency) to stay within the
+// Workers CPU budget. All user-derived text is XML-escaped. Output is a safe
+// static subset: no scripts, event handlers, foreignObject, or external
+// references — see FR-016/FR-017.
+
+import { formatHumanReadable } from "../time-format";
+
+export interface CardTheme {
+  background: string;
+  cellEmpty: string;
+  levels: [string, string, string, string];
+  text: string;
+  subtext: string;
+}
+
+// P1 ships the default theme only. Additional selectable themes (P2 / User
+// Story 5) slot in here; resolveTheme() already falls back to default for
+// unknown names (FR-006).
+export const THEMES: Record<string, CardTheme> = {
+  default: {
+    background: "#ffffff",
+    cellEmpty: "#ebedf0",
+    levels: ["#9be9a8", "#40c463", "#30a14e", "#216e39"],
+    text: "#1f2328",
+    subtext: "#656d76",
+  },
+};
+
+export function resolveTheme(name?: string): CardTheme {
+  if (name && Object.prototype.hasOwnProperty.call(THEMES, name)) return THEMES[name];
+  return THEMES.default;
+}
+
+// Normalized theme name for cache keys: unknown names collapse to "default" so
+// they share the default-theme cache entry rather than fragmenting it.
+export function resolveThemeName(name?: string): string {
+  return name && Object.prototype.hasOwnProperty.call(THEMES, name) ? name : "default";
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DAY_LABELS: Array<[number, string]> = [[1, "Mon"], [3, "Wed"], [5, "Fri"]];
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+export function escapeXml(s: string): string {
+  return s.replace(/[<>&'"]/g, (ch) => {
+    switch (ch) {
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case "&": return "&amp;";
+      case "'": return "&apos;";
+      default: return "&quot;";
+    }
+  });
+}
+
+// Fixed coding-time thresholds (seconds) → intensity level 0-4.
+function levelFor(seconds: number): number {
+  if (seconds <= 0) return 0;
+  if (seconds < 1800) return 1; // < 30 min
+  if (seconds < 3600) return 2; // < 1 h
+  if (seconds < 7200) return 3; // < 2 h
+  return 4;
+}
+
+export interface HeatmapRenderOptions {
+  username: string;
+  dayTotals: Map<string, number>;
+  todayStr: string;
+  totalSeconds: number;
+  theme?: string;
+}
+
+export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
+  const theme = resolveTheme(opts.theme);
+  const [ty, tm, td] = opts.todayStr.split("-").map(Number);
+  const today = new Date(Date.UTC(ty, tm - 1, td));
+  const todayDow = today.getUTCDay(); // 0=Sun..6=Sat
+  const WEEKS = 53;
+  const totalDays = (WEEKS - 1) * 7 + todayDow + 1;
+  const startMs = today.getTime() - (totalDays - 1) * 86400000;
+
+  const CELL = 11;
+  const GAP = 2;
+  const STEP = CELL + GAP;
+  const LEFT = 30;
+  const TOP = 34;
+  const gridH = 7 * STEP;
+  const width = LEFT + WEEKS * STEP + 14;
+  const height = TOP + gridH + 30;
+
+  let cells = "";
+  let monthLabels = "";
+  let lastMonth = -1;
+  for (let i = 0; i < totalDays; i++) {
+    const dt = new Date(startMs + i * 86400000);
+    const dateStr = `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`;
+    const col = Math.floor(i / 7);
+    const row = dt.getUTCDay();
+    const secs = opts.dayTotals.get(dateStr) ?? 0;
+    const lvl = levelFor(secs);
+    const fill = lvl === 0 ? theme.cellEmpty : theme.levels[lvl - 1];
+    const x = LEFT + col * STEP;
+    const y = TOP + row * STEP;
+    cells += `<rect x="${x}" y="${y}" width="${CELL}" height="${CELL}" rx="2" ry="2" fill="${fill}"><title>${dateStr}: ${escapeXml(formatHumanReadable(secs))}</title></rect>`;
+    if (row === 0) {
+      const month = dt.getUTCMonth();
+      if (month !== lastMonth) {
+        lastMonth = month;
+        monthLabels += `<text x="${x}" y="${TOP - 8}" class="lbl">${MONTHS[month]}</text>`;
+      }
+    }
+  }
+
+  let dayLabels = "";
+  for (const [row, label] of DAY_LABELS) {
+    const y = TOP + row * STEP + CELL - 1;
+    dayLabels += `<text x="2" y="${y}" class="lbl">${label}</text>`;
+  }
+
+  const legendY = TOP + gridH + 16;
+  const swatches = [theme.cellEmpty, ...theme.levels];
+  let legend = `<text x="${width - 152}" y="${legendY}" class="lbl">Less</text>`;
+  for (let i = 0; i < swatches.length; i++) {
+    const x = width - 124 + i * (CELL + 2);
+    legend += `<rect x="${x}" y="${legendY - 9}" width="${CELL}" height="${CELL}" rx="2" ry="2" fill="${swatches[i]}"/>`;
+  }
+  legend += `<text x="${width - 124 + swatches.length * (CELL + 2) + 4}" y="${legendY}" class="lbl">More</text>`;
+
+  const title = `@${escapeXml(opts.username)}`;
+  const totalText = escapeXml(`${formatHumanReadable(opts.totalSeconds)} in the last year`);
+  const ariaLabel = escapeXml(`Coding activity heatmap for ${opts.username}`);
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">` +
+    `<style>text{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;}` +
+    `.title{font-size:13px;font-weight:600;fill:${theme.text};}` +
+    `.total{font-size:11px;fill:${theme.subtext};}` +
+    `.lbl{font-size:9px;fill:${theme.subtext};}</style>` +
+    `<rect width="100%" height="100%" fill="${theme.background}"/>` +
+    `<text x="2" y="16" class="title">${title}</text>` +
+    `<text x="${width - 14}" y="16" text-anchor="end" class="total">${totalText}</text>` +
+    monthLabels +
+    dayLabels +
+    cells +
+    legend +
+    `</svg>`
+  );
+}

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -31,6 +31,7 @@ declare global {
       RATE_LIMIT_OAUTH_CALLBACK?: import("../src/types").RateLimit;
       RATE_LIMIT_LINK_VERIFY?: import("../src/types").RateLimit;
       RATE_LIMIT_PUBLIC_STATS?: import("../src/types").RateLimit;
+      RATE_LIMIT_EMBED_CARDS?: import("../src/types").RateLimit;
     }
   }
 }

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -62,6 +62,30 @@ describe("embeddable cards — public visibility", () => {
     expect(svg).not.toContain(user.apiKey);
   });
 
+  it("honors weak and listed If-None-Match validators", async () => {
+    const user = await seedUser({ username: "etag_user" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const first = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(first.status).toBe(200);
+    const etag = first.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    const revalidated = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`, {
+      headers: { "If-None-Match": `"miss", W/${etag}` },
+    });
+    expect(revalidated.status).toBe(304);
+    expect(await revalidated.text()).toBe("");
+  });
+
+  it("rejects an overlong cache-busting value before building a KV key", async () => {
+    const user = await seedUser({ username: "cache_key" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const res = await call(`/api/v1/users/${user.username}/cards/heatmap.svg?v=${"x".repeat(65)}`);
+    expect(res.status).toBe(400);
+  });
+
   it("returns 404 even with a warm cache after embeds are turned OFF", async () => {
     const user = await seedUser({ username: "bob" });
     await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
@@ -116,6 +140,26 @@ describe("embeddable cards — settings auth", () => {
     const user = await seedUser({ username: "erin" });
     const res = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { freshness_minutes: 0 }));
     expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty settings patch", async () => {
+    const user = await seedUser({ username: "grace" });
+    const res = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects default_theme values outside the OpenAPI pattern", async () => {
+    const user = await seedUser({ username: "heidi" });
+    const res = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { default_theme: "Dark Mode" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("normalizes an unknown but syntactically valid default theme to default", async () => {
+    const user = await seedUser({ username: "ivan" });
+    const res = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { default_theme: "future_theme" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { default_theme: string } };
+    expect(body.data.default_theme).toBe("default");
   });
 
   it("defaults to OFF with a 15-minute freshness window", async () => {

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -1,0 +1,132 @@
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+
+afterEach(async () => {
+  await truncate("heartbeats", "summaries", "embed_settings", "users");
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function authPatch(apiKey: string, body: unknown): RequestInit {
+  return {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("embeddable cards — public visibility", () => {
+  it("returns 404 when embeds are OFF by default", async () => {
+    const user = await seedUser({ username: "alice" });
+    const res = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown user", async () => {
+    const res = await call(`/api/v1/users/ghost/cards/heatmap.svg`);
+    expect(res.status).toBe(404);
+  });
+
+  it("renders the heatmap as SVG once embeds are enabled", async () => {
+    const user = await seedUser({ username: "owner" });
+    const patch = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+    expect(patch.status).toBe(200);
+    const patchBody = (await patch.json()) as { data: { enabled: boolean } };
+    expect(patchBody.data.enabled).toBe(true);
+
+    const res = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("image/svg+xml");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=");
+    expect(res.headers.get("ETag")).toBeTruthy();
+
+    const svg = await res.text();
+    expect(svg.startsWith("<svg")).toBe(true);
+    // The card URL is unauthenticated and must never echo a secret.
+    expect(svg).not.toContain(user.apiKey);
+  });
+
+  it("returns 404 even with a warm cache after embeds are turned OFF", async () => {
+    const user = await seedUser({ username: "bob" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const warm = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(warm.status).toBe(200);
+
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: false }));
+
+    const res = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(res.status).toBe(404);
+  });
+
+  it("treats summary/languages cards as not-yet-available in P1", async () => {
+    const user = await seedUser({ username: "carol" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const summary = await call(`/api/v1/users/${user.username}/cards/summary.svg`);
+    expect(summary.status).toBe(404);
+    const languages = await call(`/api/v1/users/${user.username}/cards/languages.svg`);
+    expect(languages.status).toBe(404);
+  });
+
+  it("reflects today's activity computed on demand from raw heartbeats", async () => {
+    const user = await seedUser({ username: "dave" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    // Three heartbeats spaced 60s apart (gaps under the 15-min timeout) → 120s.
+    const now = Math.floor(Date.now() / 1000);
+    for (const t of [now - 120, now - 60, now]) {
+      await env.DB.prepare(
+        "INSERT INTO heartbeats (id, user_id, entity, time) VALUES (?, ?, ?, ?)",
+      )
+        .bind(crypto.randomUUID(), user.userId, "file.ts", t)
+        .run();
+    }
+
+    const res = await call(`/api/v1/users/${user.username}/cards/heatmap.svg`);
+    expect(res.status).toBe(200);
+    const svg = await res.text();
+    expect(svg).toContain("2 mins in the last year");
+  });
+});
+
+describe("embeddable cards — settings auth", () => {
+  it("requires authentication to read embed settings", async () => {
+    const res = await call(`/api/v1/users/current/embed_settings`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an out-of-range freshness_minutes", async () => {
+    const user = await seedUser({ username: "erin" });
+    const res = await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { freshness_minutes: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("defaults to OFF with a 15-minute freshness window", async () => {
+    const user = await seedUser({ username: "frank" });
+    const res = await call(`/api/v1/users/current/embed_settings`, {
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { enabled: boolean; freshness_minutes: number; default_theme: string } };
+    expect(body.data.enabled).toBe(false);
+    expect(body.data.freshness_minutes).toBe(15);
+    expect(body.data.default_theme).toBe("default");
+  });
+});

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeXml,
+  renderHeatmapSvg,
+  resolveTheme,
+  resolveThemeName,
+} from "../../src/utils/cards/render";
+
+const TODAY = "2026-06-18";
+
+describe("renderHeatmapSvg", () => {
+  it("produces a well-formed svg root with an image role", () => {
+    const svg = renderHeatmapSvg({
+      username: "alice",
+      dayTotals: new Map(),
+      todayStr: TODAY,
+      totalSeconds: 0,
+    });
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(svg).toContain('role="img"');
+    expect(svg.trimEnd().endsWith("</svg>")).toBe(true);
+  });
+
+  it("renders a zero-activity user without throwing", () => {
+    const svg = renderHeatmapSvg({
+      username: "alice",
+      dayTotals: new Map(),
+      todayStr: TODAY,
+      totalSeconds: 0,
+    });
+    expect(svg).toContain("0 secs in the last year");
+  });
+
+  it("escapes the username to prevent markup injection", () => {
+    const svg = renderHeatmapSvg({
+      username: '<script>evil()</script>&"x',
+      dayTotals: new Map(),
+      todayStr: TODAY,
+      totalSeconds: 0,
+    });
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+
+  it("colors a high-activity day with the darkest level and a title", () => {
+    const day = "2026-06-17";
+    const svg = renderHeatmapSvg({
+      username: "a",
+      dayTotals: new Map([[day, 8 * 3600]]),
+      todayStr: TODAY,
+      totalSeconds: 8 * 3600,
+    });
+    expect(svg).toContain("#216e39");
+    expect(svg).toContain(`<title>${day}: 8 hrs`);
+  });
+
+  it("emits only a safe static subset (no script/foreignObject/href)", () => {
+    const svg = renderHeatmapSvg({
+      username: "a",
+      dayTotals: new Map([["2026-06-17", 3600]]),
+      todayStr: TODAY,
+      totalSeconds: 3600,
+    });
+    expect(svg).not.toMatch(/<script/i);
+    expect(svg).not.toMatch(/foreignObject/i);
+    expect(svg).not.toMatch(/href=/i);
+    expect(svg).not.toMatch(/on\w+=/i); // no event-handler attributes
+  });
+});
+
+describe("theme resolution", () => {
+  it("falls back to the default theme for an unknown name", () => {
+    expect(resolveThemeName("does-not-exist")).toBe("default");
+    expect(resolveTheme("does-not-exist")).toBe(resolveTheme("default"));
+  });
+
+  it("keeps a known theme name", () => {
+    expect(resolveThemeName("default")).toBe("default");
+  });
+});
+
+describe("escapeXml", () => {
+  it("escapes the five XML entities", () => {
+    expect(escapeXml("<>&'\"")).toBe("&lt;&gt;&amp;&apos;&quot;");
+  });
+});


### PR DESCRIPTION
## Summary

PR2 (implementation) of **Embeddable Stat Cards** (spec 160), scoped to the **P1 MVP**: a continuously-updated coding-time **heatmap** that embeds in a GitHub profile README, plus the **embed ON/OFF** control it needs to ship safely. Builds on the spec/design/contract merged in #173.

A single image URL stays current — including today — with no scheduled job and no commits to the user's repo, because the SVG is generated on demand at the edge from already-aggregated data.

## What's included

- **Public card** `GET /api/v1/users/{username}/cards/{card_type}.svg` (`security: []`):
  - P1 renders `heatmap`; `summary`/`languages` are valid in the contract but return `404` until P2.
  - **Visibility-OFF gate runs first** — before rate-limit budget, cache lookup, or any data read — so a private/disabled profile can't be probed and does no work (FR-008). Default is OFF.
  - URL carries **no API key or secret** (FR-009).
  - `image/svg+xml` + `Cache-Control` (from the freshness window) + `ETag`; `If-None-Match` supports listed and weak validators, and the `v` query param busts the cache for an immediate refresh (FR-010/FR-015).
  - Public inputs are bounded before cache-key construction, including the `v` cache-buster, so invalid requests fail with `400` instead of reaching KV.
- **Embed settings** `GET`/`PATCH /api/v1/users/current/embed_settings` (authenticated): `enabled`, `freshness_minutes` (1-1440, default 15), `default_theme`. Default-safe OFF when no row exists.
  - Settings validation now matches the OpenAPI constraints and rejects no-op patches.
- **Freshness**: past days from pre-aggregated `summaries`; **today computed on demand** from raw heartbeats (bounded to the local day) so the image reflects activity recorded since the last hourly aggregation (FR-002).
- **Safe SVG**: built from escaped strings — no scripts, event handlers, `foreignObject`, or external references (FR-016/FR-017).
- **DB**: new `embed_settings` table (`src/db/schema.sql` + `migrations/0004_embed_settings.sql`) with CHECK constraints for boolean/freshness/theme bounds.
- Optional `RATE_LIMIT_EMBED_CARDS` binding (fail-open when unset).

## Usage

```markdown
![My coding activity](https://<your-instance>/api/v1/users/<username>/cards/heatmap.svg)
```
Enable first: `PATCH /api/v1/users/current/embed_settings { "enabled": true }` (embeds default OFF).

## Review validation

Reviewed against current primary docs for Cloudflare KV TTL limits, D1 per-invocation query limits, Workers Rate Limiting behavior, GitHub's Camo image proxy, and HTTP conditional request semantics. The implementation keeps the public route cache-first after the OFF gate, bounds D1 work to the current local day on render misses, uses KV TTLs at or above the documented minimum, and returns standards-compatible `304` responses for matching ETags.

## Out of scope (follow-ups)

- **P2**: `summary` and `languages` cards, multiple selectable themes.
- **P3**: user-defined custom templates (`embed_templates`).

## Operator note

`wrangler.toml` is intentionally **not** modified in this PR (the working copy carries uncommitted local DB/KV ids). To enable rate limiting, add a `RATE_LIMIT_EMBED_CARDS` `[[ratelimits]]` block (next namespace id `1005`); the binding is optional and the middleware fails open without it.

## Testing

- `npm run lint:api` — green.
- `npm run typecheck` — green.
- `npm test -- tests/integration/embeddable-cards.test.ts tests/unit/cards-render.test.ts` — **22 tests pass (2 files)**.
- `npm test` — **396 tests pass (36 files)**.
- New: `tests/unit/cards-render.test.ts` (render shape, XML escaping, zero-activity, theme fallback) and `tests/integration/embeddable-cards.test.ts` (default OFF->404, unknown user->404, enable->SVG, ETag revalidation, cache-buster bounds, OFF-with-warm-cache->404, settings auth/validation, current-day overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)