### PR TITLE
[codex] clarify CloudTime streak card copy

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -334,7 +334,7 @@ token. They look like:
 ![CloudTime heatmap](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/heatmap.svg?theme=default)
 ![CloudTime summary](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/summary.svg?theme=default)
 ![CloudTime languages](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/languages.svg?theme=default)
-![CloudTime streak](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?theme=default)
+![CloudTime coding activity streak](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/streak.svg?theme=default)
 ```
 
 Paste the snippets into the root `README.md` of the GitHub profile repository

--- a/src/utils/cards/render.ts
+++ b/src/utils/cards/render.ts
@@ -284,7 +284,7 @@ export function renderStreakSvg(opts: StreakRenderOptions): string {
 
   const title = `@${escapeXml(truncateText(opts.username, 38))}`;
   const totalText = escapeXml(`${formatHumanReadable(opts.totalSeconds)} total coding time`);
-  const ariaLabel = escapeXml(`Coding streak card for ${opts.username}`);
+  const ariaLabel = escapeXml(`CloudTime coding activity streak card for ${opts.username}`);
   const rangeLabel = escapeXml(opts.rangeLabel ?? "the last year");
   const current = escapeXml(formatDays(opts.currentStreak));
   const longest = escapeXml(formatDays(opts.longestStreak));
@@ -295,7 +295,7 @@ export function renderStreakSvg(opts: StreakRenderOptions): string {
     cardStyle(theme) +
     `<rect width="100%" height="100%" rx="8" ry="8" fill="${theme.background}" stroke="${theme.border}"/>` +
     `<text x="${cardPadding}" y="31" class="title">${title}</text>` +
-    `<text x="${cardPadding}" y="52" class="subtitle">Coding streaks in ${rangeLabel}</text>` +
+    `<text x="${cardPadding}" y="52" class="subtitle">CloudTime coding activity streaks in ${rangeLabel}</text>` +
     renderMetric(cardPadding, metricTop, metricWidth, "Current", current, theme.levels[2]) +
     renderMetric(cardPadding + metricWidth + metricGap, metricTop, metricWidth, "Longest", longest, theme.levels[3]) +
     renderMetric(cardPadding + (metricWidth + metricGap) * 2, metricTop, metricWidth, "Active days", active, theme.levels[1]) +

--- a/src/utils/cards/snippets.ts
+++ b/src/utils/cards/snippets.ts
@@ -12,7 +12,7 @@ const PROFILE_CARD_TYPES: Array<{ cardType: ProfileCardType; label: string; altT
   { cardType: "heatmap", label: "Heatmap", altText: "CloudTime heatmap" },
   { cardType: "summary", label: "Summary", altText: "CloudTime summary" },
   { cardType: "languages", label: "Languages", altText: "CloudTime languages" },
-  { cardType: "streak", label: "Streak", altText: "CloudTime streak" },
+  { cardType: "streak", label: "Streak", altText: "CloudTime coding activity streak" },
 ];
 
 export function buildProfileCardSnippets({

--- a/tests/integration/embeddable-cards.test.ts
+++ b/tests/integration/embeddable-cards.test.ts
@@ -102,7 +102,7 @@ describe("embeddable cards — public visibility", () => {
     expect(res.headers.get("ETag")).toBeTruthy();
 
     const svg = await res.text();
-    expect(svg).toContain("Coding streaks in the last year");
+    expect(svg).toContain("CloudTime coding activity streaks in the last year");
     expect(svg).toContain("2 days");
     expect(svg).toContain("1 hr 30 mins total coding time");
     expect(svg).not.toContain(user.apiKey);
@@ -127,14 +127,14 @@ describe("embeddable cards — public visibility", () => {
     expect(res.status).toBe(200);
 
     const svg = await res.text();
-    expect(svg).toContain("Coding streaks in the last 7 days");
+    expect(svg).toContain("CloudTime coding activity streaks in the last 7 days");
     expect(svg).toContain("1 hr total coding time");
     expect(svg).not.toContain("3 hrs total coding time");
 
     const fallback = await call(`/api/v1/users/${user.username}/cards/streak.svg?range=not_supported`);
     expect(fallback.status).toBe(200);
     const fallbackSvg = await fallback.text();
-    expect(fallbackSvg).toContain("Coding streaks in the last year");
+    expect(fallbackSvg).toContain("CloudTime coding activity streaks in the last year");
     expect(fallbackSvg).toContain("3 hrs total coding time");
   });
 

--- a/tests/integration/web-ui.test.ts
+++ b/tests/integration/web-ui.test.ts
@@ -137,7 +137,7 @@ describe("web UI", () => {
     expect(html).toContain("![CloudTime heatmap](https://test.cloudtime.dev/api/v1/users/owner/cards/heatmap.svg?theme=default)");
     expect(html).toContain("![CloudTime summary](https://test.cloudtime.dev/api/v1/users/owner/cards/summary.svg?theme=default)");
     expect(html).toContain("![CloudTime languages](https://test.cloudtime.dev/api/v1/users/owner/cards/languages.svg?theme=default)");
-    expect(html).toContain("![CloudTime streak](https://test.cloudtime.dev/api/v1/users/owner/cards/streak.svg?theme=default)");
+    expect(html).toContain("![CloudTime coding activity streak](https://test.cloudtime.dev/api/v1/users/owner/cards/streak.svg?theme=default)");
     expect(html).not.toContain(user.apiKey);
   });
 

--- a/tests/unit/cards-render.test.ts
+++ b/tests/unit/cards-render.test.ts
@@ -193,7 +193,7 @@ describe("renderStreakSvg", () => {
       totalSeconds: 3600,
       rangeLabel: "the last 7 days",
     });
-    expect(svg).toContain("Coding streaks in the last 7 days");
+    expect(svg).toContain("CloudTime coding activity streaks in the last 7 days");
   });
 
   it("escapes the username to prevent markup injection", () => {

--- a/tests/unit/cards-snippets.test.ts
+++ b/tests/unit/cards-snippets.test.ts
@@ -20,7 +20,7 @@ describe("profile card snippets", () => {
       "![CloudTime languages](https://cloudtime.example.test/api/v1/users/alice/cards/languages.svg?theme=default)",
     );
     expect(snippets[3].markdown).toBe(
-      "![CloudTime streak](https://cloudtime.example.test/api/v1/users/alice/cards/streak.svg?theme=default)",
+      "![CloudTime coding activity streak](https://cloudtime.example.test/api/v1/users/alice/cards/streak.svg?theme=default)",
     );
   });
 


### PR DESCRIPTION
## Summary

- Clarify the public streak card subtitle as CloudTime coding activity
- Update generated profile snippet alt text and deployment docs to use the same wording
- Update renderer and integration test expectations for the new copy

## Validation

- npm test -- tests/unit/cards-render.test.ts tests/unit/cards-snippets.test.ts tests/integration/embeddable-cards.test.ts tests/integration/web-ui.test.ts
- npm run typecheck