### PR TITLE
[autoloop] spec: document goal_progress inverse (cap) goal semantics

### DIFF
--- a/schemas/paths/cards/public-badge.yaml
+++ b/schemas/paths/cards/public-badge.yaml
@@ -62,7 +62,10 @@ get:
       required: false
       description: |
         Optional goal identifier for the `goal_progress` badge. When omitted,
-        the first enabled, non-snoozed goal ordered by creation time is used.
+        the first enabled, non-snoozed goal ordered by creation time is used;
+        `is_inverse` never affects which goal is selected. For an inverse (cap)
+        goal the badge renders the share of the cap consumed and labels it as a
+        cap, so an exceeded cap reads as a blown budget rather than achievement.
       schema:
         type: string
         format: uuid

--- a/schemas/paths/cards/public-card.yaml
+++ b/schemas/paths/cards/public-card.yaml
@@ -74,7 +74,9 @@ get:
       description: |
         Optional comma-separated metric list for the `profile` composite card.
         Omit to use the server default. Repeated, unknown, or unsupported metric
-        names return `400`.
+        names return `400`. The `goal_progress` section renders an inverse (cap)
+        goal as the share of the cap consumed, labeled as a cap so an exceeded
+        cap reads as a blown budget rather than achievement.
       schema:
         type: array
         minItems: 1

--- a/specs/198-profile-card-expansion/contracts/openapi-diff.md
+++ b/specs/198-profile-card-expansion/contracts/openapi-diff.md
@@ -43,6 +43,20 @@ Changes:
 The existing `heatmap`, `summary`, `languages`, and `streak` card types remain
 unchanged.
 
+## Clarified Descriptions (goal_progress inverse goals)
+
+Both public image paths clarify how `goal_progress` renders inverse (cap) goals,
+matching the shipped behavior (FR-018):
+
+- `GET /users/{username}/badges/{badge_type}.svg` — the `goal_id` parameter
+  description states that inverse (cap) goals are rendered as a share of the cap
+  ("% of cap"), never as achievement, with identical goal selection.
+- `GET /users/{username}/cards/{card_type}.svg` — the `metrics` parameter
+  description states the same for the `goal_progress` profile section.
+
+These are description-only clarifications; no request/response shapes,
+parameters, enums, or status codes change.
+
 ## Generated Types
 
 After `npm run generate`, TypeScript clients receive:
@@ -50,3 +64,5 @@ After `npm run generate`, TypeScript clients receive:
 - new `getEmbeddableBadge` operation types
 - updated `getEmbeddableCard` `card_type` enum including `profile`
 - typed `metrics` and `layout` query fields for profile cards
+- refreshed JSDoc on the badge `goal_id` and card `metrics` parameters
+  describing inverse (cap) goal rendering (no type-shape change)

--- a/specs/198-profile-card-expansion/data-model.md
+++ b/specs/198-profile-card-expansion/data-model.md
@@ -43,7 +43,7 @@ Metric sections supported by the profile composite card.
 | all_time | Total CloudTime coding time | existing all-time/summaries semantics |
 | top_language | Top language for the selected/default range | summaries |
 | current_streak | Current CloudTime tracked-day streak | summaries + bounded current-day heartbeat overlay |
-| goal_progress | Progress for a selected/default enabled goal | goals + summaries |
+| goal_progress | Progress for a selected/default enabled goal; inverse (cap) goals are framed as share of the cap, not achievement (FR-018) | goals + summaries |
 
 ## Cache Keys
 

--- a/specs/198-profile-card-expansion/research.md
+++ b/specs/198-profile-card-expansion/research.md
@@ -134,6 +134,32 @@ generated types.
 **Rationale**: The project uses the two-PR SpecKit workflow. The implementation
 will be easier to review after the badge/profile contract is agreed.
 
+## Decision 9: Frame inverse (cap) goal progress as share of the cap
+
+**Decision**: When the resolved goal is an inverse (cap) goal, `goal_progress`
+(badge and profile metric) reports the share of the cap consumed
+(actual ÷ cap) and labels the value as a cap, so an exceeded cap reads as a
+blown budget rather than achievement. Goal eligibility and default selection are
+identical for standard and inverse goals; `is_inverse` never affects which goal
+is chosen.
+
+**Rationale**: A cap goal's percentage is a budget-consumed figure, not an
+achievement figure. Presenting 130% of a cap as "over target" would invert the
+owner's intent (they wanted to stay *under* the cap). Labeling it as a cap keeps
+the public surface honest without adding a pass/fail flag or a second selection
+rule. Reusing the standard enabled + non-snoozed, first-by-creation selection
+avoids a new setting and keeps the badge deterministic.
+
+**Alternatives considered**:
+
+- Expose a boolean pass/fail (met/blown) field. Rejected: adds public surface
+  and a success/failure judgment the contract does not otherwise make; the
+  labeled percentage already conveys the state honestly.
+- Clamp the percentage at 100%. Rejected: hides that the cap was exceeded, which
+  is exactly the signal a cap goal owner wants to see.
+- Treat inverse goals as ineligible for the public badge. Rejected: they are
+  ordinary enabled goals and excluding them would surprise owners who set a cap.
+
 ## Open Questions
 
 - Should PR2 expose a `goal_id` picker in the settings UI immediately, or start

--- a/specs/198-profile-card-expansion/spec.md
+++ b/specs/198-profile-card-expansion/spec.md
@@ -5,6 +5,19 @@
 **Status**: Draft
 **Input**: GitHub Issue #198
 
+## Clarifications
+
+### Session 2026-07-10
+
+- Q: How should `goal_progress` (badge and profile metric) present an inverse
+  (cap) goal — one whose target is a limit not to exceed rather than an amount
+  to reach? → A: Report the share of the cap consumed (actual ÷ cap) and label
+  the value as a cap, so an exceeded cap reads as a blown budget rather than
+  achievement. Goal eligibility and default selection stay identical for
+  standard and inverse goals — `is_inverse` never affects which goal is chosen.
+  No pass/fail flag is exposed; the public surface stays a single
+  percentage-of-cap presentation.
+
 ## User Stories & Testing
 
 ### User Story 1 - Add focused profile badges (Priority: P1)
@@ -35,6 +48,10 @@ non-empty accessible image name, and never includes API keys or session data.
 4. Given public embeds are disabled, when any badge URL is requested, then the
    response is `404`, no cached image is served, and no private stats are
    disclosed.
+5. Given the owner's selected goal is an inverse (cap) goal, when
+   `/badges/goal_progress.svg` is requested, then the badge frames the value as
+   a share of the cap so an exceeded cap reads as a blown budget, never as
+   achievement.
 
 ---
 
@@ -130,6 +147,12 @@ secret query parameter.
 - **FR-017**: PR1 MUST include only SpecKit artifacts, OpenAPI changes, and
   regenerated OpenAPI types. It MUST NOT include route handlers, renderers, UI
   code, DB migrations, or docs behavior changes.
+- **FR-018**: The `goal_progress` badge and profile metric MUST present inverse
+  (cap) goals as the share of the cap consumed and MUST label the value as a
+  cap, so that exceeding the cap is never rendered as achievement or
+  overachievement. Goal eligibility and default selection MUST be identical for
+  standard and inverse goals; `is_inverse` MUST NOT affect which goal is
+  selected.
 
 ### Entities
 
@@ -160,6 +183,8 @@ secret query parameter.
   bounded current-day heartbeat overlays.
 - Goal progress badge behavior is owner-scoped; selecting the first enabled,
   non-snoozed goal is deterministic and avoids adding a new setting in PR1.
+  Inverse (cap) goals reuse that same selection and are framed as a share of the
+  cap (FR-018) rather than as achievement.
 - All-time values may read aggregate summaries directly in PR2; if that is too
   expensive, PR2 may introduce a bounded cache or reuse existing all-time
   helpers without changing the public contract.

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -3335,7 +3335,9 @@ export interface operations {
                 /**
                  * @description Optional comma-separated metric list for the `profile` composite card.
                  *     Omit to use the server default. Repeated, unknown, or unsupported metric
-                 *     names return `400`.
+                 *     names return `400`. The `goal_progress` section renders an inverse (cap)
+                 *     goal as the share of the cap consumed, labeled as a cap so an exceeded
+                 *     cap reads as a blown budget rather than achievement.
                  */
                 metrics?: ("today" | "week" | "all_time" | "top_language" | "current_streak" | "goal_progress")[];
                 /** @description Optional layout for the `profile` composite card. */
@@ -3383,7 +3385,10 @@ export interface operations {
                 range?: "today" | "last_7_days" | "last_30_days" | "last_6_months" | "last_year" | "all_time";
                 /**
                  * @description Optional goal identifier for the `goal_progress` badge. When omitted,
-                 *     the first enabled, non-snoozed goal ordered by creation time is used.
+                 *     the first enabled, non-snoozed goal ordered by creation time is used;
+                 *     `is_inverse` never affects which goal is selected. For an inverse (cap)
+                 *     goal the badge renders the share of the cap consumed and labels it as a
+                 *     cap, so an exceeded cap reads as a blown budget rather than achievement.
                  */
                 goal_id?: string;
                 /** @description Optional short label override for the left side of the badge. */


### PR DESCRIPTION
## Goal

Ratify the shipped `goal_progress` inverse (cap) goal rendering in the spec and
public OpenAPI contract. The badge and profile metric already render an inverse
(cap) goal as the share of the cap consumed ("% of cap"), never as achievement
(shipped in PR #202), but neither `spec.md`, the OpenAPI paths, `data-model.md`,
nor `openapi-diff.md` said so. This docs-stage PR closes that spec↔impl gap.

## Key decisions

- **Ratify, not revise.** The conservative choice: document the shipped
  share-of-cap framing rather than change behavior. An exceeded cap reads as a
  blown budget, not overachievement.
- Goal eligibility and default selection are identical for standard and inverse
  goals — `is_inverse` never affects which goal is chosen.
- No pass/fail flag is exposed; the public surface stays a single
  percentage-of-cap presentation.

## Changes

- `spec.md`: Clarifications entry, `FR-018`, US1 acceptance scenario 5, assumption note.
- `research.md`: Decision 9 (share-of-cap framing) with alternatives.
- `data-model.md`, `contracts/openapi-diff.md`: note the inverse framing.
- `schemas/paths/cards/public-badge.yaml` (`goal_id`) and `public-card.yaml`
  (`metrics`): clarify inverse-goal rendering. Description-only — no
  request/response shape, parameter, enum, or status-code change.
- `src/types/generated.ts`: regenerated (JSDoc-only; not hand-edited).

## Gate results

- `npm run lint:api` — valid (7 pre-existing explicit ignores).
- `npm run generate` — drift confined to the two intended JSDoc descriptions on
  `goal_id` and `metrics`; no structural change.
- `npm run typecheck` — clean.
- `npm test` — 622/622 passed.

Refs #198
