### PR TITLE
[autoloop] docs: refresh stale plan pointer in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,17 @@ Think in English, interact with the user in Japanese.
 - The Workers test pool runs `tests/setup.ts` once per file to load `src/db/schema.sql`. Helpers in `tests/helpers/fixtures.ts` mint users + API keys without going through OAuth.
 - CI runs both `typecheck` and `test` on every PR (`.github/workflows/test.yml`).
 
+## Current Work Context
+- For up-to-date feature context, consult the most recently updated
+  `specs/<nnn>-<slug>/plan.md` and the open GitHub issues — they are
+  authoritative over the pointer in the managed section below.
+- The section between the SPECKIT markers is auto-managed by
+  `.specify/extensions/agent-context` (refreshed when a plan is generated);
+  it points at the plan that was worked on most recently and may lag behind
+  merged work. Do not hand-edit it expecting the edit to persist.
+
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan:
-`specs/159-rate-limit-expansion/plan.md`
+shell commands, and other important information, read the current plan
+at specs/198-profile-card-expansion/plan.md
 <!-- SPECKIT END -->


### PR DESCRIPTION
## Goal

The SPECKIT-managed block at the bottom of `CLAUDE.md` still pointed at `specs/159-rate-limit-expansion/plan.md`, a feature that shipped in PRs #169/#171. Agents reading the context file were being sent to a stale plan.

## Key decisions

- The block between the SPECKIT markers is auto-managed by `.specify/extensions/agent-context`: any content between the markers is fully replaced with a fixed template whenever a plan is (re)generated, and deleting the markers just makes the tooling re-append the section. A durable instruction **inside** the markers would therefore not survive.
- So the durable guidance lives **outside** the markers: a new "Current Work Context" section tells readers to consult the most recently updated `specs/<nnn>-<slug>/plan.md` and open GitHub issues, and explains that the managed pointer below can lag behind merged work.
- The managed section itself is refreshed to `specs/198-profile-card-expansion/plan.md` (the most recent spec, merged via #199) using the exact line format both update scripts emit, so the next tooling run produces a minimal diff.

Docs-only change; no spec or implementation code touched.

## Gate results

- `npm run lint:api` — pass (API description valid)
- `npm run generate` — pass, no drift in `src/types/generated.ts`
- `npm run typecheck` — pass
- `npm test` — 463 passed (41 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
