### PR TITLE
[codex] feat: backfill hourly summaries

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -92,6 +92,7 @@ npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --fil
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0003_hourly_summaries.sql
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0004_embed_settings.sql
 npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0005_embed_templates.sql
+npx wrangler d1 execute cloudtime-db --remote --config wrangler.local.toml --file=./migrations/0006_hourly_backfill_dates.sql
 ```
 
 ## 6. Configure secrets

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -88,6 +88,47 @@ wrangler d1 execute cloudtime-db --remote --command \
 Repeat until the row count stabilises. Always
 [back up](./backup-restore.md) before bulk deletes.
 
+## Hourly summaries backfill
+
+Issue #142 adds a one-off backfill for the `hours` insight's
+`hourly_summaries` table. The hourly cron derives missing hour-of-day buckets
+from retained raw heartbeats, using the same session-gap and timezone rules as
+normal aggregation.
+
+### How it works
+
+- The backfill runs inside the existing hourly cron and processes at most
+  **5000** heartbeats per run.
+- It only reads heartbeats at or behind the normal `last_aggregated_at` cursor,
+  so it does not race ahead of regular aggregation.
+- It tracks progress in `meta.hourly_backfill_cursor` and sets
+  `meta.hourly_backfill_completed_at` once no retained heartbeat rows remain to
+  scan. After that, future cron runs skip the backfill.
+- It records the first date it actually filled in
+  `meta.hourly_backfill_earliest_date`, which is useful when raw heartbeat
+  retention means older history is no longer available.
+- It never adds to a user/date that already had `hourly_summaries` rows before
+  the backfill reached it. Dates created by the backfill are recorded in
+  `hourly_backfill_dates`, allowing later chunks to continue the same date
+  without double-counting cron-populated rows.
+
+### Re-running
+
+The backfill is intentionally one-off. To run it again after restoring data or
+manually clearing hourly rows, first back up D1, then remove the backfill state
+for the affected instance during a maintenance window:
+
+```bash
+wrangler d1 execute cloudtime-db --remote --command \
+  "DELETE FROM meta WHERE key IN ('hourly_backfill_cursor','hourly_backfill_completed_at','hourly_backfill_earliest_date')"
+wrangler d1 execute cloudtime-db --remote --command \
+  "DELETE FROM hourly_backfill_dates"
+```
+
+Do not reset the backfill state while keeping backfilled `hourly_summaries`
+rows unless you also understand which rows should be preserved; the cursor and
+marker table are the idempotency guard.
+
 ## Data exports (`R2_BUCKET`)
 
 The `/data_dumps` endpoints let a user export their own data (migration,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -101,9 +101,10 @@ normal aggregation.
   **5000** heartbeats per run.
 - It only reads heartbeats at or behind the normal `last_aggregated_at` cursor,
   so it does not race ahead of regular aggregation.
-- It tracks progress in `meta.hourly_backfill_cursor` and sets
-  `meta.hourly_backfill_completed_at` once no retained heartbeat rows remain to
-  scan. After that, future cron runs skip the backfill.
+- It tracks progress with the composite
+  `meta.hourly_backfill_cursor` / `meta.hourly_backfill_cursor_id` pair and
+  sets `meta.hourly_backfill_completed_at` once no retained heartbeat rows
+  remain to scan. After that, future cron runs skip the backfill.
 - It records the first date it actually filled in
   `meta.hourly_backfill_earliest_date`, which is useful when raw heartbeat
   retention means older history is no longer available.
@@ -120,7 +121,7 @@ for the affected instance during a maintenance window:
 
 ```bash
 wrangler d1 execute cloudtime-db --remote --command \
-  "DELETE FROM meta WHERE key IN ('hourly_backfill_cursor','hourly_backfill_completed_at','hourly_backfill_earliest_date')"
+  "DELETE FROM meta WHERE key IN ('hourly_backfill_cursor','hourly_backfill_cursor_id','hourly_backfill_completed_at','hourly_backfill_earliest_date')"
 wrangler d1 execute cloudtime-db --remote --command \
   "DELETE FROM hourly_backfill_dates"
 ```

--- a/migrations/0006_hourly_backfill_dates.sql
+++ b/migrations/0006_hourly_backfill_dates.sql
@@ -1,0 +1,15 @@
+-- Marker table for the one-off hourly_summaries backfill (Issue #142).
+-- Kept in sync with src/db/schema.sql so existing D1 databases can migrate and
+-- fresh deployments via `npm run db:init` get the same shape.
+--
+-- A user/date present here was created by the backfill and may be safely
+-- continued by later chunks. Dates that already existed in hourly_summaries
+-- without this marker are skipped to avoid double-counting cron-populated rows.
+
+CREATE TABLE IF NOT EXISTS hourly_backfill_dates (
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, date),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cron/aggregate.ts
+++ b/src/cron/aggregate.ts
@@ -1,6 +1,6 @@
 import { getDateForTimestamp, getHourForTimestamp } from "../utils/time-format";
 
-type HeartbeatForAggregation = {
+export type HeartbeatForAggregation = {
   user_id: string;
   time: number;
   project: string | null;
@@ -25,23 +25,23 @@ type SummaryTuple = {
   seconds: number;
 };
 
-type HourlyTuple = {
+export type HourlyTuple = {
   userId: string;
   date: string;
   hour: number;
   seconds: number;
 };
 
-type ComputedDurations = {
+export type ComputedDurations = {
   daily: Map<string, SummaryTuple>;
   hourly: Map<string, HourlyTuple>;
 };
 
 const DEFAULT_TIMEOUT = 15 * 60; // 15 minutes in seconds
 export const MAX_USER_TIMEOUT = 60 * 60; // 60 minutes - max allowed by validation
-const HEARTBEAT_LIMIT = 5000;
+export const HEARTBEAT_LIMIT = 5000;
 
-async function getLastAggregatedAt(db: D1Database): Promise<number> {
+export async function getLastAggregatedAt(db: D1Database): Promise<number> {
   const row = await db
     .prepare("SELECT value FROM meta WHERE key = 'last_aggregated_at'")
     .first<{ value: string }>();
@@ -52,7 +52,7 @@ type UserSettings = { timeout: number; timezone: string };
 
 const BIND_CHUNK_SIZE = 100;
 
-async function getUserSettings(
+export async function getUserSettings(
   db: D1Database,
   userIds: string[],
 ): Promise<Map<string, UserSettings>> {
@@ -81,7 +81,7 @@ async function getUserSettings(
   return map;
 }
 
-function computeDurations(
+export function computeDurations(
   heartbeats: HeartbeatForAggregation[],
   userSettings: Map<string, UserSettings>,
   lastAggregatedAt: number,

--- a/src/cron/aggregate.ts
+++ b/src/cron/aggregate.ts
@@ -85,6 +85,8 @@ export function computeDurations(
   heartbeats: HeartbeatForAggregation[],
   userSettings: Map<string, UserSettings>,
   lastAggregatedAt: number,
+  shouldProcessHeartbeat: (heartbeat: HeartbeatForAggregation) => boolean = (heartbeat) =>
+    heartbeat.time > lastAggregatedAt,
 ): ComputedDurations {
   const result = new Map<string, SummaryTuple>();
   // Hour-of-day aggregate (Issue #134), bucketed in the same walk so a single
@@ -113,8 +115,8 @@ export function computeDurations(
       const curr = userHeartbeats[i];
       const gap = curr.time - prev.time;
 
-      // Only generate durations for heartbeats after lastAggregatedAt
-      if (curr.time <= lastAggregatedAt) continue;
+      // Only generate durations for heartbeats after the caller's cursor.
+      if (!shouldProcessHeartbeat(curr)) continue;
 
       if (gap > timeout || gap <= 0) continue;
 

--- a/src/cron/hourly-backfill.ts
+++ b/src/cron/hourly-backfill.ts
@@ -9,9 +9,12 @@ import {
 } from "./aggregate";
 
 const CURSOR_KEY = "hourly_backfill_cursor";
+const CURSOR_ID_KEY = "hourly_backfill_cursor_id";
 const COMPLETED_KEY = "hourly_backfill_completed_at";
 const EARLIEST_DATE_KEY = "hourly_backfill_earliest_date";
 const DATE_PAIR_CHUNK_SIZE = 50;
+
+type BackfillHeartbeat = HeartbeatForAggregation & { id: string };
 
 export type HourlyBackfillStatus = "waiting" | "skipped" | "processed" | "complete";
 
@@ -37,11 +40,13 @@ export async function backfillHourlySummaries(
   }
 
   const cursor = await getMetaNumber(db, CURSOR_KEY);
+  const cursorId = await getMetaString(db, CURSOR_ID_KEY);
   const safeLimit = Math.max(1, Math.floor(limit));
-  const newHeartbeats = await loadBackfillHeartbeats(db, cursor, lastAggregatedAt, safeLimit);
+  const newHeartbeats = await loadBackfillHeartbeats(db, cursor, cursorId, lastAggregatedAt, safeLimit);
   if (newHeartbeats.length === 0) {
     await db.batch([
       upsertMeta(db, CURSOR_KEY, String(lastAggregatedAt)),
+      upsertMeta(db, CURSOR_ID_KEY, ""),
       upsertMeta(db, COMPLETED_KEY, new Date().toISOString()),
     ]);
     return {
@@ -52,13 +57,22 @@ export async function backfillHourlySummaries(
     };
   }
 
-  const lookbackHeartbeats = await loadLookbackHeartbeats(db, cursor);
+  const lookbackHeartbeats = await loadLookbackHeartbeats(db, cursor, cursorId);
   const heartbeats = [...lookbackHeartbeats, ...newHeartbeats];
   const userSettings = await getUserSettings(db, [...new Set(heartbeats.map((hb) => hb.user_id))]);
-  const { hourly } = computeDurations(heartbeats, userSettings, cursor);
+  const { hourly } = computeDurations(
+    heartbeats,
+    userSettings,
+    cursor,
+    (hb) => hb.time > cursor || (hb.time === cursor && (hb as BackfillHeartbeat).id > cursorId),
+  );
   const fillable = await filterTuplesForBackfillableDates(db, [...hourly.values()]);
 
-  const maxTime = Math.max(...newHeartbeats.map((hb) => hb.time));
+  const lastHeartbeat = newHeartbeats.at(-1);
+  if (!lastHeartbeat) {
+    throw new Error("backfillHourlySummaries: expected a non-empty heartbeat batch");
+  }
+  const maxTime = lastHeartbeat.time;
   const complete = newHeartbeats.length < safeLimit;
   const earliestDate = minDate(fillable);
 
@@ -91,6 +105,7 @@ DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds`;
   }
 
   statements.push(upsertMeta(db, CURSOR_KEY, String(maxTime)));
+  statements.push(upsertMeta(db, CURSOR_ID_KEY, lastHeartbeat.id));
   if (earliestDate) statements.push(upsertEarliestDate(db, earliestDate));
   if (complete) statements.push(upsertMeta(db, COMPLETED_KEY, new Date().toISOString()));
 
@@ -116,42 +131,60 @@ async function getMetaNumber(db: D1Database, key: string): Promise<number> {
   return Number.isFinite(value) && value > 0 ? value : 0;
 }
 
+async function getMetaString(db: D1Database, key: string): Promise<string> {
+  const row = await db.prepare("SELECT value FROM meta WHERE key = ?").bind(key).first<{ value: string }>();
+  return row?.value ?? "";
+}
+
 async function loadLookbackHeartbeats(
   db: D1Database,
   cursor: number,
-): Promise<HeartbeatForAggregation[]> {
+  cursorId: string,
+): Promise<BackfillHeartbeat[]> {
   if (cursor <= 0) return [];
   const lookbackTime = Math.max(0, cursor - MAX_USER_TIMEOUT);
+  const cursorPredicate = cursorId
+    ? "(time < ? OR (time = ? AND id <= ?))"
+    : "time <= ?";
+  const bindings = cursorId
+    ? [lookbackTime, cursor, cursor, cursorId]
+    : [lookbackTime, cursor];
   const { results } = await db
     .prepare(
-      `SELECT user_id, max(time) as time, project, branch, language, editor,
+      `SELECT id, user_id, time, project, branch, language, editor,
               operating_system, category, machine
-       FROM heartbeats
-       WHERE time > ? AND time <= ?
-       GROUP BY user_id`,
+       FROM (
+         SELECT id, user_id, time, project, branch, language, editor,
+                operating_system, category, machine,
+                ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY time DESC, id DESC) AS rn
+         FROM heartbeats
+         WHERE time > ? AND ${cursorPredicate}
+       )
+       WHERE rn = 1`,
     )
-    .bind(lookbackTime, cursor)
-    .all<HeartbeatForAggregation>();
+    .bind(...bindings)
+    .all<BackfillHeartbeat>();
   return results;
 }
 
 async function loadBackfillHeartbeats(
   db: D1Database,
   cursor: number,
+  cursorId: string,
   lastAggregatedAt: number,
   limit: number,
-): Promise<HeartbeatForAggregation[]> {
+): Promise<BackfillHeartbeat[]> {
   const { results } = await db
     .prepare(
-      `SELECT user_id, time, project, branch, language, editor,
+      `SELECT id, user_id, time, project, branch, language, editor,
               operating_system, category, machine
        FROM heartbeats
-       WHERE time > ? AND time <= ?
-       ORDER BY time ASC
+       WHERE (time > ? OR (time = ? AND id > ?)) AND time <= ?
+       ORDER BY time ASC, id ASC
        LIMIT ?`,
     )
-    .bind(cursor, lastAggregatedAt, limit)
-    .all<HeartbeatForAggregation>();
+    .bind(cursor, cursor, cursorId, lastAggregatedAt, limit)
+    .all<BackfillHeartbeat>();
   return results;
 }
 

--- a/src/cron/hourly-backfill.ts
+++ b/src/cron/hourly-backfill.ts
@@ -1,0 +1,237 @@
+import {
+  computeDurations,
+  getLastAggregatedAt,
+  getUserSettings,
+  HEARTBEAT_LIMIT,
+  MAX_USER_TIMEOUT,
+  type HeartbeatForAggregation,
+  type HourlyTuple,
+} from "./aggregate";
+
+const CURSOR_KEY = "hourly_backfill_cursor";
+const COMPLETED_KEY = "hourly_backfill_completed_at";
+const EARLIEST_DATE_KEY = "hourly_backfill_earliest_date";
+const DATE_PAIR_CHUNK_SIZE = 50;
+
+export type HourlyBackfillStatus = "waiting" | "skipped" | "processed" | "complete";
+
+export interface HourlyBackfillResult {
+  status: HourlyBackfillStatus;
+  scannedHeartbeats: number;
+  insertedRows: number;
+  cursor: number;
+  earliestDate?: string;
+}
+
+export async function backfillHourlySummaries(
+  db: D1Database,
+  limit = HEARTBEAT_LIMIT,
+): Promise<HourlyBackfillResult> {
+  if (await hasMetaKey(db, COMPLETED_KEY)) {
+    return { status: "skipped", scannedHeartbeats: 0, insertedRows: 0, cursor: 0 };
+  }
+
+  const lastAggregatedAt = await getLastAggregatedAt(db);
+  if (lastAggregatedAt <= 0) {
+    return { status: "waiting", scannedHeartbeats: 0, insertedRows: 0, cursor: 0 };
+  }
+
+  const cursor = await getMetaNumber(db, CURSOR_KEY);
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const newHeartbeats = await loadBackfillHeartbeats(db, cursor, lastAggregatedAt, safeLimit);
+  if (newHeartbeats.length === 0) {
+    await db.batch([
+      upsertMeta(db, CURSOR_KEY, String(lastAggregatedAt)),
+      upsertMeta(db, COMPLETED_KEY, new Date().toISOString()),
+    ]);
+    return {
+      status: "complete",
+      scannedHeartbeats: 0,
+      insertedRows: 0,
+      cursor: lastAggregatedAt,
+    };
+  }
+
+  const lookbackHeartbeats = await loadLookbackHeartbeats(db, cursor);
+  const heartbeats = [...lookbackHeartbeats, ...newHeartbeats];
+  const userSettings = await getUserSettings(db, [...new Set(heartbeats.map((hb) => hb.user_id))]);
+  const { hourly } = computeDurations(heartbeats, userSettings, cursor);
+  const fillable = await filterTuplesForBackfillableDates(db, [...hourly.values()]);
+
+  const maxTime = Math.max(...newHeartbeats.map((hb) => hb.time));
+  const complete = newHeartbeats.length < safeLimit;
+  const earliestDate = minDate(fillable);
+
+  const statements: D1PreparedStatement[] = [];
+  const insertSql = `INSERT INTO hourly_summaries (user_id, date, hour, total_seconds)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id, date, hour)
+DO UPDATE SET total_seconds = total_seconds + excluded.total_seconds`;
+
+  for (const tuple of fillable) {
+    statements.push(
+      db.prepare(insertSql).bind(
+        tuple.userId,
+        tuple.date,
+        tuple.hour,
+        Math.round(tuple.seconds),
+      ),
+    );
+  }
+  for (const tuple of uniqueDateTuples(fillable)) {
+    statements.push(
+      db
+        .prepare(
+          `INSERT INTO hourly_backfill_dates (user_id, date, created_at)
+           VALUES (?, ?, datetime('now'))
+           ON CONFLICT (user_id, date) DO NOTHING`,
+        )
+        .bind(tuple.userId, tuple.date),
+    );
+  }
+
+  statements.push(upsertMeta(db, CURSOR_KEY, String(maxTime)));
+  if (earliestDate) statements.push(upsertEarliestDate(db, earliestDate));
+  if (complete) statements.push(upsertMeta(db, COMPLETED_KEY, new Date().toISOString()));
+
+  await db.batch(statements);
+
+  return {
+    status: complete ? "complete" : "processed",
+    scannedHeartbeats: newHeartbeats.length,
+    insertedRows: fillable.length,
+    cursor: maxTime,
+    earliestDate: earliestDate ?? undefined,
+  };
+}
+
+async function hasMetaKey(db: D1Database, key: string): Promise<boolean> {
+  const row = await db.prepare("SELECT 1 AS ok FROM meta WHERE key = ?").bind(key).first<{ ok: number }>();
+  return row !== null;
+}
+
+async function getMetaNumber(db: D1Database, key: string): Promise<number> {
+  const row = await db.prepare("SELECT value FROM meta WHERE key = ?").bind(key).first<{ value: string }>();
+  const value = Number(row?.value ?? 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+async function loadLookbackHeartbeats(
+  db: D1Database,
+  cursor: number,
+): Promise<HeartbeatForAggregation[]> {
+  if (cursor <= 0) return [];
+  const lookbackTime = Math.max(0, cursor - MAX_USER_TIMEOUT);
+  const { results } = await db
+    .prepare(
+      `SELECT user_id, max(time) as time, project, branch, language, editor,
+              operating_system, category, machine
+       FROM heartbeats
+       WHERE time > ? AND time <= ?
+       GROUP BY user_id`,
+    )
+    .bind(lookbackTime, cursor)
+    .all<HeartbeatForAggregation>();
+  return results;
+}
+
+async function loadBackfillHeartbeats(
+  db: D1Database,
+  cursor: number,
+  lastAggregatedAt: number,
+  limit: number,
+): Promise<HeartbeatForAggregation[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT user_id, time, project, branch, language, editor,
+              operating_system, category, machine
+       FROM heartbeats
+       WHERE time > ? AND time <= ?
+       ORDER BY time ASC
+       LIMIT ?`,
+    )
+    .bind(cursor, lastAggregatedAt, limit)
+    .all<HeartbeatForAggregation>();
+  return results;
+}
+
+async function filterTuplesForBackfillableDates(
+  db: D1Database,
+  tuples: HourlyTuple[],
+): Promise<HourlyTuple[]> {
+  const { existingDates, backfilledDates } = await loadHourlyDateState(db, tuples);
+  return tuples.filter((tuple) => {
+    const key = hourlyDateKey(tuple.userId, tuple.date);
+    return !existingDates.has(key) || backfilledDates.has(key);
+  });
+}
+
+async function loadHourlyDateState(
+  db: D1Database,
+  tuples: HourlyTuple[],
+): Promise<{ existingDates: Set<string>; backfilledDates: Set<string> }> {
+  const uniquePairs = uniqueDateTuples(tuples);
+  const existingDates = new Set<string>();
+  const backfilledDates = new Set<string>();
+
+  for (let i = 0; i < uniquePairs.length; i += DATE_PAIR_CHUNK_SIZE) {
+    const chunk = uniquePairs.slice(i, i + DATE_PAIR_CHUNK_SIZE);
+    if (chunk.length === 0) continue;
+    const clauses = chunk.map(() => "(user_id = ? AND date = ?)").join(" OR ");
+    const binds = chunk.flatMap((pair) => [pair.userId, pair.date]);
+    const hourly = await db
+      .prepare(`SELECT DISTINCT user_id, date FROM hourly_summaries WHERE ${clauses}`)
+      .bind(...binds)
+      .all<{ user_id: string; date: string }>();
+    for (const row of hourly.results) {
+      existingDates.add(hourlyDateKey(row.user_id, row.date));
+    }
+
+    const backfilled = await db
+      .prepare(`SELECT user_id, date FROM hourly_backfill_dates WHERE ${clauses}`)
+      .bind(...binds)
+      .all<{ user_id: string; date: string }>();
+    for (const row of backfilled.results) {
+      backfilledDates.add(hourlyDateKey(row.user_id, row.date));
+    }
+  }
+
+  return { existingDates, backfilledDates };
+}
+
+function uniqueDateTuples(tuples: HourlyTuple[]): Array<{ userId: string; date: string }> {
+  return [...new Map(tuples.map((tuple) => [
+    hourlyDateKey(tuple.userId, tuple.date),
+    { userId: tuple.userId, date: tuple.date },
+  ])).values()];
+}
+
+function hourlyDateKey(userId: string, date: string): string {
+  return `${userId}|${date}`;
+}
+
+function minDate(tuples: HourlyTuple[]): string | null {
+  let earliest: string | null = null;
+  for (const tuple of tuples) {
+    if (!earliest || tuple.date < earliest) earliest = tuple.date;
+  }
+  return earliest;
+}
+
+function upsertMeta(db: D1Database, key: string, value: string): D1PreparedStatement {
+  return db
+    .prepare(
+      "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key, value);
+}
+
+function upsertEarliestDate(db: D1Database, date: string): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO meta (key, value) VALUES (?, ?)
+       ON CONFLICT (key) DO UPDATE SET
+         value = CASE WHEN value < excluded.value THEN value ELSE excluded.value END`,
+    )
+    .bind(EARLIEST_DATE_KEY, date);
+}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -168,6 +168,18 @@ CREATE TABLE IF NOT EXISTS hourly_summaries (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_hourly_summaries_unique
   ON hourly_summaries(user_id, date, hour);
 
+-- Marker table for the one-off hourly_summaries backfill (Issue #142).
+-- A user/date present here was created by the backfill and may be safely
+-- continued by later chunks. Dates that already existed in hourly_summaries
+-- without this marker are skipped to avoid double-counting cron-populated rows.
+CREATE TABLE IF NOT EXISTS hourly_backfill_dates (
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, date),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 -- ============================================================
 -- Goals
 -- ============================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { cardsPublic, cardsSettings } from "./routes/cards";
 import { aggregateHeartbeats } from "./cron/aggregate";
+import { backfillHourlySummaries } from "./cron/hourly-backfill";
 import { parseRetentionDays, purgeOldHeartbeats } from "./cron/purge";
 import { processPendingDumps, purgeExpiredDumps } from "./cron/data-dumps";
 
@@ -198,11 +199,17 @@ export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(
       (async () => {
-        // Run aggregation, session cleanup, and the optional heartbeat purge
-        // independently so a failure in one does not prevent the others from
-        // completing.
+        // Run cron tasks independently so a failure in one does not prevent
+        // the others from completing.
         const retentionDays = parseRetentionDays(env.HEARTBEAT_RETENTION_DAYS);
-        const [, batchResults, purgeResult, dumpBuildResult, dumpPurgeResult] = await Promise.allSettled([
+        const [
+          aggregationResult,
+          batchResults,
+          purgeResult,
+          dumpBuildResult,
+          dumpPurgeResult,
+          hourlyBackfillResult,
+        ] = await Promise.allSettled([
           aggregateHeartbeats(env.DB),
           // Atomic DELETE + RETURNING avoids TOCTOU between SELECT and DELETE
           env.DB.batch([
@@ -219,6 +226,9 @@ export default {
           // No-ops when R2_BUCKET is unbound.
           processPendingDumps(env),
           purgeExpiredDumps(env),
+          // One-off Issue #142 backfill. It stops after COMPLETED_KEY is set
+          // and skips user/date pairs that already have hourly rows.
+          backfillHourlySummaries(env.DB),
         ]);
 
         // Clean up KV cache for deleted sessions
@@ -229,6 +239,9 @@ export default {
           }
         }
 
+        if (aggregationResult?.status === "rejected") {
+          console.error("Heartbeat aggregation failed:", aggregationResult.reason);
+        }
         if (purgeResult?.status === "rejected") {
           console.error("Heartbeat purge failed:", purgeResult.reason);
         }
@@ -237,6 +250,18 @@ export default {
         }
         if (dumpPurgeResult?.status === "rejected") {
           console.error("Data dump purge failed:", dumpPurgeResult.reason);
+        }
+        if (hourlyBackfillResult?.status === "fulfilled") {
+          const result = hourlyBackfillResult.value;
+          if (result.insertedRows > 0) {
+            console.log(
+              `Hourly summaries backfill inserted ${result.insertedRows} rows ` +
+                `through cursor ${result.cursor}` +
+                (result.earliestDate ? `; earliest backfilled date ${result.earliestDate}` : ""),
+            );
+          }
+        } else if (hourlyBackfillResult?.status === "rejected") {
+          console.error("Hourly summaries backfill failed:", hourlyBackfillResult.reason);
         }
       })(),
     );

--- a/tests/aggregation/hourly-backfill.test.ts
+++ b/tests/aggregation/hourly-backfill.test.ts
@@ -9,11 +9,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { backfillHourlySummaries } from "../../src/cron/hourly-backfill";
 import { seedUser, truncate } from "../helpers/fixtures";
 
-async function seedHeartbeat(userId: string, epochSeconds: number): Promise<void> {
+async function seedHeartbeat(userId: string, epochSeconds: number, id = crypto.randomUUID()): Promise<void> {
   await env.DB.prepare(
     `INSERT INTO heartbeats (id, user_id, entity, time) VALUES (?, ?, ?, ?)`,
   )
-    .bind(crypto.randomUUID(), userId, "src/main.ts", epochSeconds)
+    .bind(id, userId, "src/main.ts", epochSeconds)
     .run();
 }
 
@@ -110,6 +110,33 @@ describe("backfillHourlySummaries", () => {
     expect(second.status).toBe("complete");
     expect(await hourlyRows(user.userId)).toEqual([
       { date: "2026-05-01", hour: 13, total_seconds: 900 },
+    ]);
+  });
+
+  it("does not skip heartbeats that share the chunk-boundary timestamp", async () => {
+    const userA = await seedUser({ username: "backfill_tie_a", timezone: "UTC" });
+    const userB = await seedUser({ username: "backfill_tie_b", timezone: "UTC" });
+    const base = Date.UTC(2026, 4, 1, 14, 0, 0) / 1000;
+
+    await seedHeartbeat(userA.userId, base, "a-100");
+    await seedHeartbeat(userB.userId, base, "b-100");
+    await seedHeartbeat(userA.userId, base + 100, "a-200");
+    await seedHeartbeat(userB.userId, base + 100, "b-200");
+    await seedHeartbeat(userB.userId, base + 200, "b-300");
+    await setMeta("last_aggregated_at", String(base + 200));
+
+    const first = await backfillHourlySummaries(env.DB, 3);
+    expect(first.status).toBe("processed");
+    expect(first.cursor).toBe(base + 100);
+
+    const second = await backfillHourlySummaries(env.DB, 3);
+    expect(second.status).toBe("complete");
+
+    expect(await hourlyRows(userA.userId)).toEqual([
+      { date: "2026-05-01", hour: 14, total_seconds: 100 },
+    ]);
+    expect(await hourlyRows(userB.userId)).toEqual([
+      { date: "2026-05-01", hour: 14, total_seconds: 200 },
     ]);
   });
 

--- a/tests/aggregation/hourly-backfill.test.ts
+++ b/tests/aggregation/hourly-backfill.test.ts
@@ -1,0 +1,129 @@
+/**
+ * One-off hourly_summaries backfill tests (Issue #142).
+ *
+ * The backfill derives hour-of-day rows from retained raw heartbeats, but never
+ * adds to dates that already have hourly rows.
+ */
+import { env } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import { backfillHourlySummaries } from "../../src/cron/hourly-backfill";
+import { seedUser, truncate } from "../helpers/fixtures";
+
+async function seedHeartbeat(userId: string, epochSeconds: number): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO heartbeats (id, user_id, entity, time) VALUES (?, ?, ?, ?)`,
+  )
+    .bind(crypto.randomUUID(), userId, "src/main.ts", epochSeconds)
+    .run();
+}
+
+async function setMeta(key: string, value: string): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+  )
+    .bind(key, value)
+    .run();
+}
+
+async function hourlyRows(userId: string): Promise<{ date: string; hour: number; total_seconds: number }[]> {
+  const { results } = await env.DB.prepare(
+    `SELECT date, hour, total_seconds
+       FROM hourly_summaries
+       WHERE user_id = ?
+       ORDER BY date, hour`,
+  )
+    .bind(userId)
+    .all<{ date: string; hour: number; total_seconds: number }>();
+  return results;
+}
+
+async function metaValue(key: string): Promise<string | null> {
+  const row = await env.DB.prepare("SELECT value FROM meta WHERE key = ?").bind(key).first<{ value: string }>();
+  return row?.value ?? null;
+}
+
+afterEach(async () => {
+  await truncate("hourly_backfill_dates", "hourly_summaries", "heartbeats", "meta", "users");
+});
+
+describe("backfillHourlySummaries", () => {
+  it("waits until the normal aggregation cursor exists", async () => {
+    const result = await backfillHourlySummaries(env.DB);
+    expect(result).toEqual({ status: "waiting", scannedHeartbeats: 0, insertedRows: 0, cursor: 0 });
+  });
+
+  it("backfills missing hourly dates and is idempotent", async () => {
+    const user = await seedUser({ username: "backfill_utc", timezone: "UTC" });
+    const date1 = Date.UTC(2026, 2, 1, 9, 0, 0) / 1000;
+    const date2 = Date.UTC(2026, 2, 2, 11, 0, 0) / 1000;
+
+    await seedHeartbeat(user.userId, date1);
+    await seedHeartbeat(user.userId, date1 + 600);
+    await seedHeartbeat(user.userId, date1 + 1200);
+    await seedHeartbeat(user.userId, date2);
+    await seedHeartbeat(user.userId, date2 + 600);
+
+    await env.DB.prepare(
+      "INSERT INTO hourly_summaries (user_id, date, hour, total_seconds) VALUES (?, '2026-03-02', 11, 999)",
+    )
+      .bind(user.userId)
+      .run();
+    await setMeta("last_aggregated_at", String(date2 + 600));
+
+    const result = await backfillHourlySummaries(env.DB, 100);
+    expect(result.status).toBe("complete");
+    expect(result.scannedHeartbeats).toBe(5);
+    expect(result.insertedRows).toBe(1);
+    expect(result.earliestDate).toBe("2026-03-01");
+    expect(await metaValue("hourly_backfill_earliest_date")).toBe("2026-03-01");
+    expect(await metaValue("hourly_backfill_completed_at")).toBeTruthy();
+
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-03-01", hour: 9, total_seconds: 1200 },
+      { date: "2026-03-02", hour: 11, total_seconds: 999 },
+    ]);
+
+    const rerun = await backfillHourlySummaries(env.DB, 100);
+    expect(rerun.status).toBe("skipped");
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-03-01", hour: 9, total_seconds: 1200 },
+      { date: "2026-03-02", hour: 11, total_seconds: 999 },
+    ]);
+  });
+
+  it("continues across chunks with a lookback heartbeat", async () => {
+    const user = await seedUser({ username: "backfill_chunked", timezone: "UTC" });
+    const base = Date.UTC(2026, 4, 1, 13, 0, 0) / 1000;
+    for (const offset of [0, 300, 600, 900]) {
+      await seedHeartbeat(user.userId, base + offset);
+    }
+    await setMeta("last_aggregated_at", String(base + 900));
+
+    const first = await backfillHourlySummaries(env.DB, 3);
+    expect(first.status).toBe("processed");
+    expect(first.cursor).toBe(base + 600);
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-05-01", hour: 13, total_seconds: 600 },
+    ]);
+
+    const second = await backfillHourlySummaries(env.DB, 3);
+    expect(second.status).toBe("complete");
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-05-01", hour: 13, total_seconds: 900 },
+    ]);
+  });
+
+  it("uses the user's profile timezone for backfilled dates and hours", async () => {
+    const user = await seedUser({ username: "backfill_jst", timezone: "Asia/Tokyo" });
+    const t0 = Date.UTC(2026, 2, 13, 23, 0, 0) / 1000;
+    await seedHeartbeat(user.userId, t0);
+    await seedHeartbeat(user.userId, t0 + 600);
+    await setMeta("last_aggregated_at", String(t0 + 600));
+
+    await backfillHourlySummaries(env.DB, 100);
+
+    expect(await hourlyRows(user.userId)).toEqual([
+      { date: "2026-03-14", hour: 8, total_seconds: 600 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a bounded one-off hourly_summaries backfill that runs from the existing hourly cron.
- Reuse the normal aggregation duration logic, timezone bucketing, and last_aggregated_at safety boundary.
- Track progress with hourly_backfill_cursor/completed meta keys and a hourly_backfill_dates marker table so chunks can continue safely without adding to cron-populated dates.
- Document the operator behavior, re-run procedure, and new migration.

## Why

The hours insight was forward-only after hourly_summaries was introduced. Existing retained raw heartbeats can safely fill historical hour buckets, but request-time backfill would be too expensive and naive UPSERTs could double-count.

## Validation

- npm run typecheck
- npm test -- tests/aggregation/hourly-backfill.test.ts tests/aggregation/hourly-aggregate.test.ts
- npm test
- npm run lint:api
- git diff --check

Closes #142.