### PR TITLE
[codex] feat: add summary and language cards

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -330,6 +330,8 @@ token. They look like:
 
 ```markdown
 ![CloudTime heatmap](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?theme=default)
+![CloudTime summary](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?theme=default)
+![CloudTime languages](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/languages.svg?theme=default)
 ![CloudTime streak](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?theme=default)
 ```
 

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -3,8 +3,21 @@ import type { AuthEnv, Env } from "../types";
 import type { Context } from "hono";
 import { authMiddleware } from "../middleware/auth";
 import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
-import { getHeatmapData, getStreakData, resolveCardRange, type CardRange } from "../utils/cards/data";
-import { renderHeatmapSvg, renderStreakSvg, resolveThemeName } from "../utils/cards/render";
+import {
+  getHeatmapData,
+  getLanguagesCardData,
+  getStreakData,
+  getSummaryCardData,
+  resolveCardRange,
+  type CardRange,
+} from "../utils/cards/data";
+import {
+  renderHeatmapSvg,
+  renderLanguagesSvg,
+  renderStreakSvg,
+  renderSummarySvg,
+  resolveThemeName,
+} from "../utils/cards/render";
 import {
   loadEmbedSettings,
   prepareEmbedSettingsUpdate,
@@ -63,9 +76,7 @@ cardsSettings.patch("/embed_settings", async (c) => {
 
 export const cardsPublic = new Hono<{ Bindings: Env }>();
 
-// summary/languages are valid in the contract but land in later phases; until
-// then they are reported as not found.
-const IMPLEMENTED_CARD_TYPES = new Set(["heatmap", "streak"]);
+const IMPLEMENTED_CARD_TYPES = new Set(["heatmap", "summary", "languages", "streak"]);
 
 function notFound(c: Context): Response {
   return c.json({ error: "Not found" }, 404, { "Cache-Control": "no-store" });
@@ -125,7 +136,7 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
     return badRequest(c, `v must be at most ${CACHE_BUSTER_MAX} characters`);
   }
   const ifNoneMatch = c.req.raw.headers.get("If-None-Match");
-  const cacheRange = cardType === "streak" ? cardRange.key : "year";
+  const cacheRange = cardType === "heatmap" ? "year" : cardRange.key;
 
   const cacheKey = buildCardCacheKey({
     userId: user.id,
@@ -179,6 +190,30 @@ async function renderPublicCardSvg(
       longestStreak: data.longestStreak,
       trackedDays: data.trackedDays,
       totalSeconds: data.totalSeconds,
+      theme: themeName,
+      rangeLabel: cardRange.label,
+    });
+  }
+
+  if (cardType === "summary") {
+    const data = await getSummaryCardData(db, user.id, user.timezone, user.timeout, cardRange.days);
+    return renderSummarySvg({
+      username: user.username,
+      totalSeconds: data.totalSeconds,
+      dailyAverageSeconds: data.dailyAverageSeconds,
+      bestDay: data.bestDay,
+      topLanguage: data.topLanguage,
+      theme: themeName,
+      rangeLabel: cardRange.label,
+    });
+  }
+
+  if (cardType === "languages") {
+    const data = await getLanguagesCardData(db, user.id, user.timezone, user.timeout, cardRange.days);
+    return renderLanguagesSvg({
+      username: user.username,
+      totalSeconds: data.totalSeconds,
+      languages: data.languages,
       theme: themeName,
       rangeLabel: cardRange.label,
     });

--- a/src/ui/settings.tsx
+++ b/src/ui/settings.tsx
@@ -1,6 +1,7 @@
 import { EmptyState, Notice, Panel } from "./components";
 import type { DashboardData } from "./dashboard";
 import { buildProfileCardSnippets } from "../utils/cards/snippets";
+import { THEMES } from "../utils/cards/render";
 
 const FALLBACK_TIMEZONES = [
   "UTC",
@@ -44,6 +45,7 @@ export function SettingsView({
     username: data.user.username,
     theme: data.embedSettings.default_theme,
   });
+  const themeOptions = Object.keys(THEMES);
   const cacheBusterValue = data.today.date.replace(/-/g, "");
 
   return (
@@ -139,9 +141,11 @@ export function SettingsView({
             <label class="form-control grid gap-2">
               <span class="label-text font-medium">Default theme</span>
               <select class="select select-bordered w-full" name="default_theme">
-                <option value="default" selected={data.embedSettings.default_theme === "default"}>
-                  default
-                </option>
+                {themeOptions.map((theme) => (
+                  <option value={theme} selected={data.embedSettings.default_theme === theme}>
+                    {theme}
+                  </option>
+                ))}
               </select>
             </label>
 

--- a/src/utils/cards/data.ts
+++ b/src/utils/cards/data.ts
@@ -25,6 +25,26 @@ export interface StreakData extends StreakStats {
   totalSeconds: number;
 }
 
+export interface SummaryCardData {
+  todayStr: string;
+  totalSeconds: number;
+  dailyAverageSeconds: number;
+  bestDay: { date: string; seconds: number } | null;
+  topLanguage: LanguageShare | null;
+}
+
+export interface LanguageShare {
+  language: string;
+  seconds: number;
+  percent: number;
+}
+
+export interface LanguagesCardData {
+  todayStr: string;
+  totalSeconds: number;
+  languages: LanguageShare[];
+}
+
 // 53 columns covers a full trailing year plus the current partial week, matching
 // a contribution-graph layout.
 const HEATMAP_WEEKS = 53;
@@ -112,6 +132,53 @@ export async function getStreakData(
   };
 }
 
+export async function getSummaryCardData(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  timeoutMinutes: number,
+  rangeDays = STREAK_DAYS,
+): Promise<SummaryCardData> {
+  const { todayStr, startStr, days } = resolveTrailingRange(tz, rangeDays);
+  const { dayTotals, totalSeconds: pastSeconds } = await loadSummaryDayTotals(
+    db,
+    userId,
+    startStr,
+    todayStr,
+  );
+  let totalSeconds = pastSeconds;
+
+  const todaySeconds = await computeTodaySeconds(db, userId, tz, todayStr, timeoutMinutes);
+  if (todaySeconds > 0) {
+    dayTotals.set(todayStr, todaySeconds);
+    totalSeconds += todaySeconds;
+  }
+
+  const languages = await loadLanguageShares(db, userId, tz, todayStr, startStr, timeoutMinutes);
+  const topLanguage = languages[0] ?? null;
+
+  return {
+    todayStr,
+    totalSeconds,
+    dailyAverageSeconds: totalSeconds / days,
+    bestDay: findBestDay(dayTotals),
+    topLanguage,
+  };
+}
+
+export async function getLanguagesCardData(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  timeoutMinutes: number,
+  rangeDays = STREAK_DAYS,
+): Promise<LanguagesCardData> {
+  const { todayStr, startStr } = resolveTrailingRange(tz, rangeDays);
+  const languages = await loadLanguageShares(db, userId, tz, todayStr, startStr, timeoutMinutes);
+  const totalSeconds = languages.reduce((sum, language) => sum + language.seconds, 0);
+  return { todayStr, totalSeconds, languages };
+}
+
 export function calculateStreakStats(dayTotals: Map<string, number>, todayStr: string): StreakStats {
   const activeDays = new Set<string>();
   for (const [date, seconds] of dayTotals) {
@@ -149,6 +216,52 @@ export function calculateStreakStats(dayTotals: Map<string, number>, todayStr: s
   return { trackedDays, currentStreak, longestStreak };
 }
 
+function resolveTrailingRange(tz: string, rangeDays: number): { todayStr: string; startStr: string; days: number } {
+  const today = getToday(tz);
+  const todayStr = formatDate(today);
+  const days = Math.max(1, Math.floor(rangeDays));
+  const startStr = formatDate(addDays(today, -(days - 1)));
+  return { todayStr, startStr, days };
+}
+
+function findBestDay(dayTotals: Map<string, number>): { date: string; seconds: number } | null {
+  let best: { date: string; seconds: number } | null = null;
+  for (const [date, seconds] of dayTotals) {
+    if (seconds <= 0) continue;
+    if (!best || seconds > best.seconds || (seconds === best.seconds && date > best.date)) {
+      best = { date, seconds };
+    }
+  }
+  return best;
+}
+
+async function loadLanguageShares(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  todayStr: string,
+  startStr: string,
+  timeoutMinutes: number,
+): Promise<LanguageShare[]> {
+  const languageTotals = await loadLanguageTotals(db, userId, startStr, todayStr);
+  const todayLanguageTotals = await computeTodayLanguageSeconds(db, userId, tz, todayStr, timeoutMinutes);
+  for (const [language, seconds] of todayLanguageTotals) {
+    languageTotals.set(language, (languageTotals.get(language) ?? 0) + seconds);
+  }
+
+  const totalSeconds = [...languageTotals.values()].reduce((sum, seconds) => sum + seconds, 0);
+  if (totalSeconds <= 0) return [];
+
+  return [...languageTotals.entries()]
+    .map(([language, seconds]) => ({
+      language,
+      seconds,
+      percent: (seconds / totalSeconds) * 100,
+    }))
+    .sort((a, b) => b.seconds - a.seconds || a.language.localeCompare(b.language))
+    .slice(0, 5);
+}
+
 async function loadSummaryDayTotals(
   db: D1Database,
   userId: string,
@@ -170,6 +283,30 @@ async function loadSummaryDayTotals(
     totalSeconds += seconds;
   }
   return { dayTotals, totalSeconds };
+}
+
+async function loadLanguageTotals(
+  db: D1Database,
+  userId: string,
+  startStr: string,
+  endExclusiveStr: string,
+): Promise<Map<string, number>> {
+  const { results } = await db
+    .prepare(
+      `SELECT COALESCE(NULLIF(language, ''), 'Unknown') AS language, SUM(total_seconds) AS seconds
+       FROM summaries
+       WHERE user_id = ? AND date >= ? AND date < ?
+       GROUP BY COALESCE(NULLIF(language, ''), 'Unknown')`,
+    )
+    .bind(userId, startStr, endExclusiveStr)
+    .all<{ language: string; seconds: number | null }>();
+
+  const languageTotals = new Map<string, number>();
+  for (const row of results) {
+    const seconds = Number(row.seconds ?? 0);
+    if (seconds > 0) languageTotals.set(row.language, seconds);
+  }
+  return languageTotals;
 }
 
 function parseUtcDate(dateStr: string): Date | null {
@@ -214,4 +351,31 @@ async function computeTodaySeconds(
     if (gap > 0 && gap <= timeout) total += gap;
   }
   return total;
+}
+
+async function computeTodayLanguageSeconds(
+  db: D1Database,
+  userId: string,
+  tz: string,
+  todayStr: string,
+  timeoutMinutes: number,
+): Promise<Map<string, number>> {
+  const { start, end } = getEpochBoundsForDate(todayStr, tz);
+  const { results } = await db
+    .prepare(
+      "SELECT time, language FROM heartbeats WHERE user_id = ? AND time >= ? AND time < ? ORDER BY time ASC",
+    )
+    .bind(userId, start, end)
+    .all<{ time: number; language: string | null }>();
+
+  const timeout = timeoutMinutes * 60;
+  const totals = new Map<string, number>();
+  for (let i = 1; i < results.length; i++) {
+    const prev = results[i - 1];
+    const gap = results[i].time - prev.time;
+    if (gap <= 0 || gap > timeout) continue;
+    const language = prev.language && prev.language.length > 0 ? prev.language : "Unknown";
+    totals.set(language, (totals.get(language) ?? 0) + gap);
+  }
+  return totals;
 }

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -9,22 +9,32 @@ import { formatHumanReadable } from "../time-format";
 
 export interface CardTheme {
   background: string;
+  border: string;
   cellEmpty: string;
+  accent: string;
   levels: [string, string, string, string];
   text: string;
   subtext: string;
 }
 
-// P1 ships the default theme only. Additional selectable themes (P2 / User
-// Story 5) slot in here; resolveTheme() already falls back to default for
-// unknown names (FR-006).
 export const THEMES: Record<string, CardTheme> = {
   default: {
     background: "#ffffff",
+    border: "#d0d7de",
     cellEmpty: "#ebedf0",
+    accent: "#30a14e",
     levels: ["#9be9a8", "#40c463", "#30a14e", "#216e39"],
     text: "#1f2328",
     subtext: "#656d76",
+  },
+  dark: {
+    background: "#0d1117",
+    border: "#30363d",
+    cellEmpty: "#161b22",
+    accent: "#2f81f7",
+    levels: ["#0e4429", "#006d32", "#26a641", "#39d353"],
+    text: "#e6edf3",
+    subtext: "#8b949e",
   },
 };
 
@@ -81,6 +91,24 @@ export interface StreakRenderOptions {
   longestStreak: number;
   trackedDays: number;
   totalSeconds: number;
+  theme?: string;
+  rangeLabel?: string;
+}
+
+export interface SummaryRenderOptions {
+  username: string;
+  totalSeconds: number;
+  dailyAverageSeconds: number;
+  bestDay: { date: string; seconds: number } | null;
+  topLanguage: { language: string; seconds: number; percent: number } | null;
+  theme?: string;
+  rangeLabel?: string;
+}
+
+export interface LanguagesRenderOptions {
+  username: string;
+  totalSeconds: number;
+  languages: Array<{ language: string; seconds: number; percent: number }>;
   theme?: string;
   rangeLabel?: string;
 }
@@ -162,6 +190,78 @@ export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
   );
 }
 
+export function renderSummarySvg(opts: SummaryRenderOptions): string {
+  const theme = resolveTheme(opts.theme);
+  const width = 495;
+  const height = 195;
+  const cardPadding = 22;
+  const rangeLabel = escapeXml(opts.rangeLabel ?? "the last year");
+  const title = `@${escapeXml(truncateText(opts.username, 38))}`;
+  const ariaLabel = escapeXml(`Coding summary card for ${opts.username}`);
+  const bestDayText = opts.bestDay
+    ? `${opts.bestDay.date} / ${formatHumanReadable(opts.bestDay.seconds)}`
+    : "No activity";
+  const topLanguageText = opts.topLanguage
+    ? `${truncateText(opts.topLanguage.language, 18)} / ${formatPercent(opts.topLanguage.percent)}`
+    : "No language";
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">` +
+    cardStyle(theme) +
+    `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="${theme.border}"/>` +
+    `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
+    `<text x="${cardPadding}" y="52" class="subtitle">Coding summary in ${rangeLabel}</text>` +
+    renderSummaryMetric(cardPadding, 90, "Total time", formatHumanReadable(opts.totalSeconds), theme.accent) +
+    renderSummaryMetric(260, 90, "Daily average", formatHumanReadable(opts.dailyAverageSeconds), theme.levels[1]) +
+    renderSummaryMetric(cardPadding, 145, "Best day", bestDayText, theme.levels[2]) +
+    renderSummaryMetric(260, 145, "Top language", topLanguageText, theme.levels[3]) +
+    `</svg>`
+  );
+}
+
+export function renderLanguagesSvg(opts: LanguagesRenderOptions): string {
+  const theme = resolveTheme(opts.theme);
+  const width = 495;
+  const height = 210;
+  const cardPadding = 22;
+  const rangeLabel = escapeXml(opts.rangeLabel ?? "the last year");
+  const title = `@${escapeXml(truncateText(opts.username, 38))}`;
+  const totalText = escapeXml(`${formatHumanReadable(opts.totalSeconds)} total coding time`);
+  const ariaLabel = escapeXml(`Top languages card for ${opts.username}`);
+  const barX = 148;
+  const barWidth = 250;
+  const barHeight = 9;
+
+  let rows = "";
+  if (opts.languages.length === 0) {
+    rows = `<text x="${cardPadding}" y="104" class="subtitle">No language data in ${rangeLabel}</text>`;
+  } else {
+    for (let i = 0; i < opts.languages.length; i++) {
+      const language = opts.languages[i];
+      const y = 78 + i * 24;
+      const pct = Math.max(0, Math.min(100, language.percent));
+      const fill = theme.levels[i % theme.levels.length];
+      const filled = Math.max(2, Math.round((barWidth * pct) / 100));
+      rows += `<text x="${cardPadding}" y="${y + 9}" class="label">${escapeXml(truncateText(language.language, 16))}</text>`;
+      rows += `<rect x="${barX}" y="${y}" width="${barWidth}" height="${barHeight}" rx="4.5" ry="4.5" fill="${theme.cellEmpty}"/>`;
+      rows += `<rect x="${barX}" y="${y}" width="${filled}" height="${barHeight}" rx="4.5" ry="4.5" fill="${fill}"/>`;
+      rows += `<text x="${width - cardPadding}" y="${y + 9}" text-anchor="end" class="label">${escapeXml(formatPercent(pct))}</text>`;
+    }
+  }
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">` +
+    cardStyle(theme) +
+    `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="${theme.border}"/>` +
+    `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
+    `<text x="${cardPadding}" y="52" class="subtitle">Top languages in ${rangeLabel}</text>` +
+    rows +
+    `<text x="${cardPadding}" y="${height - 18}" class="note">${totalText}</text>` +
+    `<text x="${width - cardPadding}" y="${height - 18}" text-anchor="end" class="note">CloudTime</text>` +
+    `</svg>`
+  );
+}
+
 export function renderStreakSvg(opts: StreakRenderOptions): string {
   const theme = resolveTheme(opts.theme);
   const width = 495;
@@ -188,13 +288,8 @@ export function renderStreakSvg(opts: StreakRenderOptions): string {
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">` +
-    `<style>text{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;}` +
-    `.title{font-size:16px;font-weight:700;fill:${theme.text};}` +
-    `.subtitle{font-size:12px;fill:${theme.subtext};}` +
-    `.metric{font-size:25px;font-weight:700;fill:${theme.text};}` +
-    `.label{font-size:11px;font-weight:600;fill:${theme.subtext};}` +
-    `.note{font-size:11px;fill:${theme.subtext};}</style>` +
-    `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="#d0d7de"/>` +
+    cardStyle(theme) +
+    `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="${theme.border}"/>` +
     `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
     `<text x="${cardPadding}" y="52" class="subtitle">Coding streaks in ${rangeLabel}</text>` +
     renderMetric(cardPadding, metricTop, metricWidth, "Current", current, theme.levels[2]) +
@@ -218,9 +313,36 @@ function renderMetric(x: number, y: number, width: number, label: string, value:
   );
 }
 
+function renderSummaryMetric(x: number, y: number, label: string, value: string, accent: string): string {
+  return (
+    `<g>` +
+    `<rect x="${x}" y="${y - 19}" width="190" height="3" rx="1.5" ry="1.5" fill="${accent}"/>` +
+    `<text x="${x}" y="${y}" class="label">${escapeXml(label)}</text>` +
+    `<text x="${x}" y="${y + 23}" class="summaryValue">${escapeXml(truncateText(value, 28))}</text>` +
+    `</g>`
+  );
+}
+
+function cardStyle(theme: CardTheme): string {
+  return (
+    `<style>text{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;}` +
+    `.title{font-size:16px;font-weight:700;fill:${theme.text};}` +
+    `.subtitle{font-size:12px;fill:${theme.subtext};}` +
+    `.metric{font-size:25px;font-weight:700;fill:${theme.text};}` +
+    `.summaryValue{font-size:18px;font-weight:700;fill:${theme.text};}` +
+    `.label{font-size:11px;font-weight:600;fill:${theme.subtext};}` +
+    `.note{font-size:11px;fill:${theme.subtext};}</style>`
+  );
+}
+
 function formatDays(days: number): string {
   const safeDays = Math.max(0, Math.floor(days));
   return `${safeDays} ${safeDays === 1 ? "day" : "days"}`;
+}
+
+function formatPercent(percent: number): string {
+  const rounded = Math.round(percent);
+  return `${rounded}%`;
 }
 
 function truncateText(value: string, maxChars: number): string {

--- a/src/utils/cards/snippets.ts
+++ b/src/utils/cards/snippets.ts
@@ -1,4 +1,4 @@
-export type ProfileCardType = "heatmap" | "streak";
+export type ProfileCardType = "heatmap" | "summary" | "languages" | "streak";
 
 export interface ProfileCardSnippet {
   cardType: ProfileCardType;
@@ -10,6 +10,8 @@ export interface ProfileCardSnippet {
 
 const PROFILE_CARD_TYPES: Array<{ cardType: ProfileCardType; label: string; altText: string }> = [
   { cardType: "heatmap", label: "Heatmap", altText: "CloudTime heatmap" },
+  { cardType: "summary", label: "Summary", altText: "CloudTime summary" },
+  { cardType: "languages", label: "Languages", altText: "CloudTime languages" },
   { cardType: "streak", label: "Streak", altText: "CloudTime streak" },
 ];
 

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -164,14 +164,68 @@ describe("embeddable cards — public visibility", () => {
     expect(res.status).toBe(404);
   });
 
-  it("treats summary/languages cards as not-yet-available in later phases", async () => {
+  it("renders summary and languages cards for requested ranges", async () => {
     const user = await seedUser({ username: "carol" });
     await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
 
-    const summary = await call(`/api/v1/users/${user.username}/cards/summary.svg`);
-    expect(summary.status).toBe(404);
-    const languages = await call(`/api/v1/users/${user.username}/cards/languages.svg`);
-    expect(languages.status).toBe(404);
+    const bestDay = formatUtcDate(-2);
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', 'TypeScript', ?)",
+    )
+      .bind(user.userId, bestDay, 7200)
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', 'Markdown', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-1), 3600)
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', 'Go', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-8), 1800)
+      .run();
+
+    const summary = await call(`/api/v1/users/${user.username}/cards/summary.svg?range=last_7_days`);
+    expect(summary.status).toBe(200);
+    expect(summary.headers.get("Content-Type")).toContain("image/svg+xml");
+    const summarySvg = await summary.text();
+    expect(summarySvg).toContain("Coding summary in the last 7 days");
+    expect(summarySvg).toContain("3 hrs");
+    expect(summarySvg).toContain(`${bestDay} / 2 hrs`);
+    expect(summarySvg).toContain("TypeScript / 67%");
+    expect(summarySvg).not.toContain(user.apiKey);
+
+    const languages = await call(`/api/v1/users/${user.username}/cards/languages.svg?range=last_7_days`);
+    expect(languages.status).toBe(200);
+    const languagesSvg = await languages.text();
+    expect(languagesSvg).toContain("Top languages in the last 7 days");
+    expect(languagesSvg).toContain("TypeScript");
+    expect(languagesSvg).toContain("67%");
+    expect(languagesSvg).toContain("Markdown");
+    expect(languagesSvg).toContain("33%");
+    expect(languagesSvg).not.toContain("Go");
+
+    const fallback = await call(`/api/v1/users/${user.username}/cards/languages.svg?range=not_supported`);
+    expect(fallback.status).toBe(200);
+    const fallbackSvg = await fallback.text();
+    expect(fallbackSvg).toContain("Top languages in the last year");
+    expect(fallbackSvg).toContain("Go");
+    expect(fallbackSvg).toContain("3 hrs 30 mins total coding time");
+  });
+
+  it("applies built-in themes and falls back to default for unknown themes", async () => {
+    const user = await seedUser({ username: "theme_user" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const dark = await call(`/api/v1/users/${user.username}/cards/heatmap.svg?theme=dark`);
+    expect(dark.status).toBe(200);
+    expect(await dark.text()).toContain("#0d1117");
+
+    const fallback = await call(`/api/v1/users/${user.username}/cards/summary.svg?theme=future_theme`);
+    expect(fallback.status).toBe(200);
+    const fallbackSvg = await fallback.text();
+    expect(fallbackSvg).toContain("#ffffff");
+    expect(fallbackSvg).not.toContain("#0d1117");
   });
 
   it("reflects today's activity computed on demand from raw heartbeats", async () => {

--- a/tests/integration/web-ui.test.ts
+++ b/tests/integration/web-ui.test.ts
@@ -135,6 +135,8 @@ describe("web UI", () => {
     expect(html).toContain("Public cards are off");
     expect(html).toContain("Copy Markdown");
     expect(html).toContain("![CloudTime heatmap](https://test.cloudtime.dev/api/v1/users/owner/cards/heatmap.svg?theme=default)");
+    expect(html).toContain("![CloudTime summary](https://test.cloudtime.dev/api/v1/users/owner/cards/summary.svg?theme=default)");
+    expect(html).toContain("![CloudTime languages](https://test.cloudtime.dev/api/v1/users/owner/cards/languages.svg?theme=default)");
     expect(html).toContain("![CloudTime streak](https://test.cloudtime.dev/api/v1/users/owner/cards/streak.svg?theme=default)");
     expect(html).not.toContain(user.apiKey);
   });
@@ -215,6 +217,8 @@ describe("web UI", () => {
     expect(html).toContain("Card settings saved.");
     expect(html).toContain("badge badge-success");
     expect(html).toContain("https://test.cloudtime.dev/api/v1/users/owner/cards/heatmap.svg?theme=default");
+    expect(html).toContain("https://test.cloudtime.dev/api/v1/users/owner/cards/summary.svg?theme=default");
+    expect(html).toContain("https://test.cloudtime.dev/api/v1/users/owner/cards/languages.svg?theme=default");
     expect(html).toContain("https://test.cloudtime.dev/api/v1/users/owner/cards/streak.svg?theme=default");
     expect(html).not.toContain(user.apiKey);
     expect(html).not.toContain(user.sessionToken);

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   escapeXml,
   renderHeatmapSvg,
+  renderLanguagesSvg,
   renderStreakSvg,
+  renderSummarySvg,
   resolveTheme,
   resolveThemeName,
 } from "../../src/utils/cards/render";
@@ -67,6 +69,80 @@ describe("renderHeatmapSvg", () => {
     expect(svg).not.toMatch(/foreignObject/i);
     expect(svg).not.toMatch(/href=/i);
     expect(svg).not.toMatch(/on\w+=/i); // no event-handler attributes
+  });
+});
+
+describe("renderSummarySvg", () => {
+  it("renders summary metrics and escapes language text", () => {
+    const svg = renderSummarySvg({
+      username: "alice",
+      totalSeconds: 3 * 3600,
+      dailyAverageSeconds: 1800,
+      bestDay: { date: "2026-06-17", seconds: 2 * 3600 },
+      topLanguage: { language: '<script>TypeScript</script>', seconds: 7200, percent: 66.7 },
+      rangeLabel: "the last 7 days",
+    });
+
+    expect(svg).toContain("Coding summary in the last 7 days");
+    expect(svg).toContain("3 hrs");
+    expect(svg).toContain("30 mins");
+    expect(svg).toContain("2026-06-17 / 2 hrs");
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+
+  it("emits only a safe static subset", () => {
+    const svg = renderSummarySvg({
+      username: "a",
+      totalSeconds: 0,
+      dailyAverageSeconds: 0,
+      bestDay: null,
+      topLanguage: null,
+    });
+    expect(svg).not.toMatch(/<script/i);
+    expect(svg).not.toMatch(/foreignObject/i);
+    expect(svg).not.toMatch(/href=/i);
+    expect(svg).not.toMatch(/on\w+=/i);
+  });
+});
+
+describe("renderLanguagesSvg", () => {
+  it("renders language shares and zero activity states", () => {
+    const svg = renderLanguagesSvg({
+      username: "alice",
+      totalSeconds: 3 * 3600,
+      languages: [
+        { language: "TypeScript", seconds: 7200, percent: 66.7 },
+        { language: "Markdown", seconds: 3600, percent: 33.3 },
+      ],
+      rangeLabel: "the last 30 days",
+    });
+
+    expect(svg).toContain("Top languages in the last 30 days");
+    expect(svg).toContain("TypeScript");
+    expect(svg).toContain("67%");
+    expect(svg).toContain("Markdown");
+    expect(svg).toContain("33%");
+
+    const empty = renderLanguagesSvg({
+      username: "alice",
+      totalSeconds: 0,
+      languages: [],
+    });
+    expect(empty).toContain("No language data in the last year");
+  });
+
+  it("escapes language names and emits only a safe static subset", () => {
+    const svg = renderLanguagesSvg({
+      username: "a",
+      totalSeconds: 60,
+      languages: [{ language: '<script>x</script>', seconds: 60, percent: 100 }],
+    });
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&lt;script&gt;");
+    expect(svg).not.toMatch(/foreignObject/i);
+    expect(svg).not.toMatch(/href=/i);
+    expect(svg).not.toMatch(/on\w+=/i);
   });
 });
 
@@ -144,6 +220,11 @@ describe("theme resolution", () => {
 
   it("keeps a known theme name", () => {
     expect(resolveThemeName("default")).toBe("default");
+  });
+
+  it("supports the dark built-in theme", () => {
+    expect(resolveThemeName("dark")).toBe("dark");
+    expect(resolveTheme("dark").background).toBe("#0d1117");
   });
 });
 

--- a/tests/unit/cards-snippets.test.ts
+++ b/tests/unit/cards-snippets.test.ts
@@ -9,11 +9,17 @@ describe("profile card snippets", () => {
       theme: "default",
     });
 
-    expect(snippets.map((snippet) => snippet.cardType)).toEqual(["heatmap", "streak"]);
+    expect(snippets.map((snippet) => snippet.cardType)).toEqual(["heatmap", "summary", "languages", "streak"]);
     expect(snippets[0].markdown).toBe(
       "![CloudTime heatmap](https://cloudtime.example.test/api/v1/users/alice/cards/heatmap.svg?theme=default)",
     );
     expect(snippets[1].markdown).toBe(
+      "![CloudTime summary](https://cloudtime.example.test/api/v1/users/alice/cards/summary.svg?theme=default)",
+    );
+    expect(snippets[2].markdown).toBe(
+      "![CloudTime languages](https://cloudtime.example.test/api/v1/users/alice/cards/languages.svg?theme=default)",
+    );
+    expect(snippets[3].markdown).toBe(
       "![CloudTime streak](https://cloudtime.example.test/api/v1/users/alice/cards/streak.svg?theme=default)",
     );
   });


### PR DESCRIPTION
## Summary

- Add `summary.svg` and `languages.svg` public embeddable cards.
- Add a `dark` built-in theme and apply theme fallback across all built-in cards.
- Compute summary totals, daily average, best day, top language, and language shares from existing summaries with current-day heartbeat overlay where applicable.
- Include summary/languages in dashboard README snippets and deployment docs.

Closes #175.

## Validation

- `npm run build:css`
- `npm run typecheck`
- `npm test`
- `npm run lint:api`
- `git diff --check`