### PR TITLE
[codex] specify profile badges and composite card

### DIFF
--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -96,6 +96,8 @@ paths:
     $ref: paths/users/data-dumps.yaml
   /users/{username}/cards/{card_type}.svg:
     $ref: paths/cards/public-card.yaml
+  /users/{username}/badges/{badge_type}.svg:
+    $ref: paths/cards/public-badge.yaml
   /users/current/embed_settings:
     $ref: paths/cards/embed-settings.yaml
   /users/current/embed_templates:

--- a/schemas/paths/cards/public-badge.yaml
+++ b/schemas/paths/cards/public-badge.yaml
@@ -1,0 +1,122 @@
+get:
+  operationId: getEmbeddableBadge
+  tags:
+    - embeddable_cards
+  summary: Render a public embeddable profile badge
+  description: |
+    Returns a small SVG badge suitable for embedding in a GitHub profile README
+    or other Markdown surfaces that display remote images. This operation is
+    intentionally public (`security: []`) and MUST NOT require or accept an API
+    key in the URL.
+
+    The target user is selected by a non-secret username. If embeds are
+    disabled for that user, the user does not exist, or the requested metric is
+    unavailable, the response is `404` and no cached badge image is served.
+
+    Successful responses include explicit cache headers derived from the user's
+    freshness window. The optional `v` parameter participates in cache keys so a
+    user can force a refetch, but it never changes badge data or visibility.
+
+    Badge rendering uses original CloudTime copy and visual design. The
+    generated SVG MUST expose an accessible image name matching the Markdown alt
+    text guidance for informative images.
+  security: []
+  parameters:
+    - name: username
+      in: path
+      required: true
+      description: Public CloudTime username identifying the badge owner.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 64
+    - name: badge_type
+      in: path
+      required: true
+      description: Badge metric to render.
+      schema:
+        type: string
+        enum:
+          - coding_time
+          - top_language
+          - current_streak
+          - goal_progress
+    - name: range
+      in: query
+      required: false
+      description: |
+        Optional range for range-aware badges. `coding_time` defaults to
+        `today`; `top_language` defaults to `last_7_days`; `current_streak` and
+        `goal_progress` ignore this parameter.
+      schema:
+        type: string
+        enum:
+          - today
+          - last_7_days
+          - last_30_days
+          - last_6_months
+          - last_year
+          - all_time
+    - name: goal_id
+      in: query
+      required: false
+      description: |
+        Optional goal identifier for the `goal_progress` badge. When omitted,
+        the first enabled, non-snoozed goal ordered by creation time is used.
+      schema:
+        type: string
+        format: uuid
+    - name: label
+      in: query
+      required: false
+      description: Optional short label override for the left side of the badge.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 24
+    - name: theme
+      in: query
+      required: false
+      description: Built-in visual theme. Unknown themes fall back to the user's default theme.
+      schema:
+        type: string
+        maxLength: 32
+        pattern: ^[a-zA-Z0-9_-]+$
+    - name: style
+      in: query
+      required: false
+      description: Optional badge shape style.
+      schema:
+        type: string
+        enum:
+          - flat
+          - pill
+    - name: v
+      in: query
+      required: false
+      description: Optional cache-busting value. Changes the cache key only.
+      schema:
+        type: string
+        maxLength: 64
+  responses:
+    '200':
+      description: SVG badge image
+      headers:
+        Cache-Control:
+          description: Public cache policy derived from the user's freshness window.
+          schema:
+            type: string
+        ETag:
+          description: Entity tag for the rendered SVG.
+          schema:
+            type: string
+      content:
+        image/svg+xml:
+          schema:
+            type: string
+    '400':
+      $ref: ../../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+    '429':
+      $ref: ../../components/responses/TooManyRequests.yaml

--- a/schemas/paths/cards/public-card.yaml
+++ b/schemas/paths/cards/public-card.yaml
@@ -4,9 +4,10 @@ get:
     - embeddable_cards
   summary: Render a public embeddable stats card
   description: |
-    Returns an SVG image suitable for embedding in a GitHub README or any
-    page that displays remote images. This operation is intentionally public
-    (`security: []`) and MUST NOT require or accept an API key in the URL.
+    Returns an SVG image suitable for embedding in a GitHub profile README or
+    any page that displays remote images. This operation is intentionally
+    public (`security: []`) and MUST NOT require or accept an API key in the
+    URL.
 
     The target user is selected by a non-secret username. If embeds are
     disabled for that user, the user does not exist, or the requested template
@@ -16,6 +17,11 @@ get:
     user's freshness window. The optional `v` parameter participates in cache
     keys so a user can force a refetch, but it never changes card data or
     visibility.
+
+    The `profile` card type is a composite image for personal profile READMEs.
+    It combines several CloudTime-owned metrics into one original SVG surface.
+    The optional `metrics` and `layout` query parameters apply only to the
+    composite profile card; unsupported metric names return `400`.
   security: []
   parameters:
     - name: username
@@ -37,6 +43,7 @@ get:
           - summary
           - languages
           - streak
+          - profile
     - name: range
       in: query
       required: false
@@ -59,6 +66,38 @@ get:
       schema:
         type: string
         format: uuid
+    - name: metrics
+      in: query
+      required: false
+      style: form
+      explode: false
+      description: |
+        Optional comma-separated metric list for the `profile` composite card.
+        Omit to use the server default. Repeated, unknown, or unsupported metric
+        names return `400`.
+      schema:
+        type: array
+        minItems: 1
+        maxItems: 8
+        uniqueItems: true
+        items:
+          type: string
+          enum:
+            - today
+            - week
+            - all_time
+            - top_language
+            - current_streak
+            - goal_progress
+    - name: layout
+      in: query
+      required: false
+      description: Optional layout for the `profile` composite card.
+      schema:
+        type: string
+        enum:
+          - default
+          - compact
     - name: v
       in: query
       required: false

--- a/specs/198-profile-card-expansion/checklists/requirements.md
+++ b/specs/198-profile-card-expansion/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Requirements Checklist: Profile Badge and Composite Card Expansion
+
+## Specification Quality
+
+- [x] User stories are independently testable.
+- [x] Functional requirements are numbered and verifiable.
+- [x] Public privacy behavior is explicit.
+- [x] Accessibility requirements are explicit.
+- [x] Cache behavior is explicit.
+- [x] Legal/implementation boundaries are referenced.
+- [x] Team and multi-user work is out of scope.
+- [x] PR1 excludes implementation code.
+
+## Contract Coverage
+
+- [x] Badge endpoint path is defined.
+- [x] Badge path/query parameters are bounded.
+- [x] Badge response headers are defined.
+- [x] Profile card type is defined.
+- [x] Profile metric selection is bounded.
+- [x] Error behavior covers `400`, `404`, and `429`.
+- [x] Existing card types remain unchanged.
+
+## Research Coverage
+
+- [x] GitHub README image syntax checked against official GitHub Docs.
+- [x] Profile README behavior checked against official GitHub Docs.
+- [x] Alt text guidance checked against W3C WAI.
+- [x] SVG accessible name guidance checked against MDN.
+- [x] Cache headers checked against MDN and Cloudflare docs.
+- [x] No third-party source code or visual assets consulted.

--- a/specs/198-profile-card-expansion/contracts/openapi-diff.md
+++ b/specs/198-profile-card-expansion/contracts/openapi-diff.md
@@ -1,0 +1,52 @@
+# OpenAPI Diff: Profile Badge and Composite Card Expansion
+
+## Added Path
+
+### `GET /users/{username}/badges/{badge_type}.svg`
+
+Public, unauthenticated SVG badge endpoint.
+
+Path parameters:
+
+- `username`: public CloudTime username, 1-64 chars.
+- `badge_type`: one of `coding_time`, `top_language`, `current_streak`,
+  `goal_progress`.
+
+Query parameters:
+
+- `range`: optional enum `today`, `last_7_days`, `last_30_days`,
+  `last_6_months`, `last_year`, `all_time`.
+- `goal_id`: optional UUID for `goal_progress`.
+- `label`: optional 1-24 char label override.
+- `theme`: optional built-in theme name.
+- `style`: optional enum `flat`, `pill`.
+- `v`: optional cache-busting value that changes only the cache key.
+
+Responses:
+
+- `200 image/svg+xml` with `Cache-Control` and `ETag`.
+- `400 BadRequest`.
+- `404 NotFound`.
+- `429 TooManyRequests`.
+
+## Changed Path
+
+### `GET /users/{username}/cards/{card_type}.svg`
+
+Changes:
+
+- Adds `profile` to the `card_type` enum.
+- Adds optional `metrics` query for the `profile` composite card.
+- Adds optional `layout` query for the `profile` composite card.
+- Clarifies GitHub profile README use and cache/visibility behavior.
+
+The existing `heatmap`, `summary`, `languages`, and `streak` card types remain
+unchanged.
+
+## Generated Types
+
+After `npm run generate`, TypeScript clients receive:
+
+- new `getEmbeddableBadge` operation types
+- updated `getEmbeddableCard` `card_type` enum including `profile`
+- typed `metrics` and `layout` query fields for profile cards

--- a/specs/198-profile-card-expansion/data-model.md
+++ b/specs/198-profile-card-expansion/data-model.md
@@ -1,0 +1,67 @@
+# Data Model: Profile Badge and Composite Card Expansion
+
+PR1 does not add database tables or migrations. The following are contract-level
+entities for PR2 implementation.
+
+## ProfileBadgeRequest
+
+Represents a public badge image request.
+
+| Field | Type | Source | Validation |
+|---|---|---|---|
+| username | string | path | 1-64 chars |
+| badge_type | enum | path | `coding_time`, `top_language`, `current_streak`, `goal_progress` |
+| range | enum | query | optional; `today`, `last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `all_time` |
+| goal_id | uuid | query | optional; applies to `goal_progress` |
+| label | string | query | optional; 1-24 chars |
+| theme | string | query | optional; same theme rules as cards |
+| style | enum | query | optional; `flat`, `pill` |
+| v | string | query | optional; cache key only |
+
+## ProfileCardRequest
+
+Extends the existing public card request when `card_type=profile`.
+
+| Field | Type | Source | Validation |
+|---|---|---|---|
+| username | string | path | 1-64 chars |
+| card_type | enum | path | includes `profile` |
+| metrics | enum array | query | optional; 1-8 unique items |
+| layout | enum | query | optional; `default`, `compact` |
+| theme | string | query | optional; same theme rules as cards |
+| template_id | uuid | query | optional; same ownership rules as cards |
+| v | string | query | optional; cache key only |
+
+## ProfileMetric
+
+Metric sections supported by the profile composite card.
+
+| Metric | Description | Initial data source |
+|---|---|---|
+| today | Coding time for the user's current local day | summaries + bounded current-day heartbeat overlay |
+| week | Coding time for the trailing 7 days | summaries + bounded current-day heartbeat overlay |
+| all_time | Total CloudTime coding time | existing all-time/summaries semantics |
+| top_language | Top language for the selected/default range | summaries |
+| current_streak | Current CloudTime tracked-day streak | summaries + bounded current-day heartbeat overlay |
+| goal_progress | Progress for a selected/default enabled goal | goals + summaries |
+
+## Cache Keys
+
+PR2 should use separate cache namespaces/prefixes for badges and profile cards.
+Cache keys must include:
+
+- route kind (`badge` or `card`)
+- user id or username
+- badge/card type
+- normalized theme/style/layout
+- normalized range/metrics/goal id/label/template id
+- freshness window
+- optional `v`
+
+## Privacy Rules
+
+- Missing user, disabled embeds, unavailable goal/template, or unsupported
+  metric data returns `404`.
+- Invalid request shape returns `400`.
+- Disabled embeds return before cache lookup and before aggregate data reads.
+- No public request may include an API key or session credential.

--- a/specs/198-profile-card-expansion/plan.md
+++ b/specs/198-profile-card-expansion/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Profile Badge and Composite Card Expansion
+
+**Branch**: `198-profile-card-expansion` | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
+**Input**: GitHub Issue #198
+
+## Summary
+
+Extend CloudTime's public image surface for individual users with focused SVG
+badges and one composite `profile` card. Badges live at
+`GET /users/{username}/badges/{badge_type}.svg`; the composite card extends the
+existing public card route with `card_type=profile`. Both surfaces reuse the
+existing embed visibility/freshness model, public non-secret URLs, explicit
+cache headers, and original CloudTime visual language.
+
+**PR1 (this PR)**: SpecKit artifacts, OpenAPI path/parameter changes, and
+regenerated types. **No route handlers, renderers, migrations, UI changes, or
+docs behavior changes.**
+
+**PR2 (after PR1 merges)**: badge/profile data builders, SVG renderers, cache
+keys, route wiring, dashboard snippets, and tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022, Cloudflare Workers)
+**Primary Dependencies**: Hono >= 4.9.7; existing generated OpenAPI types;
+existing D1/KV bindings. No new dependency is planned for fixed SVG badges or
+the composite card.
+**Storage**: no new tables in PR1. PR2 should reuse `embed_settings`, `goals`,
+`summaries`, and bounded current-day heartbeat reads. KV cache entries should be
+separate for badges and profile cards.
+**Testing**: Vitest + workers pool. PR2 should cover public visibility,
+invalid query parameters, cache headers, badge fallback/default behavior,
+accessible SVG names, snippet secrecy, and cross-user isolation.
+**Performance Goals**: Public image cache hits return from KV. Cache misses read
+pre-aggregated summaries and bounded current-day data only. Disabled embeds
+return before cache lookup or data reads.
+**Constraints**: GitHub profile README images are public remote images; snippets
+must use standard Markdown image syntax with meaningful alt text and no
+credentials. SVG images must be accessible and static. Public image cache
+semantics should remain explicit with `Cache-Control` and `ETag`.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SDD | PASS | PR1 updates OpenAPI before implementation and regenerates types. |
+| II. Cloudflare-Native | PASS | PR2 reuses KV/D1 and bounded aggregate reads; no server-side image dependency. |
+| III. Type Safety | PASS | New contracts are generated from OpenAPI. |
+| IV. Legal/Trademark | PASS | Designs, labels, and docs are CloudTime-original; research uses official public docs only. |
+| V. Simplicity First | PASS | Four badge types plus one composite card; team features and integrations deferred. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/198-profile-card-expansion/
+|-- plan.md
+|-- spec.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- tasks.md
+|-- contracts/
+|   `-- openapi-diff.md
+`-- checklists/
+    `-- requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+# PR1
+schemas/openapi.yaml                    # CHANGE: add public badge path ref
+schemas/paths/cards/public-card.yaml    # CHANGE: add profile card type and params
+schemas/paths/cards/public-badge.yaml   # ADD: public SVG badge operation
+src/types/generated.ts                  # REGENERATED
+
+# PR2 (after PR1 merges)
+src/routes/cards.ts                     # CHANGE: badge route + profile card branch
+src/utils/cards/data.ts                 # CHANGE: badge/profile metric data helpers
+src/utils/cards/render.ts               # CHANGE: badge/profile SVG renderers
+src/utils/cards/cache.ts                # CHANGE: badge/profile cache keys
+src/utils/cards/snippets.ts             # CHANGE: Markdown snippets for new images
+src/ui/settings.tsx                     # CHANGE: settings snippets/previews
+tests/unit/cards-render.test.ts         # CHANGE: renderer tests
+tests/unit/cards-snippets.test.ts       # CHANGE: snippet tests
+tests/integration/embeddable-cards.test.ts # CHANGE: route/privacy/cache tests
+docs/deployment-guide.md                # CHANGE: operator/user usage docs
+```
+
+**Structure Decision**: Add badges as a new public route rather than overloading
+the card route. Add `profile` as a new `card_type` because it is visually and
+semantically a card, not a one-metric badge. Reuse one route module in PR2 so
+visibility, rate-limit, cache, and username lookup behavior remain shared.
+
+## Phases
+
+- **PR1 - Spec + Design**: create this SpecKit set; update OpenAPI contract;
+  run `npm run generate`; run `npm run lint:api` and `npm run typecheck`;
+  open a draft PR against `develop`.
+- **PR2 - Implementation**: add route/render/data/cache/snippet logic and tests;
+  update user docs; run `npm run typecheck && npm test`; open PR referencing
+  #198 and PR1.
+
+## Risks & Mitigations
+
+- **Secret leakage in snippets** -> snippets are built only from public username
+  and app base URL; tests assert no API/session/OAuth token appears.
+- **Private profile probed through cache** -> disabled embeds return `404`
+  before cache lookup, matching existing card privacy behavior.
+- **Badge/card cache keys collide** -> PR2 uses route kind, username, metric,
+  normalized query options, template/theme, and freshness window in cache keys.
+- **Metrics query becomes too flexible** -> PR1 limits metric names and item
+  count; invalid names and duplicates are `400`.
+- **GitHub proxy freshness differs from CloudTime TTL** -> keep
+  `Cache-Control`, `ETag`, and `v` cache-busting behavior in the contract.
+- **Accessible image names drift from Markdown alt text** -> renderer and
+  snippet tests assert meaningful names for badges and profile cards.
+- **All-time reads become expensive** -> PR2 may compute from summaries and
+  cache aggressively; no raw full-history scan is required by the contract.

--- a/specs/198-profile-card-expansion/quickstart.md
+++ b/specs/198-profile-card-expansion/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Profile Badge and Composite Card Expansion
+
+This quickstart describes the expected behavior after PR2 implementation. PR1
+only defines the contract.
+
+## Enable Public Embeds
+
+From the authenticated dashboard, enable public profile cards in the GitHub
+profile cards settings section. Public image URLs must remain non-secret.
+
+## Badge Examples
+
+```markdown
+![CloudTime today](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/badges/coding_time.svg?range=today&theme=default)
+![CloudTime this week](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/badges/coding_time.svg?range=last_7_days&theme=default)
+![CloudTime top language](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/badges/top_language.svg?range=last_7_days&theme=default)
+![CloudTime current streak](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/badges/current_streak.svg?theme=default)
+![CloudTime goal progress](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/badges/goal_progress.svg?theme=default)
+```
+
+## Composite Profile Card Example
+
+```markdown
+![CloudTime profile](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/profile.svg?metrics=today,week,top_language,current_streak&theme=default)
+```
+
+## Force Refresh
+
+Append or update `v` to force a cache-key change when a proxy still serves an
+older image:
+
+```markdown
+![CloudTime profile](https://your-worker.example.com/api/v1/users/YOUR_USERNAME/cards/profile.svg?theme=default&v=20260705)
+```
+
+## Expected Responses
+
+- `200 image/svg+xml`: public embeds enabled and request valid.
+- `400 application/json`: invalid metric, label, UUID, enum, or query shape.
+- `404 application/json`: user missing, public embeds disabled, or requested
+  goal/template unavailable.
+- `429 application/json`: public image rate limit exceeded.
+
+## Validation Commands
+
+```powershell
+npm run generate
+npm run lint:api
+npm run typecheck
+npm test -- tests/unit/cards-render.test.ts tests/unit/cards-snippets.test.ts tests/integration/embeddable-cards.test.ts
+```

--- a/specs/198-profile-card-expansion/research.md
+++ b/specs/198-profile-card-expansion/research.md
@@ -1,0 +1,144 @@
+# Research: Profile Badge and Composite Card Expansion
+
+**Research Date**: 2026-07-05
+**Feature**: Profile badge and composite card expansion
+
+## Sources Consulted
+
+- GitHub Docs - Basic writing and formatting syntax:
+  `https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax`
+- GitHub Docs - Managing your profile README:
+  `https://docs.github.com/en/account-and-profile/how-tos/profile-customization/managing-your-profile-readme`
+- W3C WAI - Informative Images:
+  `https://www.w3.org/WAI/tutorials/images/informative/`
+- W3C WAI - Alt Decision Tree:
+  `https://www.w3.org/WAI/tutorials/images/decision-tree/`
+- MDN - ARIA `img` role:
+  `https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role`
+- MDN - `aria-label`:
+  `https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label`
+- MDN - Cache-Control:
+  `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control`
+- MDN - ETag:
+  `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag`
+- Cloudflare Workers Docs - Cache:
+  `https://developers.cloudflare.com/workers/runtime-apis/cache/`
+- Cloudflare Cache Docs - ETag headers:
+  `https://developers.cloudflare.com/cache/reference/etag-headers/`
+
+No third-party product source code, visual assets, screenshots, or product copy
+were consulted.
+
+## Decision 1: Use standard Markdown image snippets
+
+**Decision**: Dashboard snippets should continue to use standard Markdown image
+syntax: `![alt text](public image URL)`.
+
+**Rationale**: GitHub Docs document Markdown image syntax and require alt text
+as the short text equivalent of the image. Profile READMEs are normal README
+files rendered by GitHub. The current CloudTime snippet approach already matches
+this shape.
+
+**Alternatives considered**:
+
+- HTML `<img>` snippets with width attributes. Rejected for PR1 because it is
+  less portable across Markdown surfaces and unnecessary for fixed-size SVGs.
+
+## Decision 2: Badges get a new route
+
+**Decision**: Add `GET /users/{username}/badges/{badge_type}.svg` for small
+one-metric badges.
+
+**Rationale**: Badges differ from cards in dimensions, layout, metric focus, and
+query options. A separate route keeps the existing card route clear and avoids
+overloading `card_type` with visually different assets.
+
+**Alternatives considered**:
+
+- Add badges as more `card_type` values. Rejected because badge-specific options
+  such as `label` and `style` would clutter the card contract.
+
+## Decision 3: Composite profile card extends existing cards
+
+**Decision**: Add `profile` to the existing `card_type` enum.
+
+**Rationale**: The profile composite is still a card-sized image, shares
+existing card visibility/cache/template behavior, and belongs with the existing
+README card snippets.
+
+**Alternatives considered**:
+
+- Create `/profile.svg`. Rejected because it would duplicate card visibility
+  and cache rules without adding a useful distinction.
+
+## Decision 4: Keep metric selection constrained
+
+**Decision**: `profile.svg` accepts a comma-separated `metrics` query with a
+small enum and max item count. Unknown or duplicate metrics return `400`.
+
+**Rationale**: GitHub image URLs are easiest to copy when options remain compact.
+An enum keeps the route typeable and protects PR2 from arbitrary dynamic layout
+work.
+
+**Alternatives considered**:
+
+- Free-form JSON config in the query string. Rejected due to URL length,
+  readability, cache-key complexity, and validation surface.
+
+## Decision 5: Reuse existing public embed visibility
+
+**Decision**: Badges and the `profile` card reuse existing `embed_settings`.
+
+**Rationale**: The privacy model should remain one switch: public images are
+either enabled or disabled for the user. Adding a second switch would create
+ambiguous states and more UI work without improving privacy.
+
+**Alternatives considered**:
+
+- Separate badge visibility. Deferred until users need independent controls.
+
+## Decision 6: Preserve explicit cache headers and ETags
+
+**Decision**: Badges and profile cards must include `Cache-Control` and `ETag`
+headers, and `v` remains a cache-key-only busting parameter.
+
+**Rationale**: MDN documents `Cache-Control` as the response mechanism for cache
+directives and `ETag` as an entity version identifier useful for efficient
+revalidation. Cloudflare's docs note cache behavior and ETag support in the
+platform. Existing cards already expose this behavior.
+
+**Alternatives considered**:
+
+- No-cache dynamic images. Rejected because profile README traffic can become
+  repetitive and should not force D1 reads per view.
+
+## Decision 7: Accessible SVG names are part of the contract
+
+**Decision**: Generated SVGs must include `role="img"` and a non-empty
+accessible name, and snippets must use meaningful alt text.
+
+**Rationale**: W3C WAI guidance for informative images says text alternatives
+should convey the displayed meaning. MDN documents the ARIA `img` role and
+`aria-label` as ways to give grouped visual content an accessible name.
+
+**Alternatives considered**:
+
+- Rely only on visible SVG text. Rejected because the image may be consumed as a
+  single remote image in Markdown, and the accessible name should be explicit.
+
+## Decision 8: Keep PR1 implementation-free
+
+**Decision**: PR1 includes only SpecKit artifacts, OpenAPI changes, and
+generated types.
+
+**Rationale**: The project uses the two-PR SpecKit workflow. The implementation
+will be easier to review after the badge/profile contract is agreed.
+
+## Open Questions
+
+- Should PR2 expose a `goal_id` picker in the settings UI immediately, or start
+  with deterministic first-goal behavior and document the optional URL
+  parameter?
+- Should `all_time` badge values include external durations, heartbeat coding
+  time only, or both with labels? PR1 leaves the label as CloudTime coding time;
+  PR2 should align with existing all-time stats semantics.

--- a/specs/198-profile-card-expansion/spec.md
+++ b/specs/198-profile-card-expansion/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Profile Badge and Composite Card Expansion
+
+**Feature Branch**: `198-profile-card-expansion`
+**Created**: 2026-07-05
+**Status**: Draft
+**Input**: GitHub Issue #198
+
+## User Stories & Testing
+
+### User Story 1 - Add focused profile badges (Priority: P1)
+
+As a CloudTime owner, I want small SVG badges for focused metrics so that my
+GitHub profile README can show concise, continuously updated coding activity
+without exposing credentials.
+
+**Why this priority**: Badges are the fastest visible improvement for personal
+profile customization. They reuse existing public embed controls and require no
+team or external integration work.
+
+**Independent Test**: With public embeds enabled, request each badge URL and
+verify it returns `200 image/svg+xml`, includes public cache headers, contains a
+non-empty accessible image name, and never includes API keys or session data.
+
+**Acceptance Scenarios**:
+
+1. Given public embeds are enabled, when a user requests
+   `/api/v1/users/alice/badges/coding_time.svg?range=today`, then the response
+   is an SVG badge showing today's CloudTime coding time.
+2. Given public embeds are enabled and the user has language data, when
+   `/badges/top_language.svg?range=last_7_days` is requested, then the badge
+   shows the top language for that range.
+3. Given public embeds are enabled and the user has an enabled goal, when
+   `/badges/goal_progress.svg` is requested without `goal_id`, then the badge
+   uses the first enabled, non-snoozed goal ordered by creation time.
+4. Given public embeds are disabled, when any badge URL is requested, then the
+   response is `404`, no cached image is served, and no private stats are
+   disclosed.
+
+---
+
+### User Story 2 - Add one composite profile card (Priority: P1)
+
+As a CloudTime owner, I want one composite profile card that combines several
+personal metrics so that my README can show a compact dashboard with a single
+image URL.
+
+**Why this priority**: A composite image reduces README clutter and lets users
+show richer personal analytics without relying on multiple images or team
+features.
+
+**Independent Test**: Request
+`/api/v1/users/alice/cards/profile.svg?metrics=today,week,top_language,current_streak`
+and verify that the SVG contains exactly those sections in the requested order,
+uses original CloudTime copy, has a non-empty accessible image name, and shares
+the existing public-card visibility/cache behavior.
+
+**Acceptance Scenarios**:
+
+1. Given public embeds are enabled, when a user requests `cards/profile.svg`
+   without a `metrics` query, then the response uses the default metric set.
+2. Given a valid comma-separated `metrics` query, when the composite profile
+   card is requested, then the response includes the requested metrics in order.
+3. Given an unknown or duplicate metric name, when the composite profile card is
+   requested, then the response is `400`.
+4. Given `layout=compact`, when the composite profile card is requested, then
+   the response uses the compact layout contract while preserving the same data
+   privacy and cache semantics.
+
+---
+
+### User Story 3 - Generate safe Markdown snippets (Priority: P2)
+
+As a CloudTime owner, I want copyable Markdown snippets for badges and the
+profile card so that I can paste them into my profile README without manually
+building URLs.
+
+**Why this priority**: Snippets prevent credential leaks and keep alt text
+consistent with accessibility guidance.
+
+**Independent Test**: In the authenticated dashboard, copy snippets for all new
+badges and the composite card; verify every snippet uses a public URL, has
+meaningful alt text, and contains no API key, session token, OAuth token, or
+secret query parameter.
+
+**Acceptance Scenarios**:
+
+1. Given public embeds are enabled, when the settings page renders snippets,
+   then it includes badge snippets and the composite profile card snippet.
+2. Given public embeds are disabled, when the settings page renders snippets,
+   then it keeps the existing disabled-warning behavior and does not imply that
+   private stats are public.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The API MUST add an unauthenticated public badge endpoint:
+  `GET /api/v1/users/{username}/badges/{badge_type}.svg`.
+- **FR-002**: `badge_type` MUST initially support `coding_time`,
+  `top_language`, `current_streak`, and `goal_progress`.
+- **FR-003**: Badge URLs MUST NOT require or accept API keys, session tokens,
+  OAuth tokens, or other secrets.
+- **FR-004**: Badge rendering MUST respect the existing per-user embed
+  visibility setting; disabled or missing users MUST return `404`.
+- **FR-005**: Badge responses MUST be `image/svg+xml` and include
+  `Cache-Control` and `ETag` headers derived from the user's freshness window.
+- **FR-006**: Badge URLs MUST support `theme`, `style`, `label`, `range`,
+  `goal_id`, and `v` query parameters as documented in OpenAPI.
+- **FR-007**: Unsupported enum values, invalid UUIDs, overlong labels, and
+  otherwise invalid badge query parameters MUST return `400`.
+- **FR-008**: The existing public card endpoint MUST add `profile` to
+  `card_type`.
+- **FR-009**: `profile` card URLs MUST support optional `metrics` and `layout`
+  query parameters.
+- **FR-010**: The default profile metric set MUST include personal metrics only:
+  today's coding time, trailing-week coding time, top language, and current
+  streak.
+- **FR-011**: Supported profile metric names MUST be `today`, `week`,
+  `all_time`, `top_language`, `current_streak`, and `goal_progress`.
+- **FR-012**: Duplicate, unknown, empty, or unsupported `metrics` entries MUST
+  return `400`.
+- **FR-013**: Composite profile cards MUST preserve the existing public-card
+  cache, visibility, template, and cache-busting semantics.
+- **FR-014**: SVG badge and profile card output MUST include `role="img"` and a
+  non-empty accessible name describing the metric or metric set.
+- **FR-015**: Dashboard snippets MUST use meaningful Markdown alt text and MUST
+  never include credentials.
+- **FR-016**: Badge and profile card visuals, labels, and docs MUST be original
+  CloudTime work and follow `docs/implementation-boundaries.md`.
+- **FR-017**: PR1 MUST include only SpecKit artifacts, OpenAPI changes, and
+  regenerated OpenAPI types. It MUST NOT include route handlers, renderers, UI
+  code, DB migrations, or docs behavior changes.
+
+### Entities
+
+- **Profile Badge**: A small public SVG image for one CloudTime metric.
+- **Profile Composite Card**: A larger public SVG image combining multiple
+  CloudTime metrics in a requested or default order.
+- **Profile Metric**: A named metric section used by the composite card.
+- **Public Embed Settings**: Existing per-user settings controlling whether
+  public image endpoints may reveal stats and how long rendered images remain
+  fresh.
+
+## Success Criteria
+
+- **SC-001**: A user can embed at least four new public badge URLs in a GitHub
+  profile README using standard Markdown image syntax.
+- **SC-002**: A user can embed one composite profile card URL that replaces
+  several separate image URLs.
+- **SC-003**: Disabled public embeds always return `404` for badges and the
+  profile card before serving cache hits.
+- **SC-004**: All generated snippets contain meaningful alt text and no secrets.
+- **SC-005**: The OpenAPI contract generates TypeScript types without manual
+  edits.
+
+## Assumptions
+
+- Existing `embed_settings` controls public visibility for cards and badges.
+- Badge/profile image data is derived from CloudTime summaries, goals, and
+  bounded current-day heartbeat overlays.
+- Goal progress badge behavior is owner-scoped; selecting the first enabled,
+  non-snoozed goal is deterministic and avoids adding a new setting in PR1.
+- All-time values may read aggregate summaries directly in PR2; if that is too
+  expensive, PR2 may introduce a bounded cache or reuse existing all-time
+  helpers without changing the public contract.
+
+## Out of Scope
+
+- Team dashboards, private leaderboards, organizations, SSO, SCIM, or other
+  multi-user features.
+- Third-party visual designs, logos, screenshots, source code, or product copy.
+- New billing, invoice, or email report functionality.
+- Implementation code in PR1.

--- a/specs/198-profile-card-expansion/tasks.md
+++ b/specs/198-profile-card-expansion/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Profile Badge and Composite Card Expansion
+
+## PR1 - Spec + Design
+
+- [x] T001 Create GitHub Issue #198 for the individual profile image expansion.
+- [x] T002 Research official GitHub Markdown/profile README image behavior.
+- [x] T003 Research official accessibility guidance for informative images and SVG image names.
+- [x] T004 Research official HTTP/Cloudflare cache guidance for public image responses.
+- [x] T005 Add SpecKit artifacts under `specs/198-profile-card-expansion/`.
+- [x] T006 Add public badge OpenAPI operation.
+- [x] T007 Extend public card OpenAPI operation with `profile`, `metrics`, and `layout`.
+- [x] T008 Run `npm run generate`.
+- [x] T009 Run `npm run lint:api`.
+- [x] T010 Run `npm run typecheck`.
+- [ ] T011 Commit PR1 in spec-first order and open a draft PR against `develop`.
+
+## PR2 - Implementation
+
+- [ ] T101 Add badge/profile request parsing and validation in `src/routes/cards.ts`.
+- [ ] T102 Add badge/profile cache-key support in `src/utils/cards/cache.ts`.
+- [ ] T103 Add data helpers for badge metrics and profile metric sections.
+- [ ] T104 Add SVG renderers for `flat` and `pill` badges.
+- [ ] T105 Add SVG renderer for default and compact profile composite card layouts.
+- [ ] T106 Add dashboard snippets and previews for badges and profile card.
+- [ ] T107 Add unit tests for badge/profile renderers.
+- [ ] T108 Add unit tests for badge/profile snippets and alt text.
+- [ ] T109 Add integration tests for public badge routes.
+- [ ] T110 Add integration tests for `cards/profile.svg`.
+- [ ] T111 Add privacy tests proving disabled embeds return `404` before cache hits.
+- [ ] T112 Update deployment guide with badge/profile card usage.
+- [ ] T113 Run `npm run typecheck && npm test`.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -514,9 +514,10 @@ export interface paths {
         };
         /**
          * Render a public embeddable stats card
-         * @description Returns an SVG image suitable for embedding in a GitHub README or any
-         *     page that displays remote images. This operation is intentionally public
-         *     (`security: []`) and MUST NOT require or accept an API key in the URL.
+         * @description Returns an SVG image suitable for embedding in a GitHub profile README or
+         *     any page that displays remote images. This operation is intentionally
+         *     public (`security: []`) and MUST NOT require or accept an API key in the
+         *     URL.
          *
          *     The target user is selected by a non-secret username. If embeds are
          *     disabled for that user, the user does not exist, or the requested template
@@ -526,8 +527,48 @@ export interface paths {
          *     user's freshness window. The optional `v` parameter participates in cache
          *     keys so a user can force a refetch, but it never changes card data or
          *     visibility.
+         *
+         *     The `profile` card type is a composite image for personal profile READMEs.
+         *     It combines several CloudTime-owned metrics into one original SVG surface.
+         *     The optional `metrics` and `layout` query parameters apply only to the
+         *     composite profile card; unsupported metric names return `400`.
          */
         get: operations["getEmbeddableCard"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{username}/badges/{badge_type}.svg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Render a public embeddable profile badge
+         * @description Returns a small SVG badge suitable for embedding in a GitHub profile README
+         *     or other Markdown surfaces that display remote images. This operation is
+         *     intentionally public (`security: []`) and MUST NOT require or accept an API
+         *     key in the URL.
+         *
+         *     The target user is selected by a non-secret username. If embeds are
+         *     disabled for that user, the user does not exist, or the requested metric is
+         *     unavailable, the response is `404` and no cached badge image is served.
+         *
+         *     Successful responses include explicit cache headers derived from the user's
+         *     freshness window. The optional `v` parameter participates in cache keys so a
+         *     user can force a refetch, but it never changes badge data or visibility.
+         *
+         *     Badge rendering uses original CloudTime copy and visual design. The
+         *     generated SVG MUST expose an accessible image name matching the Markdown alt
+         *     text guidance for informative images.
+         */
+        get: operations["getEmbeddableBadge"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2797,6 +2838,14 @@ export interface operations {
                 theme?: string;
                 /** @description Optional custom template owned by the target user. */
                 template_id?: string;
+                /**
+                 * @description Optional comma-separated metric list for the `profile` composite card.
+                 *     Omit to use the server default. Repeated, unknown, or unsupported metric
+                 *     names return `400`.
+                 */
+                metrics?: ("today" | "week" | "all_time" | "top_language" | "current_streak" | "goal_progress")[];
+                /** @description Optional layout for the `profile` composite card. */
+                layout?: "default" | "compact";
                 /** @description Optional cache-busting value. Changes the cache key only. */
                 v?: string;
             };
@@ -2805,13 +2854,65 @@ export interface operations {
                 /** @description Public CloudTime username identifying the card owner. */
                 username: string;
                 /** @description Card type to render. */
-                card_type: "heatmap" | "summary" | "languages" | "streak";
+                card_type: "heatmap" | "summary" | "languages" | "streak" | "profile";
             };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description SVG card image */
+            200: {
+                headers: {
+                    /** @description Public cache policy derived from the user's freshness window. */
+                    "Cache-Control"?: string;
+                    /** @description Entity tag for the rendered SVG. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/svg+xml": string;
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            429: components["responses"]["TooManyRequests"];
+        };
+    };
+    getEmbeddableBadge: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Optional range for range-aware badges. `coding_time` defaults to
+                 *     `today`; `top_language` defaults to `last_7_days`; `current_streak` and
+                 *     `goal_progress` ignore this parameter.
+                 */
+                range?: "today" | "last_7_days" | "last_30_days" | "last_6_months" | "last_year" | "all_time";
+                /**
+                 * @description Optional goal identifier for the `goal_progress` badge. When omitted,
+                 *     the first enabled, non-snoozed goal ordered by creation time is used.
+                 */
+                goal_id?: string;
+                /** @description Optional short label override for the left side of the badge. */
+                label?: string;
+                /** @description Built-in visual theme. Unknown themes fall back to the user's default theme. */
+                theme?: string;
+                /** @description Optional badge shape style. */
+                style?: "flat" | "pill";
+                /** @description Optional cache-busting value. Changes the cache key only. */
+                v?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Public CloudTime username identifying the badge owner. */
+                username: string;
+                /** @description Badge metric to render. */
+                badge_type: "coding_time" | "top_language" | "current_streak" | "goal_progress";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description SVG badge image */
             200: {
                 headers: {
                     /** @description Public cache policy derived from the user's freshness window. */


### PR DESCRIPTION
﻿## Summary

- Add SpecKit artifacts for Issue #198: profile badges and a composite profile card for individual users
- Add the public SVG badge OpenAPI contract at `/users/{username}/badges/{badge_type}.svg`
- Extend the public card contract with `card_type=profile`, `metrics`, and `layout`
- Regenerate OpenAPI TypeScript types

## Research

Official sources checked for the contract:

- GitHub Docs for Markdown image syntax and profile README behavior
- W3C WAI and MDN for informative-image alt text and SVG accessible names
- MDN and Cloudflare docs for Cache-Control and ETag behavior

No third-party source code, visual assets, screenshots, or product copy were consulted.

## Validation

- npm run generate
- npm run lint:api
- npm run typecheck

Closes #198 after PR2 implementation lands; this PR is PR1 (Spec + Design) only.
