### PR TITLE
[codex] polish public activity cards

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 re4lity
+Copyright (c) 2026 CloudTime contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -20,7 +20,7 @@ It assumes you have a Cloudflare account and Node.js 22+ on the workstation.
 ## 2. Clone and install
 
 ```powershell
-git clone https://github.com/sudolifeagain/cloudtime.git
+git clone https://github.com/<owner>/cloudtime.git
 cd cloudtime
 npm ci
 ```

--- a/src/utils/cards/data.ts
+++ b/src/utils/cards/data.ts
@@ -49,6 +49,7 @@ export interface LanguagesCardData {
 // a contribution-graph layout.
 const HEATMAP_WEEKS = 53;
 const STREAK_DAYS = 365;
+const UNKNOWN_LANGUAGE = "Unknown";
 
 export interface CardRange {
   key: string;
@@ -246,6 +247,7 @@ async function loadLanguageShares(
   const languageTotals = await loadLanguageTotals(db, userId, startStr, todayStr);
   const todayLanguageTotals = await computeTodayLanguageSeconds(db, userId, tz, todayStr, timeoutMinutes);
   for (const [language, seconds] of todayLanguageTotals) {
+    if (language === UNKNOWN_LANGUAGE) continue;
     languageTotals.set(language, (languageTotals.get(language) ?? 0) + seconds);
   }
 
@@ -293,10 +295,10 @@ async function loadLanguageTotals(
 ): Promise<Map<string, number>> {
   const { results } = await db
     .prepare(
-      `SELECT COALESCE(NULLIF(language, ''), 'Unknown') AS language, SUM(total_seconds) AS seconds
+      `SELECT language, SUM(total_seconds) AS seconds
        FROM summaries
-       WHERE user_id = ? AND date >= ? AND date < ?
-       GROUP BY COALESCE(NULLIF(language, ''), 'Unknown')`,
+       WHERE user_id = ? AND date >= ? AND date < ? AND language IS NOT NULL AND language != ''
+       GROUP BY language`,
     )
     .bind(userId, startStr, endExclusiveStr)
     .all<{ language: string; seconds: number | null }>();
@@ -304,7 +306,7 @@ async function loadLanguageTotals(
   const languageTotals = new Map<string, number>();
   for (const row of results) {
     const seconds = Number(row.seconds ?? 0);
-    if (seconds > 0) languageTotals.set(row.language, seconds);
+    if (row.language !== UNKNOWN_LANGUAGE && seconds > 0) languageTotals.set(row.language, seconds);
   }
   return languageTotals;
 }
@@ -374,7 +376,7 @@ async function computeTodayLanguageSeconds(
     const prev = results[i - 1];
     const gap = results[i].time - prev.time;
     if (gap <= 0 || gap > timeout) continue;
-    const language = prev.language && prev.language.length > 0 ? prev.language : "Unknown";
+    const language = prev.language && prev.language.length > 0 ? prev.language : UNKNOWN_LANGUAGE;
     totals.set(language, (totals.get(language) ?? 0) + gap);
   }
   return totals;

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -134,6 +134,7 @@ export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
   let cells = "";
   let monthLabels = "";
   let lastMonth = -1;
+  let lastMonthLabelX = -Infinity;
   for (let i = 0; i < totalDays; i++) {
     const dt = new Date(startMs + i * 86400000);
     const dateStr = `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`;
@@ -145,11 +146,14 @@ export function renderHeatmapSvg(opts: HeatmapRenderOptions): string {
     const x = LEFT + col * STEP;
     const y = TOP + row * STEP;
     cells += `<rect x="${x}" y="${y}" width="${CELL}" height="${CELL}" rx="2" ry="2" fill="${fill}"><title>${dateStr}: ${escapeXml(formatHumanReadable(secs))}</title></rect>`;
-    if (row === 0) {
+    if (dt.getUTCDate() === 1) {
       const month = dt.getUTCMonth();
       if (month !== lastMonth) {
         lastMonth = month;
-        monthLabels += `<text x="${x}" y="${TOP - 8}" class="lbl">${MONTHS[month]}</text>`;
+        if (x - lastMonthLabelX >= 32) {
+          monthLabels += `<text x="${x}" y="${TOP - 8}" class="lbl">${MONTHS[month]}</text>`;
+          lastMonthLabelX = x;
+        }
       }
     }
   }

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -191,6 +191,11 @@ describe("embeddable cards — public visibility", () => {
       .bind(user.userId, formatUtcDate(-1), 3600)
       .run();
     await env.DB.prepare(
+      "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', '', ?)",
+    )
+      .bind(user.userId, formatUtcDate(-1), 10800)
+      .run();
+    await env.DB.prepare(
       "INSERT INTO summaries (user_id, date, project, language, total_seconds) VALUES (?, ?, 'cards', 'Go', ?)",
     )
       .bind(user.userId, formatUtcDate(-8), 1800)
@@ -201,9 +206,10 @@ describe("embeddable cards — public visibility", () => {
     expect(summary.headers.get("Content-Type")).toContain("image/svg+xml");
     const summarySvg = await summary.text();
     expect(summarySvg).toContain("Coding summary in the last 7 days");
-    expect(summarySvg).toContain("3 hrs");
-    expect(summarySvg).toContain(`${bestDay} / 2 hrs`);
+    expect(summarySvg).toContain("6 hrs");
+    expect(summarySvg).toContain(`${formatUtcDate(-1)} / 4 hrs`);
     expect(summarySvg).toContain("TypeScript / 67%");
+    expect(summarySvg).not.toContain("Unknown");
     expect(summarySvg).not.toContain(user.apiKey);
 
     const languages = await call(`/api/v1/users/${user.username}/cards/languages.svg?range=last_7_days`);
@@ -214,6 +220,7 @@ describe("embeddable cards — public visibility", () => {
     expect(languagesSvg).toContain("67%");
     expect(languagesSvg).toContain("Markdown");
     expect(languagesSvg).toContain("33%");
+    expect(languagesSvg).not.toContain("Unknown");
     expect(languagesSvg).not.toContain("Go");
 
     const fallback = await call(`/api/v1/users/${user.username}/cards/languages.svg?range=not_supported`);
@@ -222,6 +229,7 @@ describe("embeddable cards — public visibility", () => {
     expect(fallbackSvg).toContain("Top languages in the last year");
     expect(fallbackSvg).toContain("Go");
     expect(fallbackSvg).toContain("3 hrs 30 mins total coding time");
+    expect(fallbackSvg).not.toContain("Unknown");
   });
 
   it("applies built-in themes and falls back to default for unknown themes", async () => {

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -58,6 +58,17 @@ describe("renderHeatmapSvg", () => {
     expect(svg).toContain(`<title>${day}: 8 hrs`);
   });
 
+  it("does not crowd adjacent month labels at the range boundary", () => {
+    const svg = renderHeatmapSvg({
+      username: "alice",
+      dayTotals: new Map(),
+      todayStr: "2026-07-04",
+      totalSeconds: 0,
+    });
+    const firstMonthLabel = svg.match(/<text x="\d+" y="26" class="lbl">([A-Z][a-z]{2})<\/text>/)?.[1];
+    expect(firstMonthLabel).toBe("Jul");
+  });
+
   it("emits only a safe static subset (no script/foreignObject/href)", () => {
     const svg = renderHeatmapSvg({
       username: "a",


### PR DESCRIPTION
## Summary

- Remove personal repository references from public OSS-facing files
- Hide unknown-language buckets from public language cards
- Improve heatmap month label spacing at range boundaries

## Validation

- npm test -- tests/unit/cards-render.test.ts tests/integration/embeddable-cards.test.ts
- npm run typecheck
- npm run lint:api
- npm test