### PR TITLE
[codex] Generate WakaTime-compatible API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ npx wrangler deploy --config wrangler.local.toml
 
 ### 4. Connect your editor
 
-After your first OAuth login, you'll receive an API key (`ck_...`). Configure your editor's WakaTime plugin to point to your instance:
+After your first OAuth login, generate an API key from your authenticated session. Configure your editor's WakaTime plugin to point to your instance:
 
 ```ini
 # ~/.wakatime.cfg
 [settings]
 api_url = https://your-cloudtime-instance.workers.dev/api/v1
-api_key = ck_your_api_key_here
+api_key = your-uuid-api-key-here
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npx wrangler deploy --config wrangler.local.toml
 
 ### 4. Connect your editor
 
-After your first OAuth login, generate an API key from your authenticated session. Configure your editor's WakaTime plugin to point to your instance:
+After your first OAuth login, generate an API key from your authenticated session. Configure your WakaTime-compatible editor plugin to point to your instance:
 
 ```ini
 # ~/.wakatime.cfg

--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -156,7 +156,7 @@ UUID v4 string
 Example: 00000000-0000-4000-8000-000000000000
 ```
 
-- Generated via Web Crypto API: random UUID v4, matching WakaTime-compatible CLI validation
+- Generated via Web Crypto API: random UUID v4. The UUID shape is for client compatibility; security relies on CSPRNG output and hash-only storage.
 - Stored as SHA-256 hash in DB (`api_key_hash` column); plaintext shown only once
 - Can be regenerated via POST /auth/api-key (old key immediately invalidated)
 

--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -7,7 +7,7 @@ cloudtime uses OAuth 2.0 with PKCE for user authentication. Three providers are 
 - Google
 - Discord
 
-One user account can link multiple OAuth providers. Editor plugins use a permanent API key (`ck_` prefix).
+One user account can link multiple OAuth providers. Editor plugins use a permanent UUID API key.
 
 ## Instance Modes
 
@@ -32,7 +32,7 @@ Controlled by `INSTANCE_MODE` environment variable:
 
 | Context | Method | Lifetime |
 |---------|--------|----------|
-| Editor plugins | API key (`ck_...`) via Basic Auth / Bearer | Permanent (until regenerated) |
+| Editor plugins | UUID API key via Basic Auth / Bearer | Permanent (until regenerated) |
 | Web UI | Session cookie (`__Host-session`) | 24h idle / 7d absolute |
 | OAuth flow | PKCE + state parameter | One-time |
 
@@ -152,11 +152,11 @@ change is required.
 ## API Key Format
 
 ```
-ck_<43 url-safe base64 characters>
-Example: ck_Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2RlZmdoaWo
+UUID v4 string
+Example: 00000000-0000-4000-8000-000000000000
 ```
 
-- Generated via Web Crypto API: `ck_` + base64url of 32 random bytes (256-bit entropy)
+- Generated via Web Crypto API: random UUID v4, matching WakaTime-compatible CLI validation
 - Stored as SHA-256 hash in DB (`api_key_hash` column); plaintext shown only once
 - Can be regenerated via POST /auth/api-key (old key immediately invalidated)
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -237,7 +237,7 @@ on instances that do not set the variable.
      -H "Origin: https://your-worker.example.com" \
      https://your-worker.example.com/api/v1/auth/api-key
    ```
-   The plaintext `ck_…` value is shown **once**. Store it in your password manager and your `~/.wakatime.cfg`.
+   The plaintext UUID API key is shown **once**. Store it in your password manager and your `~/.wakatime.cfg`.
 
 ### Why this matters
 
@@ -271,7 +271,7 @@ Point your editor's WakaTime-compatible plugin at your Worker. In `~/.wakatime.c
 ```ini
 [settings]
 api_url = https://your-worker.example.com/api/v1
-api_key = ck_<your plaintext key from step 3 above>
+api_key = <your UUID API key from step 3 above>
 ```
 
 Restart your editor. Your IDE's status bar should start showing today's coding time within a few seconds of typing.

--- a/schemas/paths/auth/api-key.yaml
+++ b/schemas/paths/auth/api-key.yaml
@@ -8,8 +8,8 @@ post:
     The new key is the only value returned; it cannot be retrieved again.
 
     **Security measures:**
-    - New key: 32 bytes of cryptographic randomness, base64url-encoded, prefixed with `ck_`.
-      The `ck_` prefix enables secret scanning in Git repositories.
+    - New key: UUID v4 string generated from cryptographic randomness.
+      This matches the API key format accepted by WakaTime-compatible CLI tools.
     - Storage: only the SHA-256 hash of the key is stored in the database.
     - KV cache: the old key's cache entry is explicitly deleted (not relying on TTL expiry).
     - All other active sessions for this user are invalidated (forces re-authentication
@@ -40,8 +40,9 @@ post:
                 properties:
                   api_key:
                     type: string
+                    format: uuid
                     description: |
-                      New API key (ck_...). This is the only time the plaintext is available.
+                      New UUID API key. This is the only time the plaintext is available.
                       Store it securely; it cannot be retrieved from the server.
     '401':
       $ref: ../../components/responses/Unauthorized.yaml

--- a/schemas/paths/auth/api-key.yaml
+++ b/schemas/paths/auth/api-key.yaml
@@ -8,8 +8,9 @@ post:
     The new key is the only value returned; it cannot be retrieved again.
 
     **Security measures:**
-    - New key: UUID v4 string generated from cryptographic randomness.
-      This matches the API key format accepted by WakaTime-compatible CLI tools.
+    - New key: UUID v4 string generated from the Web Crypto CSPRNG.
+      The UUID shape is for client compatibility; security relies on
+      unguessable random output and hash-only storage.
     - Storage: only the SHA-256 hash of the key is stored in the database.
     - KV cache: the old key's cache entry is explicitly deleted (not relying on TTL expiry).
     - All other active sessions for this user are invalidated (forces re-authentication

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -347,8 +347,8 @@ export interface paths {
          *     The new key is the only value returned; it cannot be retrieved again.
          *
          *     **Security measures:**
-         *     - New key: 32 bytes of cryptographic randomness, base64url-encoded, prefixed with `ck_`.
-         *       The `ck_` prefix enables secret scanning in Git repositories.
+         *     - New key: UUID v4 string generated from cryptographic randomness.
+         *       This matches the API key format accepted by WakaTime-compatible CLI tools.
          *     - Storage: only the SHA-256 hash of the key is stored in the database.
          *     - KV cache: the old key's cache entry is explicitly deleted (not relying on TTL expiry).
          *     - All other active sessions for this user are invalidated (forces re-authentication
@@ -2558,7 +2558,8 @@ export interface operations {
                     "application/json": {
                         data: {
                             /**
-                             * @description New API key (ck_...). This is the only time the plaintext is available.
+                             * Format: uuid
+                             * @description New UUID API key. This is the only time the plaintext is available.
                              *     Store it securely; it cannot be retrieved from the server.
                              */
                             api_key: string;

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -347,8 +347,9 @@ export interface paths {
          *     The new key is the only value returned; it cannot be retrieved again.
          *
          *     **Security measures:**
-         *     - New key: UUID v4 string generated from cryptographic randomness.
-         *       This matches the API key format accepted by WakaTime-compatible CLI tools.
+         *     - New key: UUID v4 string generated from the Web Crypto CSPRNG.
+         *       The UUID shape is for client compatibility; security relies on
+         *       unguessable random output and hash-only storage.
          *     - Storage: only the SHA-256 hash of the key is stored in the database.
          *     - KV cache: the old key's cache entry is explicitly deleted (not relying on TTL expiry).
          *     - All other active sessions for this user are invalidated (forces re-authentication

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -60,6 +60,7 @@ export function generateNonce(): string {
 }
 
 export async function generateApiKey(): Promise<{ plaintext: string; hash: string }> {
+  // UUID shape is for compatibility clients; security relies on Web Crypto CSPRNG output.
   const plaintext = crypto.randomUUID();
   const hash = await sha256Hex(plaintext);
   return { plaintext, hash };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -60,8 +60,7 @@ export function generateNonce(): string {
 }
 
 export async function generateApiKey(): Promise<{ plaintext: string; hash: string }> {
-  const raw = base64url(randomBytes(32));
-  const plaintext = `ck_${raw}`;
+  const plaintext = crypto.randomUUID();
   const hash = await sha256Hex(plaintext);
   return { plaintext, hash };
 }

--- a/tests/integration/auth-route-mounting.test.ts
+++ b/tests/integration/auth-route-mounting.test.ts
@@ -72,7 +72,7 @@ describe("auth route mounting (#163)", () => {
     expect(body.data.user.id).toBe(user.userId);
   });
 
-  it("regenerates a WakaTime-compatible UUID API key", async () => {
+  it("regenerates a UUID API key that authenticates", async () => {
     const user = await seedUserWithSession({ username: "owner" });
     const res = await call("/api/v1/auth/api-key", {
       method: "POST",

--- a/tests/integration/auth-route-mounting.test.ts
+++ b/tests/integration/auth-route-mounting.test.ts
@@ -15,6 +15,7 @@ import worker from "../../src/index";
 import { seedUserWithSession, truncate } from "../helpers/fixtures";
 
 const BASE = "https://test.cloudtime.dev";
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 afterEach(async () => {
   await truncate("sessions", "oauth_accounts", "users");
@@ -69,5 +70,25 @@ describe("auth route mounting (#163)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: { user: { id: string } } };
     expect(body.data.user.id).toBe(user.userId);
+  });
+
+  it("regenerates a WakaTime-compatible UUID API key", async () => {
+    const user = await seedUserWithSession({ username: "owner" });
+    const res = await call("/api/v1/auth/api-key", {
+      method: "POST",
+      headers: {
+        Cookie: `__Host-session=${user.sessionToken}`,
+        Origin: BASE,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { api_key: string } };
+    expect(body.data.api_key).toMatch(UUID_V4_RE);
+
+    const authenticated = await call("/api/v1/users/current", {
+      headers: { Authorization: `Bearer ${body.data.api_key}` },
+    });
+    expect(authenticated.status).toBe(200);
   });
 });

--- a/tests/integration/heartbeats.test.ts
+++ b/tests/integration/heartbeats.test.ts
@@ -49,7 +49,7 @@ describe("POST /api/v1/users/current/heartbeats — single", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...authHeader("ck_definitely_not_a_real_key"),
+        ...authHeader("definitely-not-a-real-api-key"),
       },
       body: JSON.stringify({ entity: "main.ts", type: "file", time: TIME_2026_03_14_10_00_UTC }),
     });

--- a/tests/security/crypto.test.ts
+++ b/tests/security/crypto.test.ts
@@ -71,9 +71,9 @@ describe("state / session / nonce / api-key generators", () => {
     expect(generateNonce()).not.toBe(generateNonce());
   });
 
-  it("generateApiKey returns ck_-prefixed plaintext and matching sha256 hash", async () => {
+  it("generateApiKey returns UUID plaintext and matching sha256 hash", async () => {
     const { plaintext, hash } = await generateApiKey();
-    expect(plaintext).toMatch(/^ck_[A-Za-z0-9_-]+$/);
+    expect(plaintext).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
     expect(hash).toBe(await sha256Hex(plaintext));
   });
 });


### PR DESCRIPTION
## Summary
- Change generated API keys from `ck_`-prefixed base64url tokens to UUID v4 strings accepted by WakaTime-compatible CLI tools.
- Update OpenAPI, generated types, auth/deployment docs, and README examples to describe UUID API keys.
- Add integration coverage proving regenerated API keys are UUID v4 values and authenticate successfully.

## Root Cause
A WakaTime-compatible CLI validates the API key format before sending any heartbeat. The `ck_...` format generated by CloudTime was rejected locally with `invalid api key format`, so editor/CLI integration required a manual UUID workaround.

## Impact
Newly generated API keys are now directly usable with WakaTime-compatible CLI/editor plugins. Existing stored keys are still validated by SHA-256 hash lookup, so already-issued keys are not rejected by the server solely because of their string format.

## Review Follow-up
- Clarified that UUID shape is for client compatibility; security relies on Web Crypto CSPRNG output and hash-only storage.
- Removed new code-level brand wording from generated comments/test names.

## Validation
- `npm run generate`
- `npm run lint:api`
- `npm run typecheck`
- `npm test -- tests/security/crypto.test.ts tests/integration/auth-route-mounting.test.ts tests/integration/heartbeats.test.ts`
- `npm test`
- Manual validation: a WakaTime-compatible CLI v2.21.4 accepted a UUID API key and CloudTime stored two heartbeat rows in remote D1.