### PR TITLE
[codex] feat: add embeddable streak card

### DIFF
--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -4,7 +4,7 @@ import type { components } from "../types/generated";
 import type { Context } from "hono";
 import { authMiddleware } from "../middleware/auth";
 import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
-import { getHeatmapData, getStreakData } from "../utils/cards/data";
+import { getHeatmapData, getStreakData, resolveCardRange, type CardRange } from "../utils/cards/data";
 import { renderHeatmapSvg, renderStreakSvg, resolveThemeName } from "../utils/cards/render";
 import {
   buildCardCacheKey,
@@ -29,6 +29,7 @@ const FRESHNESS_MAX = 1440; // one day
 const THEME_NAME_MAX = 32;
 const THEME_NAME_RE = /^[a-z0-9_-]+$/;
 const USERNAME_MAX = 64;
+const RANGE_MAX = 32;
 const CACHE_BUSTER_MAX = 64;
 
 interface SettingsRow {
@@ -202,16 +203,22 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
   }
 
   const themeName = resolveThemeName(c.req.query("theme") ?? settings.default_theme);
+  const rangeParam = c.req.query("range");
+  if ((rangeParam?.length ?? 0) > RANGE_MAX) {
+    return badRequest(c, `range must be at most ${RANGE_MAX} characters`);
+  }
+  const cardRange = resolveCardRange(rangeParam);
   const v = c.req.query("v") ?? "";
   if (v.length > CACHE_BUSTER_MAX) {
     return badRequest(c, `v must be at most ${CACHE_BUSTER_MAX} characters`);
   }
   const ifNoneMatch = c.req.raw.headers.get("If-None-Match");
+  const cacheRange = cardType === "streak" ? cardRange.key : "year";
 
   const cacheKey = buildCardCacheKey({
     userId: user.id,
     cardType,
-    range: "year",
+    range: cacheRange,
     theme: themeName,
     templateId: "",
     v,
@@ -223,7 +230,7 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
     return svgResponse(cached.svg, cached.etag, settings.freshness_minutes, ifNoneMatch);
   }
 
-  const svg = await renderPublicCardSvg(c.env.DB, cardType, user, themeName);
+  const svg = await renderPublicCardSvg(c.env.DB, cardType, user, themeName, cardRange);
   const etag = await computeCardEtag(svg);
 
   const value: CardCacheValue = { svg, etag, generated_at: new Date().toISOString() };
@@ -239,6 +246,7 @@ async function renderPublicCardSvg(
   cardType: string,
   user: PublicUserRow,
   themeName: string,
+  cardRange: CardRange,
 ): Promise<string> {
   if (cardType === "heatmap") {
     const data = await getHeatmapData(db, user.id, user.timezone, user.timeout);
@@ -252,7 +260,7 @@ async function renderPublicCardSvg(
   }
 
   if (cardType === "streak") {
-    const data = await getStreakData(db, user.id, user.timezone, user.timeout);
+    const data = await getStreakData(db, user.id, user.timezone, user.timeout, cardRange.days);
     return renderStreakSvg({
       username: user.username,
       currentStreak: data.currentStreak,
@@ -260,6 +268,7 @@ async function renderPublicCardSvg(
       trackedDays: data.trackedDays,
       totalSeconds: data.totalSeconds,
       theme: themeName,
+      rangeLabel: cardRange.label,
     });
   }
 

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -4,8 +4,8 @@ import type { components } from "../types/generated";
 import type { Context } from "hono";
 import { authMiddleware } from "../middleware/auth";
 import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
-import { getHeatmapData } from "../utils/cards/data";
-import { renderHeatmapSvg, resolveThemeName } from "../utils/cards/render";
+import { getHeatmapData, getStreakData } from "../utils/cards/data";
+import { renderHeatmapSvg, renderStreakSvg, resolveThemeName } from "../utils/cards/render";
 import {
   buildCardCacheKey,
   cardCacheControl,
@@ -150,9 +150,9 @@ cardsSettings.patch("/embed_settings", async (c) => {
 
 export const cardsPublic = new Hono<{ Bindings: Env }>();
 
-// P1 ships the heatmap. summary/languages are valid in the contract but land in
-// P2; until then they are reported as not found.
-const IMPLEMENTED_CARD_TYPES = new Set(["heatmap"]);
+// summary/languages are valid in the contract but land in later phases; until
+// then they are reported as not found.
+const IMPLEMENTED_CARD_TYPES = new Set(["heatmap", "streak"]);
 
 function notFound(c: Context): Response {
   return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
@@ -223,14 +223,7 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
     return svgResponse(cached.svg, cached.etag, settings.freshness_minutes, ifNoneMatch);
   }
 
-  const data = await getHeatmapData(c.env.DB, user.id, user.timezone, user.timeout);
-  const svg = renderHeatmapSvg({
-    username: user.username,
-    dayTotals: data.dayTotals,
-    todayStr: data.todayStr,
-    totalSeconds: data.totalSeconds,
-    theme: themeName,
-  });
+  const svg = await renderPublicCardSvg(c.env.DB, cardType, user, themeName);
   const etag = await computeCardEtag(svg);
 
   const value: CardCacheValue = { svg, etag, generated_at: new Date().toISOString() };
@@ -240,6 +233,38 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
 
   return svgResponse(svg, etag, settings.freshness_minutes, ifNoneMatch);
 });
+
+async function renderPublicCardSvg(
+  db: D1Database,
+  cardType: string,
+  user: PublicUserRow,
+  themeName: string,
+): Promise<string> {
+  if (cardType === "heatmap") {
+    const data = await getHeatmapData(db, user.id, user.timezone, user.timeout);
+    return renderHeatmapSvg({
+      username: user.username,
+      dayTotals: data.dayTotals,
+      todayStr: data.todayStr,
+      totalSeconds: data.totalSeconds,
+      theme: themeName,
+    });
+  }
+
+  if (cardType === "streak") {
+    const data = await getStreakData(db, user.id, user.timezone, user.timeout);
+    return renderStreakSvg({
+      username: user.username,
+      currentStreak: data.currentStreak,
+      longestStreak: data.longestStreak,
+      trackedDays: data.trackedDays,
+      totalSeconds: data.totalSeconds,
+      theme: themeName,
+    });
+  }
+
+  throw new Error(`Unsupported card type: ${cardType}`);
+}
 
 function svgResponse(
   svg: string,

--- a/src/utils/cards/data.ts
+++ b/src/utils/cards/data.ts
@@ -30,6 +30,26 @@ export interface StreakData extends StreakStats {
 const HEATMAP_WEEKS = 53;
 const STREAK_DAYS = 365;
 
+export interface CardRange {
+  key: string;
+  days: number;
+  label: string;
+}
+
+const CARD_RANGES: Record<string, CardRange> = {
+  last_7_days: { key: "last_7_days", days: 7, label: "the last 7 days" },
+  last_30_days: { key: "last_30_days", days: 30, label: "the last 30 days" },
+  last_6_months: { key: "last_6_months", days: 183, label: "the last 6 months" },
+  last_year: { key: "last_year", days: STREAK_DAYS, label: "the last year" },
+};
+
+export function resolveCardRange(range?: string): CardRange {
+  if (range && Object.prototype.hasOwnProperty.call(CARD_RANGES, range)) {
+    return CARD_RANGES[range];
+  }
+  return CARD_RANGES.last_year;
+}
+
 export async function getHeatmapData(
   db: D1Database,
   userId: string,
@@ -64,10 +84,12 @@ export async function getStreakData(
   userId: string,
   tz: string,
   timeoutMinutes: number,
+  rangeDays = STREAK_DAYS,
 ): Promise<StreakData> {
   const today = getToday(tz);
   const todayStr = formatDate(today);
-  const startStr = formatDate(addDays(today, -(STREAK_DAYS - 1)));
+  const days = Math.max(1, Math.floor(rangeDays));
+  const startStr = formatDate(addDays(today, -(days - 1)));
 
   const { dayTotals, totalSeconds: pastSeconds } = await loadSummaryDayTotals(
     db,

--- a/src/utils/cards/data.ts
+++ b/src/utils/cards/data.ts
@@ -14,9 +14,21 @@ export interface HeatmapData {
   totalSeconds: number;
 }
 
+export interface StreakStats {
+  trackedDays: number;
+  currentStreak: number;
+  longestStreak: number;
+}
+
+export interface StreakData extends StreakStats {
+  todayStr: string;
+  totalSeconds: number;
+}
+
 // 53 columns covers a full trailing year plus the current partial week, matching
 // a contribution-graph layout.
 const HEATMAP_WEEKS = 53;
+const STREAK_DAYS = 365;
 
 export async function getHeatmapData(
   db: D1Database,
@@ -30,19 +42,13 @@ export async function getHeatmapData(
   const totalDays = (HEATMAP_WEEKS - 1) * 7 + todayDow + 1;
   const startStr = formatDate(addDays(today, -(totalDays - 1)));
 
-  const { results } = await db
-    .prepare(
-      "SELECT date, SUM(total_seconds) AS seconds FROM summaries WHERE user_id = ? AND date >= ? AND date < ? GROUP BY date",
-    )
-    .bind(userId, startStr, todayStr)
-    .all<{ date: string; seconds: number }>();
-
-  const dayTotals = new Map<string, number>();
-  let totalSeconds = 0;
-  for (const row of results) {
-    dayTotals.set(row.date, row.seconds);
-    totalSeconds += row.seconds;
-  }
+  const { dayTotals, totalSeconds: pastSeconds } = await loadSummaryDayTotals(
+    db,
+    userId,
+    startStr,
+    todayStr,
+  );
+  let totalSeconds = pastSeconds;
 
   const todaySeconds = await computeTodaySeconds(db, userId, tz, todayStr, timeoutMinutes);
   if (todaySeconds > 0) {
@@ -51,6 +57,114 @@ export async function getHeatmapData(
   }
 
   return { dayTotals, todayStr, totalSeconds };
+}
+
+export async function getStreakData(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  timeoutMinutes: number,
+): Promise<StreakData> {
+  const today = getToday(tz);
+  const todayStr = formatDate(today);
+  const startStr = formatDate(addDays(today, -(STREAK_DAYS - 1)));
+
+  const { dayTotals, totalSeconds: pastSeconds } = await loadSummaryDayTotals(
+    db,
+    userId,
+    startStr,
+    todayStr,
+  );
+  let totalSeconds = pastSeconds;
+
+  const todaySeconds = await computeTodaySeconds(db, userId, tz, todayStr, timeoutMinutes);
+  if (todaySeconds > 0) {
+    dayTotals.set(todayStr, todaySeconds);
+    totalSeconds += todaySeconds;
+  }
+
+  return {
+    todayStr,
+    totalSeconds,
+    ...calculateStreakStats(dayTotals, todayStr),
+  };
+}
+
+export function calculateStreakStats(dayTotals: Map<string, number>, todayStr: string): StreakStats {
+  const activeDays = new Set<string>();
+  for (const [date, seconds] of dayTotals) {
+    if (seconds > 0) activeDays.add(date);
+  }
+
+  const sorted = [...activeDays].filter((date) => parseUtcDate(date) !== null).sort();
+  const trackedDays = sorted.length;
+  let longestStreak = 0;
+  let run = 0;
+  let previous: Date | null = null;
+
+  for (const dateStr of sorted) {
+    const current = parseUtcDate(dateStr);
+    if (!current) continue;
+    if (previous && formatDate(addDays(previous, 1)) === dateStr) {
+      run += 1;
+    } else {
+      run = 1;
+    }
+    longestStreak = Math.max(longestStreak, run);
+    previous = current;
+  }
+
+  let currentStreak = 0;
+  const today = parseUtcDate(todayStr);
+  if (today) {
+    let cursor = activeDays.has(todayStr) ? today : addDays(today, -1);
+    while (activeDays.has(formatDate(cursor))) {
+      currentStreak += 1;
+      cursor = addDays(cursor, -1);
+    }
+  }
+
+  return { trackedDays, currentStreak, longestStreak };
+}
+
+async function loadSummaryDayTotals(
+  db: D1Database,
+  userId: string,
+  startStr: string,
+  endExclusiveStr: string,
+): Promise<{ dayTotals: Map<string, number>; totalSeconds: number }> {
+  const { results } = await db
+    .prepare(
+      "SELECT date, SUM(total_seconds) AS seconds FROM summaries WHERE user_id = ? AND date >= ? AND date < ? GROUP BY date",
+    )
+    .bind(userId, startStr, endExclusiveStr)
+    .all<{ date: string; seconds: number | null }>();
+
+  const dayTotals = new Map<string, number>();
+  let totalSeconds = 0;
+  for (const row of results) {
+    const seconds = Number(row.seconds ?? 0);
+    dayTotals.set(row.date, seconds);
+    totalSeconds += seconds;
+  }
+  return { dayTotals, totalSeconds };
+}
+
+function parseUtcDate(dateStr: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const parsed = new Date(Date.UTC(y, m - 1, d));
+  if (
+    parsed.getUTCFullYear() !== y ||
+    parsed.getUTCMonth() !== m - 1 ||
+    parsed.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return parsed;
 }
 
 // Sum coding seconds for the user's current local day directly from heartbeats,

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -75,6 +75,15 @@ export interface HeatmapRenderOptions {
   theme?: string;
 }
 
+export interface StreakRenderOptions {
+  username: string;
+  currentStreak: number;
+  longestStreak: number;
+  trackedDays: number;
+  totalSeconds: number;
+  theme?: string;
+}
+
 export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
   const theme = resolveTheme(opts.theme);
   const [ty, tm, td] = opts.todayStr.split("-").map(Number);
@@ -150,4 +159,69 @@ export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
     legend +
     `</svg>`
   );
+}
+
+export function renderStreakSvg(opts: StreakRenderOptions): string {
+  const theme = resolveTheme(opts.theme);
+  const width = 495;
+  const height = 195;
+  const cardPadding = 22;
+  const metricTop = 78;
+  const metricWidth = 142;
+  const metricGap = 12;
+  const barWidth = 350;
+  const barX = cardPadding;
+  const barY = 152;
+  const streakRatio = opts.longestStreak > 0
+    ? Math.min(1, Math.max(0, opts.currentStreak / opts.longestStreak))
+    : 0;
+  const filledBarWidth = Math.round(barWidth * streakRatio);
+
+  const title = `@${escapeXml(truncateText(opts.username, 38))}`;
+  const totalText = escapeXml(`${formatHumanReadable(opts.totalSeconds)} total coding time`);
+  const ariaLabel = escapeXml(`Coding streak card for ${opts.username}`);
+  const current = escapeXml(formatDays(opts.currentStreak));
+  const longest = escapeXml(formatDays(opts.longestStreak));
+  const active = escapeXml(formatDays(opts.trackedDays));
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">` +
+    `<style>text{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;}` +
+    `.title{font-size:16px;font-weight:700;fill:${theme.text};}` +
+    `.subtitle{font-size:12px;fill:${theme.subtext};}` +
+    `.metric{font-size:25px;font-weight:700;fill:${theme.text};}` +
+    `.label{font-size:11px;font-weight:600;fill:${theme.subtext};}` +
+    `.note{font-size:11px;fill:${theme.subtext};}</style>` +
+    `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="#d0d7de"/>` +
+    `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
+    `<text x="${cardPadding}" y="52" class="subtitle">Coding streaks in the last year</text>` +
+    renderMetric(cardPadding, metricTop, metricWidth, "Current", current, theme.levels[2]) +
+    renderMetric(cardPadding + metricWidth + metricGap, metricTop, metricWidth, "Longest", longest, theme.levels[3]) +
+    renderMetric(cardPadding + (metricWidth + metricGap) * 2, metricTop, metricWidth, "Active days", active, theme.levels[1]) +
+    `<rect x="${barX}" y="${barY}" width="${barWidth}" height="8" rx="4" ry="4" fill="${theme.cellEmpty}"/>` +
+    `<rect x="${barX}" y="${barY}" width="${filledBarWidth}" height="8" rx="4" ry="4" fill="${theme.levels[2]}"/>` +
+    `<text x="${barX}" y="178" class="note">${totalText}</text>` +
+    `<text x="${width - cardPadding}" y="178" text-anchor="end" class="note">CloudTime</text>` +
+    `</svg>`
+  );
+}
+
+function renderMetric(x: number, y: number, width: number, label: string, value: string, accent: string): string {
+  return (
+    `<g>` +
+    `<rect x="${x}" y="${y - 16}" width="${width}" height="3" rx="1.5" ry="1.5" fill="${accent}"/>` +
+    `<text x="${x}" y="${y + 18}" class="metric">${value}</text>` +
+    `<text x="${x}" y="${y + 40}" class="label">${label}</text>` +
+    `</g>`
+  );
+}
+
+function formatDays(days: number): string {
+  const safeDays = Math.max(0, Math.floor(days));
+  return `${safeDays} ${safeDays === 1 ? "day" : "days"}`;
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 3))}...`;
 }

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -82,6 +82,7 @@ export interface StreakRenderOptions {
   trackedDays: number;
   totalSeconds: number;
   theme?: string;
+  rangeLabel?: string;
 }
 
 export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
@@ -180,6 +181,7 @@ export function renderStreakSvg(opts: StreakRenderOptions): string {
   const title = `@${escapeXml(truncateText(opts.username, 38))}`;
   const totalText = escapeXml(`${formatHumanReadable(opts.totalSeconds)} total coding time`);
   const ariaLabel = escapeXml(`Coding streak card for ${opts.username}`);
+  const rangeLabel = escapeXml(opts.rangeLabel ?? "the last year");
   const current = escapeXml(formatDays(opts.currentStreak));
   const longest = escapeXml(formatDays(opts.longestStreak));
   const active = escapeXml(formatDays(opts.trackedDays));
@@ -194,7 +196,7 @@ export function renderStreakSvg(opts: StreakRenderOptions): string {
     `.note{font-size:11px;fill:${theme.subtext};}</style>` +
     `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="#d0d7de"/>` +
     `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
-    `<text x="${cardPadding}" y="52" class="subtitle">Coding streaks in the last year</text>` +
+    `<text x="${cardPadding}" y="52" class="subtitle">Coding streaks in ${rangeLabel}</text>` +
     renderMetric(cardPadding, metricTop, metricWidth, "Current", current, theme.levels[2]) +
     renderMetric(cardPadding + metricWidth + metricGap, metricTop, metricWidth, "Longest", longest, theme.levels[3]) +
     renderMetric(cardPadding + (metricWidth + metricGap) * 2, metricTop, metricWidth, "Active days", active, theme.levels[1]) +

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -31,6 +31,13 @@ function authPatch(apiKey: string, body: unknown): RequestInit {
   };
 }
 
+function formatUtcDate(daysFromToday: number): string {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  today.setUTCDate(today.getUTCDate() + daysFromToday);
+  return today.toISOString().slice(0, 10);
+}
+
 describe("embeddable cards — public visibility", () => {
   it("returns 404 when embeds are OFF by default", async () => {
     const user = await seedUser({ username: "alice" });
@@ -59,6 +66,34 @@ describe("embeddable cards — public visibility", () => {
     const svg = await res.text();
     expect(svg.startsWith("<svg")).toBe(true);
     // The card URL is unauthenticated and must never echo a secret.
+    expect(svg).not.toContain(user.apiKey);
+  });
+
+  it("renders the streak card as SVG once embeds are enabled", async () => {
+    const user = await seedUser({ username: "streak_owner" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, ?, 'cards', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-2), 1800)
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, ?, 'cards', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-1), 3600)
+      .run();
+
+    const res = await call(`/api/v1/users/${user.username}/cards/streak.svg`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("image/svg+xml");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=");
+    expect(res.headers.get("ETag")).toBeTruthy();
+
+    const svg = await res.text();
+    expect(svg).toContain("Coding streaks in the last year");
+    expect(svg).toContain("2 days");
+    expect(svg).toContain("1 hr 30 mins total coding time");
     expect(svg).not.toContain(user.apiKey);
   });
 
@@ -99,7 +134,7 @@ describe("embeddable cards — public visibility", () => {
     expect(res.status).toBe(404);
   });
 
-  it("treats summary/languages cards as not-yet-available in P1", async () => {
+  it("treats summary/languages cards as not-yet-available in later phases", async () => {
     const user = await seedUser({ username: "carol" });
     await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
 

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -97,6 +97,36 @@ describe("embeddable cards — public visibility", () => {
     expect(svg).not.toContain(user.apiKey);
   });
 
+  it("applies the requested streak range to rendered totals", async () => {
+    const user = await seedUser({ username: "streak_range" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, ?, 'cards', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-7), 7200)
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, total_seconds) VALUES (?, ?, 'cards', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-6), 3600)
+      .run();
+
+    const res = await call(`/api/v1/users/${user.username}/cards/streak.svg?range=last_7_days`);
+    expect(res.status).toBe(200);
+
+    const svg = await res.text();
+    expect(svg).toContain("Coding streaks in the last 7 days");
+    expect(svg).toContain("1 hr total coding time");
+    expect(svg).not.toContain("3 hrs total coding time");
+
+    const fallback = await call(`/api/v1/users/${user.username}/cards/streak.svg?range=not_supported`);
+    expect(fallback.status).toBe(200);
+    const fallbackSvg = await fallback.text();
+    expect(fallbackSvg).toContain("Coding streaks in the last year");
+    expect(fallbackSvg).toContain("3 hrs total coding time");
+  });
+
   it("honors weak and listed If-None-Match validators", async () => {
     const user = await seedUser({ username: "etag_user" });
     await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));

--- a/tests/unit/cards-data.test.ts
+++ b/tests/unit/cards-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { calculateStreakStats } from "../../src/utils/cards/data";
+import { calculateStreakStats, resolveCardRange } from "../../src/utils/cards/data";
 
 describe("calculateStreakStats", () => {
   it("calculates active days plus current and longest streaks", () => {
@@ -60,5 +60,36 @@ describe("calculateStreakStats", () => {
     expect(stats.trackedDays).toBe(2);
     expect(stats.currentStreak).toBe(1);
     expect(stats.longestStreak).toBe(1);
+  });
+
+  it("counts streaks only from the supplied range window", () => {
+    const stats = calculateStreakStats(
+      new Map([
+        ["2026-06-17", 120],
+        ["2026-06-18", 180],
+      ]),
+      "2026-06-18",
+    );
+
+    expect(stats).toEqual({
+      trackedDays: 2,
+      currentStreak: 2,
+      longestStreak: 2,
+    });
+  });
+});
+
+describe("resolveCardRange", () => {
+  it("normalizes supported card ranges", () => {
+    expect(resolveCardRange("last_7_days")).toEqual({
+      key: "last_7_days",
+      days: 7,
+      label: "the last 7 days",
+    });
+  });
+
+  it("falls back to the default streak range for unsupported values", () => {
+    expect(resolveCardRange("all_time").key).toBe("last_year");
+    expect(resolveCardRange().key).toBe("last_year");
   });
 });

--- a/tests/unit/cards-data.test.ts
+++ b/tests/unit/cards-data.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { calculateStreakStats } from "../../src/utils/cards/data";
+
+describe("calculateStreakStats", () => {
+  it("calculates active days plus current and longest streaks", () => {
+    const stats = calculateStreakStats(
+      new Map([
+        ["2026-06-14", 120],
+        ["2026-06-15", 180],
+        ["2026-06-17", 240],
+        ["2026-06-18", 300],
+      ]),
+      "2026-06-18",
+    );
+
+    expect(stats).toEqual({
+      trackedDays: 4,
+      currentStreak: 2,
+      longestStreak: 2,
+    });
+  });
+
+  it("keeps the current streak alive when only yesterday has activity", () => {
+    const stats = calculateStreakStats(
+      new Map([
+        ["2026-06-15", 120],
+        ["2026-06-16", 180],
+        ["2026-06-17", 240],
+      ]),
+      "2026-06-18",
+    );
+
+    expect(stats.currentStreak).toBe(3);
+    expect(stats.longestStreak).toBe(3);
+  });
+
+  it("resets the current streak when both today and yesterday are inactive", () => {
+    const stats = calculateStreakStats(
+      new Map([
+        ["2026-06-14", 120],
+        ["2026-06-15", 180],
+      ]),
+      "2026-06-18",
+    );
+
+    expect(stats.currentStreak).toBe(0);
+    expect(stats.longestStreak).toBe(2);
+  });
+
+  it("ignores zero-second days", () => {
+    const stats = calculateStreakStats(
+      new Map([
+        ["2026-06-16", 120],
+        ["2026-06-17", 0],
+        ["2026-06-18", 180],
+      ]),
+      "2026-06-18",
+    );
+
+    expect(stats.trackedDays).toBe(2);
+    expect(stats.currentStreak).toBe(1);
+    expect(stats.longestStreak).toBe(1);
+  });
+});

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   escapeXml,
   renderHeatmapSvg,
+  renderStreakSvg,
   resolveTheme,
   resolveThemeName,
 } from "../../src/utils/cards/render";
@@ -66,6 +67,60 @@ describe("renderHeatmapSvg", () => {
     expect(svg).not.toMatch(/foreignObject/i);
     expect(svg).not.toMatch(/href=/i);
     expect(svg).not.toMatch(/on\w+=/i); // no event-handler attributes
+  });
+});
+
+describe("renderStreakSvg", () => {
+  it("produces a well-formed svg root with an image role", () => {
+    const svg = renderStreakSvg({
+      username: "alice",
+      currentStreak: 0,
+      longestStreak: 0,
+      trackedDays: 0,
+      totalSeconds: 0,
+    });
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(svg).toContain('role="img"');
+    expect(svg.trimEnd().endsWith("</svg>")).toBe(true);
+  });
+
+  it("renders a zero-activity user without throwing", () => {
+    const svg = renderStreakSvg({
+      username: "alice",
+      currentStreak: 0,
+      longestStreak: 0,
+      trackedDays: 0,
+      totalSeconds: 0,
+    });
+    expect(svg).toContain("0 days");
+    expect(svg).toContain("0 secs total coding time");
+  });
+
+  it("escapes the username to prevent markup injection", () => {
+    const svg = renderStreakSvg({
+      username: '<script>evil()</script>&"x',
+      currentStreak: 1,
+      longestStreak: 1,
+      trackedDays: 1,
+      totalSeconds: 60,
+    });
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+
+  it("emits only a safe static subset (no script/foreignObject/href)", () => {
+    const svg = renderStreakSvg({
+      username: "a",
+      currentStreak: 3,
+      longestStreak: 5,
+      trackedDays: 12,
+      totalSeconds: 3600,
+    });
+    expect(svg).not.toMatch(/<script/i);
+    expect(svg).not.toMatch(/foreignObject/i);
+    expect(svg).not.toMatch(/href=/i);
+    expect(svg).not.toMatch(/on\w+=/i);
   });
 });
 

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -97,6 +97,18 @@ describe("renderStreakSvg", () => {
     expect(svg).toContain("0 secs total coding time");
   });
 
+  it("renders the normalized range label", () => {
+    const svg = renderStreakSvg({
+      username: "alice",
+      currentStreak: 2,
+      longestStreak: 4,
+      trackedDays: 5,
+      totalSeconds: 3600,
+      rangeLabel: "the last 7 days",
+    });
+    expect(svg).toContain("Coding streaks in the last 7 days");
+  });
+
   it("escapes the username to prevent markup injection", () => {
     const svg = renderStreakSvg({
       username: '<script>evil()</script>&"x',


### PR DESCRIPTION
## Summary

- Add the public `streak.svg` embeddable card renderer and route wiring.
- Build streak data from pre-aggregated daily summaries plus the current local day from raw heartbeats.
- Keep `summary.svg` and `languages.svg` unavailable until their later implementation phases.
- Add unit and integration coverage for streak calculations, safe static SVG output, public-card visibility, caching headers, and secret non-disclosure.

Closes #187.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run lint:api`