### PR TITLE
[codex] feat: add custom card templates

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -91,6 +91,7 @@ npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --fil
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0002_pending_link_email_verification.sql
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0003_hourly_summaries.sql
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0004_embed_settings.sql
+npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0005_embed_templates.sql
 ```
 
 ## 6. Configure secrets
@@ -341,6 +342,28 @@ its image proxy, so CloudTime controls its own `Cache-Control` and `ETag`
 headers, but GitHub may still refetch on its own cadence. If you need a new
 CloudTime URL for manual verification, append a short `v=` value from the
 settings page.
+
+Custom SVG templates can be managed through the authenticated API. Templates
+are stored only after validation as a safe static SVG subset, and they are
+revalidated before each public render. A card references a template with
+`template_id`:
+
+```powershell
+curl -X POST "https://your-worker.example.com/api/v1/users/current/embed_templates" `
+  -H "Authorization: Bearer <your API key>" `
+  -H "Content-Type: application/json" `
+  --data '{"name":"compact","template_svg":"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"360\" height=\"96\" viewBox=\"0 0 360 96\"><text x=\"12\" y=\"28\">{{username}}</text><text x=\"12\" y=\"56\">{{total_time}}</text></svg>"}'
+```
+
+Then use:
+
+```markdown
+![CloudTime custom summary](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?template_id=TEMPLATE_UUID)
+```
+
+Supported placeholders are `username`, `card_type`, `range`, `theme`,
+`total_time`, `daily_average`, `best_day`, `top_language`, `languages`,
+`current_streak`, `longest_streak`, and `tracked_days`.
 
 ---
 

--- a/migrations/0005_embed_templates.sql
+++ b/migrations/0005_embed_templates.sql
@@ -1,0 +1,19 @@
+-- User-defined SVG templates for public embeddable cards (spec 160).
+-- Kept in sync with src/db/schema.sql so existing D1 databases can migrate and
+-- fresh deployments via `npm run db:init` get the same shape.
+--
+-- Templates are untrusted input. Runtime validation enforces a safe static SVG
+-- subset both before storage and again before public rendering.
+
+CREATE TABLE IF NOT EXISTS embed_templates (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL CHECK (length(name) BETWEEN 1 AND 64),
+  template_svg TEXT NOT NULL CHECK (length(template_svg) BETWEEN 1 AND 20000),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_embed_templates_user_created
+  ON embed_templates(user_id, created_at DESC);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -398,3 +398,19 @@ CREATE TABLE IF NOT EXISTS embed_settings (
   modified_at TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+-- User-defined SVG templates for public embeddable cards (spec 160).
+-- Templates are untrusted input. Runtime validation enforces a safe static SVG
+-- subset both before storage and again before public rendering.
+CREATE TABLE IF NOT EXISTS embed_templates (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL CHECK (length(name) BETWEEN 1 AND 64),
+  template_svg TEXT NOT NULL CHECK (length(template_svg) BETWEEN 1 AND 20000),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_embed_templates_user_created
+  ON embed_templates(user_id, created_at DESC);

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { AuthEnv, Env } from "../types";
 import type { Context } from "hono";
+import type { components, operations } from "../types/generated";
 import { authMiddleware } from "../middleware/auth";
 import { rateLimitExceeded, tooManyRequests } from "../middleware/rate-limit";
 import {
@@ -19,6 +20,15 @@ import {
   resolveThemeName,
 } from "../utils/cards/render";
 import {
+  defaultTemplateValues,
+  formatDays,
+  formatTemplatePercent,
+  renderTemplateSvg,
+  validateTemplateName,
+  validateTemplateSvg,
+  type CardTemplateValues,
+} from "../utils/cards/templates";
+import {
   loadEmbedSettings,
   prepareEmbedSettingsUpdate,
   saveEmbedSettings,
@@ -31,10 +41,17 @@ import {
   computeCardEtag,
   type CardCacheValue,
 } from "../utils/cards/cache";
+import { formatHumanReadable } from "../utils/time-format";
 
 const USERNAME_MAX = 64;
 const RANGE_MAX = 32;
 const CACHE_BUSTER_MAX = 64;
+const TEMPLATE_ID_MAX = 64;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type EmbedTemplate = components["schemas"]["EmbedTemplate"];
+type EmbedTemplateInput = components["schemas"]["EmbedTemplateInput"];
+type EmbedTemplateUpdate = operations["updateEmbedTemplate"]["requestBody"]["content"]["application/json"];
 
 // ============================================================
 // Authenticated settings: /users/current/embed_settings
@@ -67,6 +84,90 @@ cardsSettings.patch("/embed_settings", async (c) => {
   return c.json({ data: updated });
 });
 
+cardsSettings.get("/embed_templates", async (c) => {
+  const userId = c.get("userId");
+  const templates = await listEmbedTemplates(c.env.DB, userId);
+  return c.json({ data: templates });
+});
+
+cardsSettings.post("/embed_templates", async (c) => {
+  const userId = c.get("userId");
+  const body = (await c.req.json().catch(() => null)) as EmbedTemplateInput | null;
+  if (!isPlainObject(body)) {
+    return c.json({ error: "Invalid request body" }, 400);
+  }
+
+  const prepared = prepareTemplateInput(body);
+  if (!prepared.ok) {
+    return c.json({ error: prepared.error }, 400);
+  }
+
+  const id = crypto.randomUUID();
+  await c.env.DB
+    .prepare(
+      `INSERT INTO embed_templates (id, user_id, name, template_svg, created_at, modified_at)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    )
+    .bind(id, userId, prepared.input.name, prepared.input.template_svg)
+    .run();
+
+  const template = await loadEmbedTemplate(c.env.DB, userId, id);
+  if (!template) throw new Error("Created embed template could not be loaded");
+  return c.json({ data: template }, 201);
+});
+
+cardsSettings.get("/embed_templates/:template_id", async (c) => {
+  const userId = c.get("userId");
+  const templateId = c.req.param("template_id");
+  const template = await loadEmbedTemplate(c.env.DB, userId, templateId);
+  if (!template) return notFound(c);
+  return c.json({ data: template });
+});
+
+cardsSettings.patch("/embed_templates/:template_id", async (c) => {
+  const userId = c.get("userId");
+  const templateId = c.req.param("template_id");
+  const existing = await loadEmbedTemplate(c.env.DB, userId, templateId);
+  if (!existing) return notFound(c);
+
+  const body = (await c.req.json().catch(() => null)) as EmbedTemplateUpdate | null;
+  if (!isPlainObject(body)) {
+    return c.json({ error: "Invalid request body" }, 400);
+  }
+
+  const prepared = prepareTemplateUpdate(existing, body);
+  if (!prepared.ok) {
+    return c.json({ error: prepared.error }, 400);
+  }
+
+  await c.env.DB
+    .prepare(
+      `UPDATE embed_templates
+       SET name = ?, template_svg = ?, modified_at = datetime('now')
+       WHERE id = ? AND user_id = ?`,
+    )
+    .bind(prepared.next.name, prepared.next.template_svg, templateId, userId)
+    .run();
+
+  const updated = await loadEmbedTemplate(c.env.DB, userId, templateId);
+  if (!updated) throw new Error("Updated embed template could not be loaded");
+  return c.json({ data: updated });
+});
+
+cardsSettings.delete("/embed_templates/:template_id", async (c) => {
+  const userId = c.get("userId");
+  const templateId = c.req.param("template_id");
+  const existing = await loadEmbedTemplate(c.env.DB, userId, templateId);
+  if (!existing) return notFound(c);
+
+  await c.env.DB
+    .prepare("DELETE FROM embed_templates WHERE id = ? AND user_id = ?")
+    .bind(templateId, userId)
+    .run();
+
+  return new Response(null, { status: 204 });
+});
+
 // ============================================================
 // Public cards: /users/{username}/cards/{card_type}.svg
 // Unauthenticated (security: []). The visibility OFF gate runs before any
@@ -83,7 +184,7 @@ function notFound(c: Context): Response {
 }
 
 function badRequest(c: Context, error: string): Response {
-  return c.json({ error }, 400);
+  return c.json({ error }, 400, { "Cache-Control": "no-store" });
 }
 
 interface PublicUserRow {
@@ -91,6 +192,111 @@ interface PublicUserRow {
   username: string;
   timezone: string;
   timeout: number;
+}
+
+interface EmbedTemplateRow {
+  id: string;
+  name: string;
+  template_svg: string;
+  created_at: string;
+  modified_at: string;
+}
+
+class TemplateRenderError extends Error {}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mapEmbedTemplate(row: EmbedTemplateRow): EmbedTemplate {
+  return {
+    id: row.id,
+    name: row.name,
+    template_svg: row.template_svg,
+    created_at: row.created_at,
+    modified_at: row.modified_at,
+  };
+}
+
+async function listEmbedTemplates(db: D1Database, userId: string): Promise<EmbedTemplate[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT id, name, template_svg, created_at, modified_at
+       FROM embed_templates
+       WHERE user_id = ?
+       ORDER BY created_at DESC, id DESC`,
+    )
+    .bind(userId)
+    .all<EmbedTemplateRow>();
+
+  return results.map(mapEmbedTemplate);
+}
+
+async function loadEmbedTemplate(
+  db: D1Database,
+  userId: string,
+  templateId: string,
+): Promise<EmbedTemplate | null> {
+  if (templateId.length < 1 || templateId.length > TEMPLATE_ID_MAX) return null;
+  const row = await db
+    .prepare(
+      `SELECT id, name, template_svg, created_at, modified_at
+       FROM embed_templates
+       WHERE user_id = ? AND id = ?`,
+    )
+    .bind(userId, templateId)
+    .first<EmbedTemplateRow>();
+
+  return row ? mapEmbedTemplate(row) : null;
+}
+
+function prepareTemplateInput(
+  body: Record<string, unknown>,
+): { ok: true; input: EmbedTemplateInput } | { ok: false; error: string } {
+  const nameValidation = validateTemplateName(body.name);
+  if (!nameValidation.ok) return nameValidation;
+
+  const svgValidation = validateTemplateSvg(body.template_svg);
+  if (!svgValidation.ok) return svgValidation;
+
+  return {
+    ok: true,
+    input: {
+      name: (body.name as string).trim(),
+      template_svg: body.template_svg as string,
+    },
+  };
+}
+
+function prepareTemplateUpdate(
+  existing: EmbedTemplate,
+  body: Record<string, unknown>,
+): { ok: true; next: EmbedTemplateInput } | { ok: false; error: string } {
+  let updates = 0;
+  const next: EmbedTemplateInput = {
+    name: existing.name,
+    template_svg: existing.template_svg,
+  };
+
+  if ("name" in body) {
+    const nameValidation = validateTemplateName(body.name);
+    if (!nameValidation.ok) return nameValidation;
+    next.name = (body.name as string).trim();
+    updates++;
+  }
+
+  if ("template_svg" in body) {
+    const svgValidation = validateTemplateSvg(body.template_svg);
+    if (!svgValidation.ok) return svgValidation;
+    next.template_svg = body.template_svg as string;
+    updates++;
+  }
+
+  if (updates === 0) {
+    return { ok: false, error: "No fields to update" };
+  }
+
+  return { ok: true, next };
 }
 
 cardsPublic.get("/users/:username/cards/:file", async (c) => {
@@ -135,6 +341,16 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
   if (v.length > CACHE_BUSTER_MAX) {
     return badRequest(c, `v must be at most ${CACHE_BUSTER_MAX} characters`);
   }
+  const templateId = c.req.query("template_id") ?? "";
+  if (templateId.length > 0 && (templateId.length > TEMPLATE_ID_MAX || !UUID_RE.test(templateId))) {
+    return badRequest(c, "template_id must be a valid UUID");
+  }
+
+  const template = templateId.length > 0
+    ? await loadEmbedTemplate(c.env.DB, user.id, templateId)
+    : null;
+  if (templateId.length > 0 && !template) return notFound(c);
+
   const ifNoneMatch = c.req.raw.headers.get("If-None-Match");
   const cacheRange = cardType === "heatmap" ? "year" : cardRange.key;
 
@@ -143,7 +359,8 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
     cardType,
     range: cacheRange,
     theme: themeName,
-    templateId: "",
+    templateId,
+    templateModifiedAt: template?.modified_at ?? "",
     v,
     settingsModifiedAt: settings.modified_at ?? "",
   });
@@ -153,7 +370,15 @@ cardsPublic.get("/users/:username/cards/:file", async (c) => {
     return svgResponse(cached.svg, cached.etag, settings.freshness_minutes, ifNoneMatch);
   }
 
-  const svg = await renderPublicCardSvg(c.env.DB, cardType, user, themeName, cardRange);
+  let svg: string;
+  try {
+    svg = await renderPublicCardSvg(c.env.DB, cardType, user, themeName, cardRange, template);
+  } catch (err) {
+    if (err instanceof TemplateRenderError) {
+      return badRequest(c, err.message);
+    }
+    throw err;
+  }
   const etag = await computeCardEtag(svg);
 
   const value: CardCacheValue = { svg, etag, generated_at: new Date().toISOString() };
@@ -170,9 +395,21 @@ async function renderPublicCardSvg(
   user: PublicUserRow,
   themeName: string,
   cardRange: CardRange,
+  template: EmbedTemplate | null,
 ): Promise<string> {
   if (cardType === "heatmap") {
     const data = await getHeatmapData(db, user.id, user.timezone, user.timeout);
+    if (template) {
+      const rendered = renderTemplateSvg(template.template_svg, defaultTemplateValues({
+        username: user.username,
+        card_type: cardType,
+        range: "the last year",
+        theme: themeName,
+        total_time: formatHumanReadable(data.totalSeconds),
+      }));
+      if (!rendered.ok) throw new TemplateRenderError(rendered.error);
+      return rendered.svg;
+    }
     return renderHeatmapSvg({
       username: user.username,
       dayTotals: data.dayTotals,
@@ -184,6 +421,20 @@ async function renderPublicCardSvg(
 
   if (cardType === "streak") {
     const data = await getStreakData(db, user.id, user.timezone, user.timeout, cardRange.days);
+    if (template) {
+      const rendered = renderTemplateSvg(template.template_svg, defaultTemplateValues({
+        username: user.username,
+        card_type: cardType,
+        range: cardRange.label,
+        theme: themeName,
+        total_time: formatHumanReadable(data.totalSeconds),
+        current_streak: formatDays(data.currentStreak),
+        longest_streak: formatDays(data.longestStreak),
+        tracked_days: formatDays(data.trackedDays),
+      }));
+      if (!rendered.ok) throw new TemplateRenderError(rendered.error);
+      return rendered.svg;
+    }
     return renderStreakSvg({
       username: user.username,
       currentStreak: data.currentStreak,
@@ -197,6 +448,20 @@ async function renderPublicCardSvg(
 
   if (cardType === "summary") {
     const data = await getSummaryCardData(db, user.id, user.timezone, user.timeout, cardRange.days);
+    if (template) {
+      const rendered = renderTemplateSvg(template.template_svg, summaryTemplateValues(
+        user.username,
+        cardType,
+        themeName,
+        cardRange.label,
+        data.totalSeconds,
+        data.dailyAverageSeconds,
+        data.bestDay,
+        data.topLanguage,
+      ));
+      if (!rendered.ok) throw new TemplateRenderError(rendered.error);
+      return rendered.svg;
+    }
     return renderSummarySvg({
       username: user.username,
       totalSeconds: data.totalSeconds,
@@ -210,6 +475,24 @@ async function renderPublicCardSvg(
 
   if (cardType === "languages") {
     const data = await getLanguagesCardData(db, user.id, user.timezone, user.timeout, cardRange.days);
+    if (template) {
+      const topLanguage = data.languages[0] ?? null;
+      const rendered = renderTemplateSvg(template.template_svg, defaultTemplateValues({
+        username: user.username,
+        card_type: cardType,
+        range: cardRange.label,
+        theme: themeName,
+        total_time: formatHumanReadable(data.totalSeconds),
+        top_language: topLanguage
+          ? `${topLanguage.language} / ${formatTemplatePercent(topLanguage.percent)}`
+          : "No language",
+        languages: data.languages.length > 0
+          ? data.languages.map((item) => `${item.language} ${formatTemplatePercent(item.percent)}`).join(", ")
+          : "No language data",
+      }));
+      if (!rendered.ok) throw new TemplateRenderError(rendered.error);
+      return rendered.svg;
+    }
     return renderLanguagesSvg({
       username: user.username,
       totalSeconds: data.totalSeconds,
@@ -222,6 +505,32 @@ async function renderPublicCardSvg(
   throw new Error(`Unsupported card type: ${cardType}`);
 }
 
+function summaryTemplateValues(
+  username: string,
+  cardType: string,
+  themeName: string,
+  rangeLabel: string,
+  totalSeconds: number,
+  dailyAverageSeconds: number,
+  bestDay: { date: string; seconds: number } | null,
+  topLanguage: { language: string; seconds: number; percent: number } | null,
+): CardTemplateValues {
+  return defaultTemplateValues({
+    username,
+    card_type: cardType,
+    range: rangeLabel,
+    theme: themeName,
+    total_time: formatHumanReadable(totalSeconds),
+    daily_average: formatHumanReadable(dailyAverageSeconds),
+    best_day: bestDay
+      ? `${bestDay.date} / ${formatHumanReadable(bestDay.seconds)}`
+      : "No activity",
+    top_language: topLanguage
+      ? `${topLanguage.language} / ${formatTemplatePercent(topLanguage.percent)}`
+      : "No language",
+  });
+}
+
 function svgResponse(
   svg: string,
   etag: string,
@@ -229,20 +538,27 @@ function svgResponse(
   ifNoneMatch: string | null,
 ): Response {
   const cacheControl = cardCacheControl(freshnessMinutes);
+  const headers = svgResponseHeaders(cacheControl, etag);
   if (ifNoneMatch && etagMatches(ifNoneMatch, etag)) {
     return new Response(null, {
       status: 304,
-      headers: { ETag: etag, "Cache-Control": cacheControl },
+      headers,
     });
   }
   return new Response(svg, {
     status: 200,
-    headers: {
-      "Content-Type": "image/svg+xml; charset=utf-8",
-      "Cache-Control": cacheControl,
-      ETag: etag,
-    },
+    headers,
   });
+}
+
+function svgResponseHeaders(cacheControl: string, etag: string): HeadersInit {
+  return {
+    "Content-Type": "image/svg+xml; charset=utf-8",
+    "Cache-Control": cacheControl,
+    ETag: etag,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+  };
 }
 
 function normalizeEtagForComparison(value: string): string {

--- a/src/utils/cards/cache.ts
+++ b/src/utils/cards/cache.ts
@@ -20,6 +20,7 @@ export interface CardCacheKeyParts {
   range: string;
   theme: string;
   templateId: string;
+  templateModifiedAt?: string;
   v: string;
   settingsModifiedAt: string;
 }
@@ -32,6 +33,7 @@ export function buildCardCacheKey(p: CardCacheKeyParts): string {
     p.range,
     p.theme,
     p.templateId,
+    p.templateModifiedAt ?? "",
     p.v,
     p.settingsModifiedAt,
   ].join(":");

--- a/src/utils/cards/templates.ts
+++ b/src/utils/cards/templates.ts
@@ -1,0 +1,301 @@
+import { formatHumanReadable } from "../time-format";
+import { escapeXml } from "./render";
+
+export const MAX_TEMPLATE_BYTES = 20_000;
+export const TEMPLATE_NAME_MAX = 64;
+
+const ALLOWED_PLACEHOLDERS = new Set([
+  "username",
+  "card_type",
+  "range",
+  "theme",
+  "total_time",
+  "daily_average",
+  "best_day",
+  "top_language",
+  "languages",
+  "current_streak",
+  "longest_streak",
+  "tracked_days",
+] as const);
+
+export type CardTemplatePlaceholder = typeof ALLOWED_PLACEHOLDERS extends Set<infer T> ? T : never;
+export type CardTemplateValues = Record<CardTemplatePlaceholder, string>;
+
+export type TemplateValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export type TemplateRenderResult =
+  | { ok: true; svg: string }
+  | { ok: false; error: string };
+
+const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+const XML_ENTITY_RE = /&(?!amp;|lt;|gt;|quot;|apos;|#[0-9]+;|#x[0-9a-fA-F]+;)/;
+const TAG_RE = /<\s*(\/?)\s*([A-Za-z][A-Za-z0-9_.:-]*)([^<>]*?)(\/?)\s*>/g;
+const ATTR_RE = /([A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*("[^"]*"|'[^']*')/g;
+
+const ALLOWED_ELEMENTS = new Set([
+  "svg",
+  "g",
+  "rect",
+  "circle",
+  "ellipse",
+  "line",
+  "path",
+  "polyline",
+  "polygon",
+  "text",
+  "tspan",
+  "title",
+  "desc",
+  "style",
+]);
+
+const DISALLOWED_ELEMENTS = new Set([
+  "script",
+  "foreignobject",
+  "iframe",
+  "object",
+  "embed",
+  "link",
+  "meta",
+  "image",
+  "use",
+  "animate",
+  "animatemotion",
+  "animatetransform",
+  "set",
+  "mpath",
+  "textpath",
+  "feimage",
+]);
+
+export function validateTemplateName(name: unknown): TemplateValidationResult {
+  if (typeof name !== "string") {
+    return { ok: false, error: "name must be a string" };
+  }
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > TEMPLATE_NAME_MAX) {
+    return { ok: false, error: `name must be 1-${TEMPLATE_NAME_MAX} characters` };
+  }
+  return { ok: true };
+}
+
+export function validateTemplateSvg(svg: unknown): TemplateValidationResult {
+  if (typeof svg !== "string") {
+    return { ok: false, error: "template_svg must be a string" };
+  }
+  if (svg.length < 1) {
+    return { ok: false, error: "template_svg must not be empty" };
+  }
+  if (new TextEncoder().encode(svg).length > MAX_TEMPLATE_BYTES) {
+    return { ok: false, error: `template_svg must be at most ${MAX_TEMPLATE_BYTES} bytes` };
+  }
+  if (svg.includes("\u0000")) {
+    return { ok: false, error: "template_svg contains invalid control characters" };
+  }
+
+  const trimmed = svg.trim();
+  if (!trimmed.startsWith("<svg") || !trimmed.endsWith("</svg>")) {
+    return { ok: false, error: "template_svg must contain a single <svg> root" };
+  }
+  if (/<\?/.test(svg)) {
+    return { ok: false, error: "processing instructions are not allowed" };
+  }
+  if (/<\s*!(?:DOCTYPE|ENTITY|\[CDATA)/i.test(svg)) {
+    return { ok: false, error: "doctype, entity, and CDATA declarations are not allowed" };
+  }
+  if (/<\s*script\b/i.test(svg)) {
+    return { ok: false, error: "script elements are not allowed" };
+  }
+  if (/<\s*foreignObject\b/i.test(svg)) {
+    return { ok: false, error: "foreignObject elements are not allowed" };
+  }
+  if (/\son[a-z0-9_.:-]*\s*=/i.test(svg)) {
+    return { ok: false, error: "event-handler attributes are not allowed" };
+  }
+  if (/\b(?:data|javascript|vbscript)\s*:/i.test(svg)) {
+    return { ok: false, error: "data and script URL schemes are not allowed" };
+  }
+  if (/@(?:import|font-face)\b/i.test(svg) || /\burl\s*\(/i.test(svg)) {
+    return { ok: false, error: "external CSS resources are not allowed" };
+  }
+  if (XML_ENTITY_RE.test(svg)) {
+    return { ok: false, error: "template_svg contains an unescaped XML entity" };
+  }
+
+  const placeholders = validatePlaceholders(svg);
+  if (!placeholders.ok) return placeholders;
+
+  return validateTagStructure(svg);
+}
+
+export function defaultTemplateValues(overrides: Partial<CardTemplateValues>): CardTemplateValues {
+  return {
+    username: "",
+    card_type: "",
+    range: "the last year",
+    theme: "default",
+    total_time: formatHumanReadable(0),
+    daily_average: formatHumanReadable(0),
+    best_day: "No activity",
+    top_language: "No language",
+    languages: "No language data",
+    current_streak: formatDays(0),
+    longest_streak: formatDays(0),
+    tracked_days: formatDays(0),
+    ...overrides,
+  };
+}
+
+export function renderTemplateSvg(templateSvg: string, values: CardTemplateValues): TemplateRenderResult {
+  const validation = validateTemplateSvg(templateSvg);
+  if (!validation.ok) return validation;
+
+  const svg = templateSvg.replace(PLACEHOLDER_RE, (_match, rawKey: string) => {
+    const key = rawKey as CardTemplatePlaceholder;
+    return escapeXml(values[key] ?? "");
+  });
+
+  return { ok: true, svg };
+}
+
+export function formatDays(days: number): string {
+  const safeDays = Math.max(0, Math.floor(days));
+  return `${safeDays} ${safeDays === 1 ? "day" : "days"}`;
+}
+
+export function formatTemplatePercent(percent: number): string {
+  return `${Math.round(Math.max(0, Math.min(100, percent)))}%`;
+}
+
+function validatePlaceholders(svg: string): TemplateValidationResult {
+  for (const match of svg.matchAll(PLACEHOLDER_RE)) {
+    const key = match[1];
+    if (!ALLOWED_PLACEHOLDERS.has(key as CardTemplatePlaceholder)) {
+      return { ok: false, error: `unknown placeholder: ${key}` };
+    }
+  }
+
+  const stripped = svg.replace(PLACEHOLDER_RE, "");
+  if (stripped.includes("{{") || stripped.includes("}}")) {
+    return { ok: false, error: "malformed placeholder syntax" };
+  }
+  return { ok: true };
+}
+
+function validateTagStructure(svg: string): TemplateValidationResult {
+  const withoutComments = svg.replace(/<!--[\s\S]*?-->/g, "");
+  if (withoutComments.includes("<!--") || withoutComments.includes("-->")) {
+    return { ok: false, error: "malformed SVG comment" };
+  }
+
+  TAG_RE.lastIndex = 0;
+  const stack: string[] = [];
+  let cursor = 0;
+  let rootSeen = false;
+  let rootClosed = false;
+
+  for (;;) {
+    const match = TAG_RE.exec(withoutComments);
+    if (!match) break;
+
+    const before = withoutComments.slice(cursor, match.index);
+    if (before.includes("<")) {
+      return { ok: false, error: "malformed SVG" };
+    }
+
+    const closing = match[1] === "/";
+    const tagName = match[2].toLowerCase();
+    const attrs = match[3] ?? "";
+    const selfClosing = match[4] === "/" || /\/\s*$/.test(attrs);
+
+    if (tagName.includes(":")) {
+      return { ok: false, error: "namespaced SVG elements are not allowed" };
+    }
+    if (DISALLOWED_ELEMENTS.has(tagName) || !ALLOWED_ELEMENTS.has(tagName)) {
+      return { ok: false, error: `${tagName} elements are not allowed` };
+    }
+
+    if (closing) {
+      if (attrs.trim().length > 0) {
+        return { ok: false, error: "malformed closing tag" };
+      }
+      const expected = stack.pop();
+      if (expected !== tagName) {
+        return { ok: false, error: "malformed SVG tag nesting" };
+      }
+      if (tagName === "svg") rootClosed = true;
+    } else {
+      if (!rootSeen) {
+        if (tagName !== "svg") {
+          return { ok: false, error: "template_svg must contain a single <svg> root" };
+        }
+        rootSeen = true;
+      } else if (rootClosed) {
+        return { ok: false, error: "template_svg must contain a single <svg> root" };
+      }
+
+      const attrValidation = validateAttributes(attrs);
+      if (!attrValidation.ok) return attrValidation;
+      if (!selfClosing) stack.push(tagName);
+    }
+
+    cursor = match.index + match[0].length;
+  }
+
+  const after = withoutComments.slice(cursor);
+  if (after.includes("<")) {
+    return { ok: false, error: "malformed SVG" };
+  }
+  if (!rootSeen || stack.length > 0 || !rootClosed) {
+    return { ok: false, error: "malformed SVG tag nesting" };
+  }
+
+  return { ok: true };
+}
+
+function validateAttributes(attrText: string): TemplateValidationResult {
+  let attrs = attrText.trim();
+  if (attrs.endsWith("/")) attrs = attrs.slice(0, -1).trim();
+  if (attrs.length === 0) return { ok: true };
+
+  ATTR_RE.lastIndex = 0;
+  let cursor = 0;
+  for (;;) {
+    const match = ATTR_RE.exec(attrs);
+    if (!match) break;
+
+    if (attrs.slice(cursor, match.index).trim().length > 0) {
+      return { ok: false, error: "malformed SVG attributes" };
+    }
+
+    const name = match[1].toLowerCase();
+    const quoted = match[2];
+    const value = quoted.slice(1, -1);
+
+    if (name.startsWith("on")) {
+      return { ok: false, error: "event-handler attributes are not allowed" };
+    }
+    if (name === "href" || name === "xlink:href") {
+      return { ok: false, error: "href attributes are not allowed in templates" };
+    }
+    if (name === "xmlns" && value !== "http://www.w3.org/2000/svg") {
+      return { ok: false, error: "only the SVG namespace is allowed" };
+    }
+    if (name === "xmlns:xlink" && value !== "http://www.w3.org/1999/xlink") {
+      return { ok: false, error: "only the SVG xlink namespace is allowed" };
+    }
+    if (!name.startsWith("xmlns") && /\bhttps?\s*:/i.test(value)) {
+      return { ok: false, error: "external references are not allowed" };
+    }
+
+    cursor = match.index + match[0].length;
+  }
+
+  if (attrs.slice(cursor).trim().length > 0) {
+    return { ok: false, error: "malformed SVG attributes" };
+  }
+  return { ok: true };
+}

--- a/src/utils/cards/templates.ts
+++ b/src/utils/cards/templates.ts
@@ -31,7 +31,7 @@ export type TemplateRenderResult =
   | { ok: false; error: string };
 
 const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
-const XML_ENTITY_RE = /&(?!amp;|lt;|gt;|quot;|apos;|#[0-9]+;|#x[0-9a-fA-F]+;)/;
+const UNSAFE_XML_ENTITY_RE = /&(?!amp;|lt;|gt;|quot;|apos;)/;
 const TAG_RE = /<\s*(\/?)\s*([A-Za-z][A-Za-z0-9_.:-]*)([^<>]*?)(\/?)\s*>/g;
 const ATTR_RE = /([A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*("[^"]*"|'[^']*')/g;
 
@@ -49,7 +49,6 @@ const ALLOWED_ELEMENTS = new Set([
   "tspan",
   "title",
   "desc",
-  "style",
 ]);
 
 const DISALLOWED_ELEMENTS = new Set([
@@ -69,6 +68,7 @@ const DISALLOWED_ELEMENTS = new Set([
   "mpath",
   "textpath",
   "feimage",
+  "style",
 ]);
 
 export function validateTemplateName(name: unknown): TemplateValidationResult {
@@ -94,6 +94,9 @@ export function validateTemplateSvg(svg: unknown): TemplateValidationResult {
   }
   if (svg.includes("\u0000")) {
     return { ok: false, error: "template_svg contains invalid control characters" };
+  }
+  if (svg.includes("\\")) {
+    return { ok: false, error: "CSS escape sequences are not allowed" };
   }
 
   const trimmed = svg.trim();
@@ -121,8 +124,8 @@ export function validateTemplateSvg(svg: unknown): TemplateValidationResult {
   if (/@(?:import|font-face)\b/i.test(svg) || /\burl\s*\(/i.test(svg)) {
     return { ok: false, error: "external CSS resources are not allowed" };
   }
-  if (XML_ENTITY_RE.test(svg)) {
-    return { ok: false, error: "template_svg contains an unescaped XML entity" };
+  if (UNSAFE_XML_ENTITY_RE.test(svg)) {
+    return { ok: false, error: "template_svg contains an unsupported XML entity" };
   }
 
   const placeholders = validatePlaceholders(svg);
@@ -280,6 +283,9 @@ function validateAttributes(attrText: string): TemplateValidationResult {
     }
     if (name === "href" || name === "xlink:href") {
       return { ok: false, error: "href attributes are not allowed in templates" };
+    }
+    if (name === "style") {
+      return { ok: false, error: "style attributes are not allowed in templates" };
     }
     if (name === "xmlns" && value !== "http://www.w3.org/2000/svg") {
       return { ok: false, error: "only the SVG namespace is allowed" };

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -10,7 +10,7 @@ import { seedUser, truncate } from "../helpers/fixtures";
 const BASE = "https://test.cloudtime.dev";
 
 afterEach(async () => {
-  await truncate("heartbeats", "summaries", "embed_settings", "users");
+  await truncate("heartbeats", "summaries", "embed_templates", "embed_settings", "users");
 });
 
 async function call(path: string, init: RequestInit = {}): Promise<Response> {
@@ -28,6 +28,17 @@ function authPatch(apiKey: string, body: unknown): RequestInit {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+  };
+}
+
+function authJson(apiKey: string, method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
   };
 }
 
@@ -247,6 +258,80 @@ describe("embeddable cards — public visibility", () => {
     const svg = await res.text();
     expect(svg).toContain("2 mins in the last year");
   });
+
+  it("renders a public card through an owned custom template", async () => {
+    const user = await seedUser({ username: "templated" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+
+    const bestDay = formatUtcDate(-1);
+    await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', 'TypeScript', ?)",
+    )
+      .bind(user.userId, bestDay, 7200)
+      .run();
+
+    const created = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(user.apiKey, "POST", {
+        name: "summary badge",
+        template_svg:
+          '<svg xmlns="http://www.w3.org/2000/svg" width="360" height="96" viewBox="0 0 360 96" role="img">' +
+          '<text x="12" y="28">{{username}}</text>' +
+          '<text x="12" y="54">{{total_time}}</text>' +
+          '<text x="12" y="80">{{top_language}}</text>' +
+          "</svg>",
+      }),
+    );
+    expect(created.status).toBe(201);
+    const body = (await created.json()) as { data: { id: string } };
+
+    const res = await call(`/api/v1/users/${user.username}/cards/summary.svg?range=last_7_days&template_id=${body.data.id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("image/svg+xml");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'none'");
+
+    const svg = await res.text();
+    expect(svg).toContain("templated");
+    expect(svg).toContain("2 hrs");
+    expect(svg).toContain("TypeScript / 100%");
+    expect(svg).not.toContain(user.apiKey);
+  });
+
+  it("returns 404 when a public card references another user's template", async () => {
+    const owner = await seedUser({ username: "template_owner" });
+    const viewer = await seedUser({ username: "template_viewer" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(viewer.apiKey, { enabled: true }));
+
+    const created = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(owner.apiKey, "POST", {
+        name: "private template",
+        template_svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>{{username}}</text></svg>',
+      }),
+    );
+    const body = (await created.json()) as { data: { id: string } };
+
+    const res = await call(`/api/v1/users/${viewer.username}/cards/summary.svg?template_id=${body.data.id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("revalidates stored templates before public rendering", async () => {
+    const user = await seedUser({ username: "revalidate" });
+    await call(`/api/v1/users/current/embed_settings`, authPatch(user.apiKey, { enabled: true }));
+    const templateId = crypto.randomUUID();
+    await env.DB.prepare(
+      `INSERT INTO embed_templates (id, user_id, name, template_svg, created_at, modified_at)
+       VALUES (?, ?, 'unsafe', ?, datetime('now'), datetime('now'))`,
+    )
+      .bind(templateId, user.userId, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>')
+      .run();
+
+    const res = await call(`/api/v1/users/${user.username}/cards/summary.svg?template_id=${templateId}`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("script");
+  });
 });
 
 describe("embeddable cards — settings auth", () => {
@@ -291,5 +376,113 @@ describe("embeddable cards — settings auth", () => {
     expect(body.data.enabled).toBe(false);
     expect(body.data.freshness_minutes).toBe(15);
     expect(body.data.default_theme).toBe("default");
+  });
+});
+
+describe("embeddable cards - template auth", () => {
+  it("requires authentication to list embed templates", async () => {
+    const res = await call("/api/v1/users/current/embed_templates");
+    expect(res.status).toBe(401);
+  });
+
+  it("supports template CRUD for the authenticated user", async () => {
+    const user = await seedUser({ username: "template_crud" });
+    const templateSvg = '<svg xmlns="http://www.w3.org/2000/svg"><text>{{username}}</text></svg>';
+
+    const created = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(user.apiKey, "POST", { name: "Profile card", template_svg: templateSvg }),
+    );
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { data: { id: string; name: string; template_svg: string } };
+    expect(createdBody.data.name).toBe("Profile card");
+    expect(createdBody.data.template_svg).toBe(templateSvg);
+
+    const listed = await call("/api/v1/users/current/embed_templates", {
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(listed.status).toBe(200);
+    const listBody = (await listed.json()) as { data: Array<{ id: string }> };
+    expect(listBody.data.map((item) => item.id)).toContain(createdBody.data.id);
+
+    const fetched = await call(`/api/v1/users/current/embed_templates/${createdBody.data.id}`, {
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(fetched.status).toBe(200);
+
+    const patched = await call(
+      `/api/v1/users/current/embed_templates/${createdBody.data.id}`,
+      authJson(user.apiKey, "PATCH", { name: "Updated card" }),
+    );
+    expect(patched.status).toBe(200);
+    const patchedBody = (await patched.json()) as { data: { name: string } };
+    expect(patchedBody.data.name).toBe("Updated card");
+
+    const deleted = await call(
+      `/api/v1/users/current/embed_templates/${createdBody.data.id}`,
+      authJson(user.apiKey, "DELETE"),
+    );
+    expect(deleted.status).toBe(204);
+
+    const missing = await call(`/api/v1/users/current/embed_templates/${createdBody.data.id}`, {
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    expect(missing.status).toBe(404);
+  });
+
+  it("returns 404 for cross-user template access", async () => {
+    const owner = await seedUser({ username: "template_owner_auth" });
+    const other = await seedUser({ username: "template_other_auth" });
+
+    const created = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(owner.apiKey, "POST", {
+        name: "Owner template",
+        template_svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>{{username}}</text></svg>',
+      }),
+    );
+    const body = (await created.json()) as { data: { id: string } };
+
+    const res = await call(`/api/v1/users/current/embed_templates/${body.data.id}`, {
+      headers: { Authorization: `Bearer ${other.apiKey}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects unsafe template creation and stores nothing", async () => {
+    const user = await seedUser({ username: "template_invalid" });
+
+    const res = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(user.apiKey, "POST", {
+        name: "bad",
+        template_svg: '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      }),
+    );
+    expect(res.status).toBe(400);
+
+    const listed = await call("/api/v1/users/current/embed_templates", {
+      headers: { Authorization: `Bearer ${user.apiKey}` },
+    });
+    const listBody = (await listed.json()) as { data: unknown[] };
+    expect(listBody.data).toHaveLength(0);
+  });
+
+  it("rejects empty template patches", async () => {
+    const user = await seedUser({ username: "template_empty_patch" });
+    const created = await call(
+      "/api/v1/users/current/embed_templates",
+      authJson(user.apiKey, "POST", {
+        name: "patch target",
+        template_svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>{{username}}</text></svg>',
+      }),
+    );
+    const body = (await created.json()) as { data: { id: string } };
+
+    const res = await call(
+      `/api/v1/users/current/embed_templates/${body.data.id}`,
+      authJson(user.apiKey, "PATCH", {}),
+    );
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/unit/cards-templates.test.ts
+++ b/tests/unit/cards-templates.test.ts
@@ -8,10 +8,9 @@ import {
 
 const VALID_TEMPLATE =
   '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80" viewBox="0 0 320 80" role="img">' +
-  '<style>text{font-family:Arial,sans-serif;}</style>' +
   '<rect width="320" height="80" fill="#fff"></rect>' +
-  '<text x="12" y="28">{{username}}</text>' +
-  '<text x="12" y="54">{{total_time}}</text>' +
+  '<text x="12" y="28" font-family="Arial, sans-serif">{{username}}</text>' +
+  '<text x="12" y="54" font-family="Arial, sans-serif">{{total_time}}</text>' +
   "</svg>";
 
 describe("validateTemplateSvg", () => {
@@ -23,6 +22,8 @@ describe("validateTemplateSvg", () => {
     ["script element", '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'],
     ["event handler", '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="evil()" /></svg>'],
     ["foreignObject", '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>html</div></foreignObject></svg>'],
+    ["style element", '<svg xmlns="http://www.w3.org/2000/svg"><style>text{fill:red}</style></svg>'],
+    ["style attribute", '<svg xmlns="http://www.w3.org/2000/svg"><text style="fill:red">x</text></svg>'],
     ["external href", '<svg xmlns="http://www.w3.org/2000/svg"><text href="https://example.test">x</text></svg>'],
     [
       "xlink href",
@@ -31,6 +32,14 @@ describe("validateTemplateSvg", () => {
     [
       "remote font",
       '<svg xmlns="http://www.w3.org/2000/svg"><style>@font-face{font-family:X;src:url(https://example.test/x.woff2)}</style></svg>',
+    ],
+    [
+      "entity-obfuscated CSS URL",
+      '<svg xmlns="http://www.w3.org/2000/svg"><style>rect{filter:u&#x72;l(https://example.test/x)}</style><rect /></svg>',
+    ],
+    [
+      "CSS escape URL",
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect filter="u\\72l(https://example.test/x)" /></svg>',
     ],
     ["data URL", '<svg xmlns="http://www.w3.org/2000/svg"><rect fill="data:image/png;base64,aaaa" /></svg>'],
     ["processing instruction", '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'],

--- a/tests/unit/cards-templates.test.ts
+++ b/tests/unit/cards-templates.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_TEMPLATE_BYTES,
+  defaultTemplateValues,
+  renderTemplateSvg,
+  validateTemplateSvg,
+} from "../../src/utils/cards/templates";
+
+const VALID_TEMPLATE =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80" viewBox="0 0 320 80" role="img">' +
+  '<style>text{font-family:Arial,sans-serif;}</style>' +
+  '<rect width="320" height="80" fill="#fff"></rect>' +
+  '<text x="12" y="28">{{username}}</text>' +
+  '<text x="12" y="54">{{total_time}}</text>' +
+  "</svg>";
+
+describe("validateTemplateSvg", () => {
+  it("accepts a static SVG template with known placeholders", () => {
+    expect(validateTemplateSvg(VALID_TEMPLATE)).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["script element", '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'],
+    ["event handler", '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="evil()" /></svg>'],
+    ["foreignObject", '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>html</div></foreignObject></svg>'],
+    ["external href", '<svg xmlns="http://www.w3.org/2000/svg"><text href="https://example.test">x</text></svg>'],
+    [
+      "xlink href",
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><text xlink:href="#x">x</text></svg>',
+    ],
+    [
+      "remote font",
+      '<svg xmlns="http://www.w3.org/2000/svg"><style>@font-face{font-family:X;src:url(https://example.test/x.woff2)}</style></svg>',
+    ],
+    ["data URL", '<svg xmlns="http://www.w3.org/2000/svg"><rect fill="data:image/png;base64,aaaa" /></svg>'],
+    ["processing instruction", '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'],
+    ["malformed SVG", '<svg xmlns="http://www.w3.org/2000/svg"><text>oops</svg>'],
+    ["unknown placeholder", '<svg xmlns="http://www.w3.org/2000/svg"><text>{{token}}</text></svg>'],
+  ])("rejects %s", (_name, template) => {
+    const result = validateTemplateSvg(template);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects oversized templates by byte length", () => {
+    const result = validateTemplateSvg(
+      `<svg xmlns="http://www.w3.org/2000/svg"><text>${"a".repeat(MAX_TEMPLATE_BYTES)}</text></svg>`,
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("renderTemplateSvg", () => {
+  it("substitutes placeholders with XML escaping", () => {
+    const result = renderTemplateSvg(VALID_TEMPLATE, defaultTemplateValues({
+      username: '<script>alert("x")</script>&',
+      total_time: "1 hr",
+    }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.svg).not.toContain("<script>");
+    expect(result.svg).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;&amp;");
+    expect(result.svg).toContain("1 hr");
+  });
+});


### PR DESCRIPTION
## Summary

- Add D1 storage and migration for user-owned custom embeddable card templates.
- Implement authenticated template list/create/get/patch/delete endpoints using the generated OpenAPI types.
- Add safe static SVG validation, XML-escaped placeholder substitution, template-backed public rendering, and cache invalidation on template updates.
- Document the new migration and API-based custom template setup.

## Safety

- Rejects scripts, event-handler attributes, foreignObject, href/xlink:href references, data/script URL schemes, remote CSS/font references, malformed SVG, oversized templates, and unknown placeholders.
- Revalidates stored templates before public rendering and serves SVG responses with nosniff/CSP defense in depth.
- Keeps public templates scoped to the target user; cross-user template IDs return 404.

## Validation

- npm run typecheck
- npm run lint:api
- npm test -- tests/unit/cards-templates.test.ts tests/integration/embeddable-cards.test.ts
- npm test
- git diff --check

Closes #176.