### PR TITLE
spec: extend embeddable cards for GitHub profile streaks

### DIFF
--- a/schemas/paths/cards/public-card.yaml
+++ b/schemas/paths/cards/public-card.yaml
@@ -36,6 +36,7 @@ get:
           - heatmap
           - summary
           - languages
+          - streak
     - name: range
       in: query
       required: false

--- a/specs/160-embeddable-cards/checklists/requirements.md
+++ b/specs/160-embeddable-cards/checklists/requirements.md
@@ -37,5 +37,8 @@
   references). Spec updated accordingly.
 - All other underspecified details were resolved with reasonable defaults recorded in the
   Assumptions section.
+- The GitHub profile README extension is clarified: streak cards use CloudTime
+  tracked coding days, and dashboard snippets expose only public card URLs with
+  no credentials.
 - All checklist items pass. Spec is ready for `/speckit-plan` (or `/speckit-clarify` if deeper
   refinement is wanted first).

--- a/specs/160-embeddable-cards/contracts/openapi-diff.md
+++ b/specs/160-embeddable-cards/contracts/openapi-diff.md
@@ -44,7 +44,7 @@ Additive only. No existing endpoint, parameter, schema, or response is changed.
 - `security: []`
 - Path parameters:
   - `username` string
-  - `card_type` enum: `heatmap`, `summary`, `languages`
+  - `card_type` enum: `heatmap`, `summary`, `languages`, `streak`
 - Query parameters:
   - `range` string (optional)
   - `theme` string (optional)
@@ -129,3 +129,13 @@ Contract notes:
 - `components["schemas"]["EmbedTemplateInput"]`
 
 No existing generated member is removed or renamed.
+
+## 6. GitHub profile card extension (#186)
+
+Additive follow-up to the original spec 160 contract:
+
+- `card_type` enum adds `streak`.
+- `streak.svg` uses the same public visibility, cache, ETag, `theme`, `range`,
+  `template_id`, and `v` behavior as other card types.
+- The card reports CloudTime tracked-activity streaks, not GitHub
+  contribution streaks.

--- a/specs/160-embeddable-cards/data-model.md
+++ b/specs/160-embeddable-cards/data-model.md
@@ -61,12 +61,29 @@ Validation:
 Not persisted. A card render is derived from:
 
 - target user;
-- card type (`heatmap`, `summary`, `languages`);
+- card type (`heatmap`, `summary`, `languages`, `streak`);
 - range;
 - theme;
 - optional template id;
 - current embed settings;
 - aggregated summaries/hourly summaries plus current-day overlay.
+
+### Tracked Day
+
+Not persisted as a separate table. A tracked day is derived from existing
+activity data:
+
+- date is a user-local calendar date using the user's configured timezone;
+- total computed coding duration is at least one second;
+- timeout rules have already been applied by the duration/summary builder.
+
+The streak card uses tracked days to compute:
+
+- `current_streak`: consecutive tracked days ending today, or ending yesterday
+  when today has no tracked duration yet;
+- `longest_streak`: longest consecutive tracked-day run inside the selected
+  range;
+- `tracked_days`: count of tracked days in the selected range.
 
 ### Rendered Card Cache Entry
 
@@ -75,7 +92,7 @@ Stored in KV, not D1.
 | Key Part | Notes |
 |----------|-------|
 | `user_id` | Internal user id resolved from the public username. |
-| `card_type` | `heatmap`, `summary`, or `languages`. |
+| `card_type` | `heatmap`, `summary`, `languages`, or `streak`. |
 | `range` | Normalized range after fallback/defaulting. |
 | `theme` | Normalized theme after fallback/defaulting. |
 | `template_id` | Present only when a template is used. |

--- a/specs/160-embeddable-cards/data-model.md
+++ b/specs/160-embeddable-cards/data-model.md
@@ -77,13 +77,15 @@ activity data:
 - total computed coding duration is at least one second;
 - timeout rules have already been applied by the duration/summary builder.
 
-The streak card uses tracked days to compute:
+The streak card uses tracked days and selected-range totals to compute:
 
-- `current_streak`: consecutive tracked days ending today, or ending yesterday
-  when today has no tracked duration yet;
+- `current_streak`: consecutive tracked days inside the normalized range,
+  ending today, or ending yesterday when today has no tracked duration yet. If
+  the active run began before the range, only in-range days are counted;
 - `longest_streak`: longest consecutive tracked-day run inside the selected
   range;
-- `tracked_days`: count of tracked days in the selected range.
+- `tracked_days`: count of tracked days in the selected range;
+- `total_seconds`: sum of computed coding duration in the selected range.
 
 ### Rendered Card Cache Entry
 

--- a/specs/160-embeddable-cards/plan.md
+++ b/specs/160-embeddable-cards/plan.md
@@ -13,6 +13,10 @@ operator-configurable freshness window. The first implementation renders SVG
 from aggregated summaries with a current-day overlay, so a GitHub README image
 can stay current without commits or scheduled repository jobs.
 
+The GitHub profile README extension adds a `streak` card type derived from
+CloudTime tracked coding days and dashboard-generated Markdown snippets for
+copying public card URLs into profile READMEs.
+
 **PR1 (this PR)**: SpecKit artifacts + OpenAPI paths/components for the public
 SVG card endpoint, embed settings, and custom template CRUD + regenerated
 types. **No route handlers, migrations, bindings, or docs-behavior changes.**
@@ -53,7 +57,7 @@ cache keys, never authorization or data selection.
 | II. Cloudflare-Native | PASS | Public rendering is cache-first in KV and reads pre-aggregates on miss; current-day work is bounded. OFF path performs no cache/D1 work. |
 | III. Type Safety | PASS | All new endpoint and schema shapes are generated from `schemas/openapi.yaml`; no hand-edits to generated types. |
 | IV. Legal/Trademark | PASS | The feature is original; references are limited to "WakaTime-compatible" docs wording and no WakaTime source or assets are consulted. |
-| V. Simplicity First | PASS | Three fixed card types, styling-only built-in themes, one settings resource, and template customization deferred to P3. |
+| V. Simplicity First | PASS | Four fixed card types, styling-only built-in themes, one settings resource, and template customization deferred to P3. |
 
 ## Project Structure
 
@@ -101,6 +105,7 @@ tests/integration/embeddable-cards.test.ts   # ADD: route and privacy contract t
 tests/unit/cards-render.test.ts              # ADD: renderer/template unit tests
 docs/deployment-guide.md                     # CHANGE: embed privacy and freshness settings
 docs/cloudflare-constraints.md               # CHANGE: cache/rate-limit notes for public card traffic
+src/ui/dashboard.tsx                         # CHANGE: GitHub README snippets/previews after card implementation
 wrangler.toml                                # CHANGE: commented RATE_LIMIT_EMBED_CARDS block
 ```
 
@@ -138,3 +143,9 @@ SVG at write time so public rendering never evaluates untrusted active content.
   the target user's current local day and reuse existing timeout/date helpers;
   if the bounded query exceeds budget, fall back to the latest aggregate and
   mark the renderer as pending in PR2 tests.
+- **Streak semantics are confused with GitHub contributions** -> define a
+  tracked day as CloudTime coding duration in the user's timezone and avoid
+  reading GitHub contribution data.
+- **Dashboard snippet leaks credentials** -> generate snippets from the public
+  username and app base URL only; never include API keys, session tokens, or
+  query-parameter credentials.

--- a/specs/160-embeddable-cards/quickstart.md
+++ b/specs/160-embeddable-cards/quickstart.md
@@ -71,15 +71,35 @@ host page beyond the optional `v` value.
 ```bash
 curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?range=last_7_days&theme=dark"
 curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/languages.svg?range=last_30_days&theme=unknown"
+curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?range=last_year&theme=default"
 ```
 
 Expected:
 
 - summary and language card totals match aggregated stats for the range
+- streak card current/longest streak values match tracked coding days in the requested range
 - unknown theme falls back to the user's default theme
 - zero-activity ranges still return a valid readable SVG
 
-## 6. Verify custom template rejection
+## 6. Copy a GitHub profile README snippet
+
+From the authenticated dashboard, open the embeddable cards section and copy
+the Markdown snippet for a public card.
+
+Expected snippets use ordinary Markdown image syntax and contain no API key or
+session token:
+
+```markdown
+![CloudTime heatmap](https://time.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?theme=default)
+![CloudTime summary](https://time.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?theme=default)
+![CloudTime streak](https://time.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?theme=default)
+```
+
+Paste the snippet into a GitHub profile README repository. GitHub may proxy the
+remote image through Camo, so freshness is controlled by CloudTime cache
+headers plus GitHub's own best-effort proxy behavior.
+
+## 7. Verify custom template rejection
 
 ```bash
 curl -X POST "https://time.example.com/api/v1/users/current/embed_templates" \
@@ -97,7 +117,7 @@ Expected:
 Repeat with event handlers, external `href`, `foreignObject`, data URLs, and an
 unknown placeholder token; all must be rejected.
 
-## 7. Turn embeds OFF with a warm cache
+## 8. Turn embeds OFF with a warm cache
 
 1. Request a card successfully.
 2. Disable embeds:
@@ -128,5 +148,6 @@ npm test
 
 The PR2 test suite should include integration coverage for default OFF, ON
 rendering, cache headers, cache-busting, unsupported range fallback, invalid
-card type, theme fallback, zero activity, unsafe template rejection, and OFF
-with a pre-existing cached render.
+card type, theme fallback, streak calculations, zero activity, unsafe template
+rejection, dashboard snippet generation, and OFF with a pre-existing cached
+render.

--- a/specs/160-embeddable-cards/quickstart.md
+++ b/specs/160-embeddable-cards/quickstart.md
@@ -77,7 +77,8 @@ curl -i "https://time.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?ra
 Expected:
 
 - summary and language card totals match aggregated stats for the range
-- streak card current/longest streak values match tracked coding days in the requested range
+- streak card current streak, longest streak, tracked-day count, and total time
+  match tracked coding days in the requested range
 - unknown theme falls back to the user's default theme
 - zero-activity ranges still return a valid readable SVG
 

--- a/specs/160-embeddable-cards/research.md
+++ b/specs/160-embeddable-cards/research.md
@@ -159,15 +159,19 @@ implementation original while still explaining compatibility context in docs.
 
 **Decision**: A tracked day is a user-local calendar day with at least one
 second of computed coding duration after applying the user's timeout rules.
-`current_streak` counts consecutive tracked days ending today, or ending
-yesterday when today has no tracked duration yet. `longest_streak` is the
-maximum consecutive tracked-day run in the requested range.
+`current_streak` counts consecutive tracked days inside the normalized range,
+ending today, or ending yesterday when today has no tracked duration yet. If
+the active run began before the requested range, only in-range days are
+counted. `longest_streak` is the maximum consecutive tracked-day run in the
+requested range, and `total_seconds` is the selected-range coding duration.
 
 **Why**: GitHub profile users recognize streak cards, but CloudTime should not
 conflate GitHub contribution data with coding-time data. Counting days from
 CloudTime durations keeps the metric explainable, reproducible, and derived
-from data the system already owns. Allowing the current streak to end yesterday
-avoids showing zero every morning before the user has started coding.
+from data the system already owns. Bounding streak metrics to the normalized
+range keeps public rendering cacheable and avoids unbounded historical reads.
+Allowing the current streak to end yesterday avoids showing zero every morning
+before the user has started coding.
 
 **Alternatives considered**: Using GitHub contribution events was rejected
 because CloudTime does not ingest that data and the card should represent

--- a/specs/160-embeddable-cards/research.md
+++ b/specs/160-embeddable-cards/research.md
@@ -17,6 +17,21 @@ Sources consulted (2026-06-18):
 - OpenAPI Specification 3.1 - media type content and binary/text response
   description
 
+Additional sources consulted (2026-07-03) for the GitHub profile README card
+extension:
+
+- GitHub Docs: Managing your profile README - profile README repository
+  requirements
+- GitHub Docs: Basic writing and formatting syntax - Markdown image syntax
+- GitHub Docs: About anonymized URLs - Camo proxy behavior, content type
+  checks, `Cache-Control` guidance, and rare cache purge fallback
+- Cloudflare Docs: Workers Cache API - cacheable response headers and
+  conditional request behavior
+- Cloudflare Docs: ETag headers - `304 Not Modified` validation behavior
+- MDN: SVG `<script>` and `SVGScriptElement.href` - active SVG scripting and
+  external script risk
+- W3C SVG Security - scripts and external-resource references in SVG
+
 ## D-1: Public URL shape and authentication
 
 **Decision**: Use
@@ -35,6 +50,12 @@ humans inspecting the embed.
 rejected because it bakes in single-user addressing and would need a breaking
 URL later. `api_key` query parameters were rejected because FR-009 forbids
 secrets in embed URLs and README pages are public.
+
+**2026-07-03 update**: Add `streak` as a fourth built-in card type. The public
+URL shape remains unchanged:
+`GET /api/v1/users/{username}/cards/streak.svg`. The card is intended for
+GitHub profile READMEs, but remains a generic public image URL usable anywhere
+remote images are displayed.
 
 ## D-2: Visibility default and disabled behavior
 
@@ -133,3 +154,40 @@ copy are used.
 
 **Why**: This follows the repository's legal/trademark rule and keeps the
 implementation original while still explaining compatibility context in docs.
+
+## D-8: CloudTime streak semantics
+
+**Decision**: A tracked day is a user-local calendar day with at least one
+second of computed coding duration after applying the user's timeout rules.
+`current_streak` counts consecutive tracked days ending today, or ending
+yesterday when today has no tracked duration yet. `longest_streak` is the
+maximum consecutive tracked-day run in the requested range.
+
+**Why**: GitHub profile users recognize streak cards, but CloudTime should not
+conflate GitHub contribution data with coding-time data. Counting days from
+CloudTime durations keeps the metric explainable, reproducible, and derived
+from data the system already owns. Allowing the current streak to end yesterday
+avoids showing zero every morning before the user has started coding.
+
+**Alternatives considered**: Using GitHub contribution events was rejected
+because CloudTime does not ingest that data and the card should represent
+CloudTime activity. Counting raw heartbeats was rejected because summaries and
+duration builders already apply timeout rules and timezone bucketing.
+
+## D-9: GitHub profile README UX
+
+**Decision**: The authenticated dashboard should generate copyable Markdown
+snippets for each available public card and render a preview using the same
+public URL. Snippets use ordinary Markdown image syntax and never include API
+keys or session tokens. A cache-busting `v` value may be offered as a manual
+refresh helper, but the UI must describe it as a URL-change mechanism rather
+than a guaranteed immediate GitHub Camo purge.
+
+**Why**: GitHub supports online image embeds in Markdown and profile README
+display depends on a public repository named after the GitHub username. Users
+should not need to construct card URLs by hand, and the UI should make the
+public-visibility state obvious before a snippet is copied.
+
+**Alternatives considered**: Auto-editing a user's GitHub README was rejected
+because it would require a new GitHub authorization flow and introduces
+unnecessary write risk. A GitHub App is not needed for the first version.

--- a/specs/160-embeddable-cards/spec.md
+++ b/specs/160-embeddable-cards/spec.md
@@ -6,7 +6,7 @@
 
 **Status**: Draft
 
-**Input**: User description: "Embeddable stat cards — continuously-updated dynamic image cards that a user embeds in their GitHub profile README (and other sites), inspired by WakaTime-compatible embeddable charts. Card types: coding-time heatmap, stats summary, top-languages. Multiple selectable themes. User-supplied custom template/background. Public ON/OFF toggle. Short configurable freshness window so the image stays current."
+**Input**: User description: "Embeddable stat cards — continuously-updated dynamic image cards that a user embeds in their GitHub profile README (and other sites), inspired by WakaTime-compatible embeddable charts. Card types: coding-time heatmap, stats summary, top-languages, and CloudTime activity streak. Multiple selectable themes. User-supplied custom template/background. Public ON/OFF toggle. Short configurable freshness window so the image stays current."
 
 ## Background
 
@@ -108,6 +108,35 @@ A user picks from several built-in visual themes (for example a dark and a light
 
 ---
 
+### User Story 5a - Embed a CloudTime activity streak card (Priority: P2)
+
+A user embeds a compact card showing their CloudTime activity streak: current
+tracked-day streak, longest tracked-day streak, and total tracked time for a
+selectable range.
+
+**Why this priority**: GitHub profile README users commonly expect a streak
+card, and CloudTime can provide an original coding-time streak without relying
+on GitHub contribution data. It shares the same public image, visibility,
+cache, and theme infrastructure as the other P2 built-in cards.
+
+**Independent Test**: Seed activity across consecutive and non-consecutive
+timezone-local days, request `streak.svg`, and confirm the current and longest
+streak values match CloudTime duration days after timeout rules are applied.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with tracked coding activity on consecutive local days,
+   **When** the streak card is requested, **Then** it shows the current tracked
+   day streak and longest tracked day streak.
+2. **Given** today has no tracked coding time yet but yesterday continues an
+   active streak, **When** the streak card is requested, **Then** the current
+   streak may end yesterday rather than resetting to zero.
+3. **Given** a user with no tracked coding time in the requested range,
+   **When** the streak card is requested, **Then** it renders a readable
+   zero-activity state.
+
+---
+
 ### User Story 6 - Define a custom card template (Priority: P3)
 
 Beyond the built-in presets, a user supplies their own card template containing placeholder tokens (a marked-up vector template). The system fills the placeholders with the user's current stats and serves the result as a card, giving the user full control over layout and styling.
@@ -134,6 +163,8 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **High view volume**: a popular README can drive many image requests; cards must be cacheable and rate-limitable so the instance stays within edge-platform limits.
 - **Oversized/malformed custom template or background**: must be validated and rejected within size limits.
 - **Direct SVG access**: opening the SVG URL directly must not execute user-supplied scripts or load user-supplied external resources.
+- **Streak start-of-day**: current streak must not drop to zero merely because the user has not started coding today; if today has no duration, the streak may end yesterday.
+- **GitHub README cache**: Dashboard snippets may include a `v` cache-busting value, but the system must not promise that GitHub Camo will refresh immediately.
 
 ## Requirements *(mandatory)*
 
@@ -144,6 +175,7 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **FR-003**: System MUST provide a **coding-time heatmap** card showing daily coding-time intensity over a trailing period in a contribution-graph style.
 - **FR-004**: System MUST provide a **stats summary** card showing total time, daily average, best day, and top language for a selectable time range.
 - **FR-005**: System MUST provide a **top-languages** card showing each top language and its relative share of coding time.
+- **FR-005a**: System MUST provide a **CloudTime activity streak** card showing current tracked-day streak, longest tracked-day streak, and total tracked time for a selectable range.
 - **FR-006**: Users MUST be able to select among multiple built-in visual themes; an unknown or invalid theme MUST fall back to a default theme rather than fail.
 - **FR-007**: Users MUST be able to supply a custom card template containing recognized placeholder tokens; the system MUST fill those placeholders with the user's current stats and MUST reject templates that exceed size limits or contain unsupported/unsafe content (scripts, event-handler attributes, external resource references, active document features, or unknown placeholder tokens).
 - **FR-008**: Operators MUST be able to turn embeddable cards ON or OFF; the default MUST be OFF, and when OFF every card URL MUST return `404` before any cached image or coding data can be returned.
@@ -157,15 +189,18 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **FR-016**: Public card responses MUST be valid SVG images served with an image media type, explicit cache headers derived from the freshness window, and no cookies or user-private headers.
 - **FR-017**: Custom templates MUST be restricted to a safe static SVG subset; the rendered SVG MUST NOT contain scripts, event-handler attributes, `foreignObject`, external `href`/`xlink:href` references, remote fonts, or data URLs supplied by the user.
 - **FR-018**: Public card URLs MUST identify the target user with a non-secret stable identifier, not with an API key or session-bound value.
+- **FR-019**: System MUST define a tracked day for streak cards as a user-local calendar day with at least one second of computed coding duration after applying the user's timeout rules.
+- **FR-020**: System MUST provide copyable GitHub README Markdown snippets for available public card URLs in the authenticated UI, and those snippets MUST NOT include API keys, session tokens, or other secrets.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Embeddable Card**: a rendered image of a user's coding stats. Attributes: card type (heatmap / summary / top-languages), selected theme, time range, target user, and freshness metadata. Derived from aggregated data; not stored as user-editable content.
+- **Embeddable Card**: a rendered image of a user's coding stats. Attributes: card type (heatmap / summary / top-languages / streak), selected theme, time range, target user, and freshness metadata. Derived from aggregated data; not stored as user-editable content.
 - **Embed Settings**: per-user settings controlling public card visibility, freshness window, and default theme.
 - **Theme**: a named visual preset defining colors and typography only — never which data is shown.
 - **Custom Card Template**: a user-supplied template containing placeholder tokens for stat values. Scoped to a user; subject to size limits and a safe-content policy (no scripts or external references); only a defined set of placeholder tokens is recognized and substituted.
 - **Embed Visibility Setting**: configuration controlling whether cards are publicly retrievable for a user/instance.
 - **Aggregated Activity (existing)**: the daily/hourly coding-time summaries and commit data already maintained by CloudTime; the source of every number a card displays.
+- **Tracked Day**: a user-local calendar day with at least one second of computed coding duration after timeout rules are applied. Used by the streak card.
 
 ## Success Criteria *(mandatory)*
 
@@ -180,6 +215,7 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **SC-007**: Cards render a valid image in 100% of cases including zero-activity users (no broken images).
 - **SC-008**: A user can force an immediate refresh of a card and see updated data on the next view.
 - **SC-009**: A supplied unsafe template (script, event handler, external reference, `foreignObject`, data URL, or unknown placeholder) is rejected 100% of the time before it can be rendered.
+- **SC-010**: A user can copy a GitHub README Markdown snippet for every available built-in card from the authenticated dashboard without manually assembling a URL.
 
 ## Assumptions
 
@@ -189,6 +225,7 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - The default **freshness window is short** (15 minutes) and is configurable; an external image proxy's own caching is accepted as a best-effort upper bound on staleness, mitigated by a force-refresh mechanism (FR-015).
 - Cards are delivered as **SVG vector images** suitable for README embedding; raster (PNG/JPG) output is out of scope for the first version.
 - **Themes are styling-only** (colors/typography) and apply uniformly across card types.
+- The streak card uses CloudTime tracked coding activity only; it does not read or display GitHub contribution data.
 - A user-supplied custom template is durable user data managed by CloudTime and is treated as untrusted input: only a defined set of stat placeholder tokens is substituted, and unsafe SVG constructs are rejected before storage or rendering.
 - Access to cards is **read-only**; cards never mutate data.
 

--- a/specs/160-embeddable-cards/spec.md
+++ b/specs/160-embeddable-cards/spec.md
@@ -120,14 +120,16 @@ on GitHub contribution data. It shares the same public image, visibility,
 cache, and theme infrastructure as the other P2 built-in cards.
 
 **Independent Test**: Seed activity across consecutive and non-consecutive
-timezone-local days, request `streak.svg`, and confirm the current and longest
-streak values match CloudTime duration days after timeout rules are applied.
+timezone-local days, request `streak.svg`, and confirm the current streak,
+longest streak, tracked-day count, and total tracked time match CloudTime
+duration days inside the requested range after timeout rules are applied.
 
 **Acceptance Scenarios**:
 
 1. **Given** a user with tracked coding activity on consecutive local days,
    **When** the streak card is requested, **Then** it shows the current tracked
-   day streak and longest tracked day streak.
+   day streak, longest tracked day streak, tracked-day count, and total tracked
+   time for the requested range.
 2. **Given** today has no tracked coding time yet but yesterday continues an
    active streak, **When** the streak card is requested, **Then** the current
    streak may end yesterday rather than resetting to zero.
@@ -190,6 +192,7 @@ Beyond the built-in presets, a user supplies their own card template containing 
 - **FR-017**: Custom templates MUST be restricted to a safe static SVG subset; the rendered SVG MUST NOT contain scripts, event-handler attributes, `foreignObject`, external `href`/`xlink:href` references, remote fonts, or data URLs supplied by the user.
 - **FR-018**: Public card URLs MUST identify the target user with a non-secret stable identifier, not with an API key or session-bound value.
 - **FR-019**: System MUST define a tracked day for streak cards as a user-local calendar day with at least one second of computed coding duration after applying the user's timeout rules.
+- **FR-019a**: Streak card metrics MUST be computed inside the normalized requested range. If an active streak began before the range, current streak counts only the in-range consecutive tracked days.
 - **FR-020**: System MUST provide copyable GitHub README Markdown snippets for available public card URLs in the authenticated UI, and those snippets MUST NOT include API keys, session tokens, or other secrets.
 
 ### Key Entities *(include if feature involves data)*

--- a/specs/160-embeddable-cards/tasks.md
+++ b/specs/160-embeddable-cards/tasks.md
@@ -80,9 +80,10 @@ CloudTime tracked-day streaks from existing activity data.
 
 **Independent Test**: Seed activity across consecutive and non-consecutive
 timezone-local days, request `streak.svg`, and verify current/longest streak,
-zero activity, range fallback, cache headers, and theme fallback.
+tracked-day count, total seconds, range-boundary truncation, zero activity,
+range fallback, cache headers, and theme fallback.
 
-- [ ] T351 [P] Add unit tests for tracked-day streak calculations: consecutive days, gaps, today with no activity, timezone-local day boundaries, and zero activity.
+- [ ] T351 [P] Add unit tests for tracked-day streak calculations: consecutive days, gaps, today with no activity, timezone-local day boundaries, range-boundary truncation, total seconds, and zero activity.
 - [ ] T352 [P] Add renderer tests for `streak.svg` safe static SVG output and XML escaping.
 - [ ] T353 Add integration tests for `streak.svg` visibility OFF/ON, cache/ETag behavior, range fallback, and no secret leakage.
 - [ ] T354 Implement streak-card data builder from existing daily totals after timeout rules are applied.

--- a/specs/160-embeddable-cards/tasks.md
+++ b/specs/160-embeddable-cards/tasks.md
@@ -14,8 +14,8 @@ P2/P3.
 - [x] T004 Add `specs/160-embeddable-cards/quickstart.md` for PR2 manual validation.
 - [x] T005 Add `specs/160-embeddable-cards/contracts/openapi-diff.md`.
 - [x] T006 Update OpenAPI paths/components for public SVG cards, embed settings, and template CRUD.
-- [ ] T007 Run `npm run generate` and commit regenerated `src/types/generated.ts`.
-- [ ] T008 Run `npm run lint:api` and `npm run typecheck`.
+- [x] T007 Run `npm run generate` and commit regenerated `src/types/generated.ts`.
+- [x] T008 Run `npm run lint:api` and `npm run typecheck`.
 
 ---
 
@@ -73,6 +73,26 @@ values match existing stats aggregates; invalid theme falls back to default.
 
 ---
 
+## Phase 4a: User Story 5a - CloudTime activity streak card (P2)
+
+**Goal**: A GitHub-profile-friendly streak card renders current and longest
+CloudTime tracked-day streaks from existing activity data.
+
+**Independent Test**: Seed activity across consecutive and non-consecutive
+timezone-local days, request `streak.svg`, and verify current/longest streak,
+zero activity, range fallback, cache headers, and theme fallback.
+
+- [ ] T351 [P] Add unit tests for tracked-day streak calculations: consecutive days, gaps, today with no activity, timezone-local day boundaries, and zero activity.
+- [ ] T352 [P] Add renderer tests for `streak.svg` safe static SVG output and XML escaping.
+- [ ] T353 Add integration tests for `streak.svg` visibility OFF/ON, cache/ETag behavior, range fallback, and no secret leakage.
+- [ ] T354 Implement streak-card data builder from existing daily totals after timeout rules are applied.
+- [ ] T355 Implement streak-card renderer using shared themes and cache behavior.
+
+**Checkpoint**: Built-in card coverage includes heatmap, summary, languages,
+and streak.
+
+---
+
 ## Phase 5: User Story 6 - Custom templates (P3)
 
 **Goal**: A user can store a safe SVG template with placeholders and render a
@@ -95,9 +115,10 @@ unknown-placeholder templates return `400` and are never rendered.
 
 - [ ] T501 Update `docs/deployment-guide.md` with embed visibility, freshness, and force-refresh guidance.
 - [ ] T502 Update `docs/cloudflare-constraints.md` with public card cache/rate-limit behavior.
-- [ ] T503 Run `npm run generate` if PR2 changes OpenAPI further, then `npm run lint:api`.
-- [ ] T504 Run `npm run typecheck && npm test`.
-- [ ] T505 Open PR2 targeting `develop`, referencing PR1 and noting that embeds default OFF.
+- [ ] T503 Add dashboard copy/preview guidance for GitHub profile README snippets.
+- [ ] T504 Run `npm run generate` if PR2 changes OpenAPI further, then `npm run lint:api`.
+- [ ] T505 Run `npm run typecheck && npm test`.
+- [ ] T506 Open PR2 targeting `develop`, referencing PR1 and noting that embeds default OFF.
 
 ## Dependencies
 
@@ -105,5 +126,7 @@ unknown-placeholder templates return `400` and are never rendered.
 - P1 (T201-T207) must land before P2 and P3 because it establishes public
   visibility, cache, and renderer foundations.
 - P2 can proceed after P1.
+- Streak (T351-T355) can proceed after #186 lands and shares the P2 card
+  foundation with #175.
 - P3 can proceed after P1 and can run in parallel with P2 only if template
   routing does not change shared renderer interfaces.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -2805,7 +2805,7 @@ export interface operations {
                 /** @description Public CloudTime username identifying the card owner. */
                 username: string;
                 /** @description Card type to render. */
-                card_type: "heatmap" | "summary" | "languages";
+                card_type: "heatmap" | "summary" | "languages" | "streak";
             };
             cookie?: never;
         };


### PR DESCRIPTION
## Summary

- Extend the embeddable cards spec with a CloudTime activity `streak.svg` card type.
- Define tracked-day streak semantics using CloudTime coding duration, not GitHub contributions.
- Add GitHub profile README snippet/preview requirements for the authenticated dashboard.
- Update the OpenAPI card type enum and regenerate TypeScript types.

## Scope

Spec/design only. No route handlers, storage migrations, UI implementation, or runtime behavior changes are included.

## Review Follow-up

- Clarified that streak metrics are computed inside the normalized requested range.
- Added `total_seconds` to the streak data model so it matches the user story and FR-005a total tracked time requirement.
- Added implementation tasks for range-boundary truncation and total seconds tests.

## Related Issues

- Closes #186
- Relates to #175
- Relates to #187
- Relates to #188
- Relates to #176

## Verification

- `npm run generate`
- `npm run lint:api`
- `npm run typecheck`
- `npm test`

## References

- GitHub Docs: Managing your profile README: https://docs.github.com/en/account-and-profile/how-tos/profile-customization/managing-your-profile-readme
- GitHub Docs: Basic writing and formatting syntax: https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
- GitHub Docs: About anonymized URLs: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls
- Cloudflare Workers Cache API: https://developers.cloudflare.com/workers/runtime-apis/cache/
- Cloudflare ETag headers: https://developers.cloudflare.com/cache/reference/etag-headers/
- MDN SVGScriptElement href security considerations: https://developer.mozilla.org/en-US/docs/Web/API/SVGScriptElement/href
- W3C SVG Integration: https://www.w3.org/TR/svg-integration/