### PR TITLE
[autoloop] feat: git-host webhook adapter for commit ingestion

### DIFF
--- a/migrations/0008_git_webhook_endpoints.sql
+++ b/migrations/0008_git_webhook_endpoints.sql
@@ -1,0 +1,29 @@
+-- Git-host webhook endpoint registrations (Issue #146,
+-- specs/146-git-webhook-adapter/). Kept in sync with src/db/schema.sql so
+-- existing D1 databases can migrate and fresh deployments via `npm run db:init`
+-- get the same shape.
+--
+-- One row per (provider, repo) registration: maps a git host repository to a
+-- CloudTime project and stores the shared webhook secret encrypted at rest
+-- (AES-256-GCM, ENCRYPTION_KEY, AAD 'webhook:<id>') — recoverable, not hashed,
+-- because GitHub HMAC verification must recompute the signature from the raw
+-- secret (data-model.md / research D-4). The public receiver
+-- (POST /webhooks/git/{provider}) resolves the enabled registration by
+-- (provider, repo) read from the delivery payload; the owner CRUD manages rows.
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  provider TEXT NOT NULL,               -- 'github' | 'gitlab'
+  repo TEXT NOT NULL,                   -- provider repo identity: GitHub full_name / GitLab path_with_namespace
+  project TEXT NOT NULL,                -- CloudTime project the commits land under
+  secret_encrypted TEXT NOT NULL,       -- AES-256-GCM (ENCRYPTION_KEY, AAD 'webhook:<id>'); never plaintext, never a hash
+  is_enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, provider, repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_user ON webhook_endpoints(user_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_lookup ON webhook_endpoints(provider, repo);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -513,3 +513,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_daily_usage_unique
   ON ai_daily_usage(user_id, day, provider, model, agent, project);
 CREATE INDEX IF NOT EXISTS idx_ai_daily_usage_user_day
   ON ai_daily_usage(user_id, day);
+
+-- ============================================================
+-- Git-host webhook endpoint registrations (Issue #146)
+-- One row per (provider, repo) registration: maps a git host repository to a
+-- CloudTime project and stores the shared webhook secret encrypted at rest
+-- (AES-256-GCM, ENCRYPTION_KEY, AAD 'webhook:<id>') — recoverable, not hashed,
+-- because GitHub HMAC verification must recompute the signature from the raw
+-- secret. The public receiver resolves the enabled registration by
+-- (provider, repo) read from the delivery payload; the owner CRUD manages rows.
+-- UNIQUE(user_id, provider, repo) allows two users to register the same public
+-- repo (multi-user-ready); in single-user mode a (provider, repo) lookup
+-- resolves to exactly one row. Mirrors migrations/0008_git_webhook_endpoints.sql.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  project TEXT NOT NULL,
+  secret_encrypted TEXT NOT NULL,
+  is_enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE(user_id, provider, repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_user ON webhook_endpoints(user_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_lookup ON webhook_endpoints(provider, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import machines from "./routes/machines";
 import userAgents from "./routes/user-agents";
 import { cardsPublic, cardsSettings } from "./routes/cards";
 import ai from "./routes/ai";
+import { webhooksCrud, webhooksReceiver } from "./routes/webhooks";
 import { aggregateHeartbeats } from "./cron/aggregate";
 import { backfillHourlySummaries } from "./cron/hourly-backfill";
 import { parseRetentionDays, purgeOldHeartbeats } from "./cron/purge";
@@ -137,6 +138,14 @@ app.use("/*", async (c, next) => {
   if (c.req.path.startsWith("/api/v1/auth/link/verify/")) {
     return next();
   }
+  // The public git-webhook receiver (Issue #146) is CSRF-exempt: a git-host
+  // POST carries no Authorization header and no same-origin Origin, so CSRF
+  // would otherwise 403 it before the handler runs. Its authenticity is the
+  // per-repo signature (research D-3), which a CSRF attacker cannot forge — not
+  // an ambient session cookie. This is the first CSRF-exempt public write POST.
+  if (c.req.path.startsWith("/api/v1/webhooks/git/")) {
+    return next();
+  }
   return csrfMiddleware(c, next);
 });
 
@@ -151,6 +160,10 @@ app.route("/api/v1", meta);
 
 // Public embeddable card images (no auth — /users/:username/cards/:type.svg, spec 160)
 app.route("/api/v1", cardsPublic);
+
+// Public git-host webhook receiver (no auth; per-repo signature —
+// POST /webhooks/git/:provider, Issue #146)
+app.route("/api/v1", webhooksReceiver);
 
 // Auth routes (OAuth, sessions, providers — before other authenticated routes)
 app.route("/api/v1/auth", auth);
@@ -196,6 +209,10 @@ app.route("/api/v1/users/current", cardsSettings);
 
 // AI model price + usage routes (mounted at /users/current, sub-app defines /ai/*, Issue #200)
 app.route("/api/v1/users/current", ai);
+
+// Git-host webhook registration CRUD (mounted at /users/current, sub-app
+// defines /webhooks[/:webhook_id], Issue #146)
+app.route("/api/v1/users/current", webhooksCrud);
 
 // Cron trigger handler for periodic aggregation + session cleanup
 export default {

--- a/src/routes/commits.ts
+++ b/src/routes/commits.ts
@@ -39,7 +39,7 @@ type Commit = components["schemas"]["Commit"];
 const PAGE_SIZE = 100;
 const MAX_BULK = 100;
 
-interface CommitRow {
+export interface CommitRow {
   hash: string;
   message: string | null;
   author_name: string | null;
@@ -97,9 +97,11 @@ function rowToCommit(row: CommitRow): Commit {
  * Bind the idempotent commit upsert for one validated commit. Shared by the
  * single-commit `POST` (which passes the correlated or client-supplied
  * `totalSeconds`) and the bulk `POST` (which passes the supplied value
- * verbatim, no correlation). `project` comes from the path, not the body.
+ * verbatim, no correlation). `project` comes from the path, not the body. Also
+ * reused by the git-webhook receiver (Issue #146), which passes each mapped
+ * commit's `total_seconds` (always null — git payloads carry no coding time).
  */
-function commitUpsertStmt(
+export function commitUpsertStmt(
   db: D1Database,
   userId: string,
   project: string,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,242 @@
+/**
+ * Git-host webhook adapter (Issue #146, specs/146-git-webhook-adapter/).
+ *
+ * Two sub-apps:
+ *   - `webhooksCrud` (owner-authenticated): manage repo→project registrations,
+ *     mirroring the `/ai/prices` owner CRUD — `user_id`-scoped, `404`-not-`403`
+ *     for unknown/cross-user ids, the shared secret write-only. `provider`/`repo`
+ *     are the immutable natural key; a duplicate `(provider, repo)` is a `409`.
+ *   - `webhooksReceiver` (public, `security: []`): the `POST /webhooks/git/{provider}`
+ *     delivery endpoint. It authenticates each delivery by the per-repo signature
+ *     (GitHub HMAC / GitLab token), resolves the target user + project from the
+ *     stored registration, and upserts the pushed commits through the SAME bulk
+ *     write path `commits.bulk` uses (one `db.batch()`, no heartbeat correlation
+ *     — git payloads carry no coding time, so `total_seconds` is stored absent).
+ *
+ * The receiver must be CSRF-exempt and read the RAW body once (for the HMAC);
+ * both are wired in `src/index.ts` (research D-10).
+ */
+import { Hono } from "hono";
+import type { AuthEnv, Env } from "../types";
+import type { components } from "../types/generated";
+import { authMiddleware } from "../middleware/auth";
+import { normalizeDateTime } from "../utils/user";
+import { decryptToken } from "../utils/crypto";
+import { commitUpsertStmt } from "./commits";
+import { validateCreateEndpoint, validateUpdateEndpoint } from "../utils/webhooks/input";
+import {
+  deleteEndpoint,
+  getEndpoint,
+  insertEndpoint,
+  listEndpoints,
+  lookupEndpoint,
+  updateEndpoint,
+  type WebhookEndpointRow,
+} from "../utils/webhooks/store";
+import {
+  detectEvent,
+  extractRepo,
+  isPushEvent,
+  isSupportedProvider,
+  mapCommits,
+  verify,
+} from "../utils/webhooks/providers";
+
+type WebhookEndpoint = components["schemas"]["WebhookEndpoint"];
+
+/** Max commits ingested per delivery — the `commits.bulk` cap (research D-6). */
+const MAX_WEBHOOK_COMMITS = 100;
+
+/** Row → API response. `secret_encrypted` is never projected (write-only, FR-009). */
+function rowToWebhookEndpoint(row: WebhookEndpointRow): WebhookEndpoint {
+  return {
+    id: row.id,
+    provider: row.provider as WebhookEndpoint["provider"],
+    repo: row.repo,
+    project: row.project,
+    is_enabled: row.is_enabled === 1,
+    created_at: normalizeDateTime(row.created_at),
+    modified_at: normalizeDateTime(row.modified_at),
+  };
+}
+
+// ─── Owner CRUD (authenticated) ──────────────────────────────────────────────
+
+const webhooksCrud = new Hono<AuthEnv>();
+
+webhooksCrud.use("/webhooks", authMiddleware);
+webhooksCrud.use("/webhooks/*", authMiddleware);
+
+// GET /webhooks — list the owner's registrations.
+webhooksCrud.get("/webhooks", async (c) => {
+  const userId = c.get("userId");
+  try {
+    const rows = await listEndpoints(c.env.DB, userId);
+    return c.json({ data: rows.map(rowToWebhookEndpoint) });
+  } catch (err) {
+    console.error("GET /webhooks error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// POST /webhooks — create a registration.
+webhooksCrud.post("/webhooks", async (c) => {
+  const userId = c.get("userId");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const parsed = validateCreateEndpoint(body);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+
+  try {
+    const result = await insertEndpoint(c.env.DB, userId, c.env.ENCRYPTION_KEY, parsed.value);
+    if (!result.ok) return c.json({ error: result.error }, result.status);
+    return c.json({ data: rowToWebhookEndpoint(result.row) }, 201);
+  } catch (err) {
+    console.error("POST /webhooks error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// GET /webhooks/:webhook_id — a single owner registration.
+webhooksCrud.get("/webhooks/:webhook_id", async (c) => {
+  const userId = c.get("userId");
+  const id = c.req.param("webhook_id");
+  try {
+    const row = await getEndpoint(c.env.DB, userId, id);
+    if (!row) return c.json({ error: "Not found" }, 404);
+    return c.json({ data: rowToWebhookEndpoint(row) });
+  } catch (err) {
+    console.error("GET /webhooks/:webhook_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// PATCH /webhooks/:webhook_id — partial update (project/secret/is_enabled).
+webhooksCrud.patch("/webhooks/:webhook_id", async (c) => {
+  const userId = c.get("userId");
+  const id = c.req.param("webhook_id");
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  try {
+    // Existence + ownership resolved BEFORE body validation so a 400 never
+    // confirms an id the caller cannot edit exists (mirrors /ai/prices).
+    const row = await getEndpoint(c.env.DB, userId, id);
+    if (!row) return c.json({ error: "Not found" }, 404);
+
+    const parsed = validateUpdateEndpoint(body);
+    if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+
+    const updated = await updateEndpoint(c.env.DB, userId, c.env.ENCRYPTION_KEY, row, parsed.value);
+    return c.json({ data: rowToWebhookEndpoint(updated) });
+  } catch (err) {
+    console.error("PATCH /webhooks/:webhook_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// DELETE /webhooks/:webhook_id — remove a registration.
+webhooksCrud.delete("/webhooks/:webhook_id", async (c) => {
+  const userId = c.get("userId");
+  const id = c.req.param("webhook_id");
+  try {
+    const deleted = await deleteEndpoint(c.env.DB, userId, id);
+    if (!deleted) return c.json({ error: "Not found" }, 404);
+    return c.body(null, 204);
+  } catch (err) {
+    console.error("DELETE /webhooks/:webhook_id error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// ─── Public receiver (no auth; per-repo signature) ───────────────────────────
+
+const webhooksReceiver = new Hono<{ Bindings: Env }>();
+
+// POST /webhooks/git/:provider — receive a push delivery and ingest its commits.
+// Ordered handling (data-model.md): provider → raw body + parse → event → repo
+// → verify → map → write. Nothing is written until the signature verifies.
+webhooksReceiver.post("/webhooks/git/:provider", async (c) => {
+  const provider = c.req.param("provider");
+  if (!isSupportedProvider(provider)) {
+    return c.json({ error: "Not found" }, 404);
+  }
+
+  // Read the raw bytes once — the HMAC signs them, so we must not re-serialize
+  // (never call c.req.json() then re-read). Parse that same buffer.
+  const rawBody = await c.req.arrayBuffer();
+  let payload: unknown;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(rawBody));
+  } catch {
+    return c.json({ error: "Request body must be valid JSON" }, 400);
+  }
+
+  const event = detectEvent(provider, c.req.raw.headers);
+  if (event === null) {
+    return c.json({ error: "Missing event header" }, 400);
+  }
+  if (!isPushEvent(provider, event)) {
+    // ping / recognized non-push event → acknowledged, zero counts (no project).
+    return c.json({ data: { received: 0, ingested: 0, skipped: 0 } }, 202);
+  }
+
+  const repo = extractRepo(provider, payload);
+  if (repo === null) {
+    return c.json({ error: "Payload does not identify a repository" }, 400);
+  }
+
+  try {
+    const registration = await lookupEndpoint(c.env.DB, provider, repo);
+    if (!registration) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    const secret = await decryptToken(
+      registration.secret_encrypted,
+      c.env.ENCRYPTION_KEY,
+      `webhook:${registration.id}`,
+    );
+    const verified = await verify(provider, rawBody, c.req.raw.headers, secret);
+    if (!verified) {
+      // A registered repo with a bad signature is 401 (a mis-set secret is
+      // debuggable); nothing is written (FR-003, research D-7).
+      return c.json({ error: "Signature verification failed" }, 401);
+    }
+
+    const { received, commits } = mapCommits(provider, payload);
+    const capped = commits.slice(0, MAX_WEBHOOK_COMMITS);
+    const skipped = received - capped.length;
+
+    // One db.batch() of the shared idempotent upsert — the bulk write path, no
+    // heartbeat correlation, total_seconds always null (FR-005, FR-011).
+    if (capped.length > 0) {
+      await c.env.DB.batch(
+        capped.map((v) =>
+          commitUpsertStmt(c.env.DB, registration.user_id, registration.project, v, v.total_seconds),
+        ),
+      );
+    }
+
+    return c.json(
+      { data: { received, ingested: capped.length, skipped, project: registration.project } },
+      202,
+    );
+  } catch (err) {
+    console.error("POST /webhooks/git/:provider error:", err);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+export { webhooksCrud, webhooksReceiver };

--- a/src/utils/webhooks/input.ts
+++ b/src/utils/webhooks/input.ts
@@ -1,0 +1,128 @@
+/**
+ * Validation for the webhook-registration CRUD request bodies (Issue #146,
+ * specs/146-git-webhook-adapter/). Pure: turns an untrusted parsed JSON value
+ * into a normalised create/update value or a 400-worthy error. No D1, no I/O —
+ * mirrors the `commit-input.ts` / `ai/pricing.ts` split (pure validation here,
+ * D1 persistence + encryption in `store.ts`).
+ *
+ * Caps mirror the OpenAPI `WebhookEndpointInput` constraints
+ * (schemas/components/schemas/WebhookEndpointInput.yaml: repo/project/secret
+ * `minLength: 1`, `maxLength: 255`). openapi-typescript does not surface these,
+ * so they are enforced here at the write boundary.
+ */
+
+import { isSupportedProvider, type Provider } from "./providers";
+
+/** Inclusive UTF-16 length cap shared by repo, project, and secret (OpenAPI maxLength). */
+const MAX_FIELD = 255;
+
+export interface CreateEndpointValue {
+  provider: Provider;
+  repo: string;
+  project: string;
+  secret: string;
+  is_enabled: boolean;
+}
+
+export interface UpdateEndpointValue {
+  projectProvided: boolean;
+  project?: string;
+  secretProvided: boolean;
+  secret?: string;
+  isEnabledProvided: boolean;
+  isEnabled?: boolean;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function fail(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+/** A required, non-empty, ≤255 string field. */
+function checkRequiredField(v: unknown, name: string): { ok: true; value: string } | { ok: false; error: string } {
+  if (typeof v !== "string" || v.length === 0) {
+    return fail(`${name} is required and must be a non-empty string`);
+  }
+  if (v.length > MAX_FIELD) {
+    return fail(`${name} must be at most ${MAX_FIELD} characters`);
+  }
+  return { ok: true, value: v };
+}
+
+/** Validate a `POST /users/current/webhooks` body → a create value. */
+export function validateCreateEndpoint(body: unknown): ValidationResult<CreateEndpointValue> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return fail("Request body must be a JSON object");
+  }
+  const r = body as Record<string, unknown>;
+
+  if (!isSupportedProvider(r.provider)) {
+    return fail("provider is required and must be one of: github, gitlab");
+  }
+  const repo = checkRequiredField(r.repo, "repo");
+  if (!repo.ok) return repo;
+  const project = checkRequiredField(r.project, "project");
+  if (!project.ok) return project;
+  const secret = checkRequiredField(r.secret, "secret");
+  if (!secret.ok) return secret;
+
+  let isEnabled = true;
+  if (r.is_enabled !== undefined) {
+    if (typeof r.is_enabled !== "boolean") return fail("is_enabled must be a boolean");
+    isEnabled = r.is_enabled;
+  }
+
+  return {
+    ok: true,
+    value: { provider: r.provider, repo: repo.value, project: project.value, secret: secret.value, is_enabled: isEnabled },
+  };
+}
+
+/**
+ * Validate a `PATCH /users/current/webhooks/{id}` body → an update value.
+ * `provider`/`repo` are the immutable natural key: their presence in the body is
+ * a 400 (enforced here, not by the schema, matching the /ai/prices precedent —
+ * the PATCH body schema does not set `additionalProperties: false`). `project`,
+ * `secret`, and `is_enabled` are mutable; an empty patch is a 400.
+ */
+export function validateUpdateEndpoint(body: unknown): ValidationResult<UpdateEndpointValue> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return fail("Request body must be a JSON object");
+  }
+  const r = body as Record<string, unknown>;
+
+  if ("provider" in r) return fail("provider is immutable and cannot be updated");
+  if ("repo" in r) return fail("repo is immutable and cannot be updated");
+
+  const value: UpdateEndpointValue = {
+    projectProvided: false,
+    secretProvided: false,
+    isEnabledProvided: false,
+  };
+
+  if (r.project !== undefined) {
+    const project = checkRequiredField(r.project, "project");
+    if (!project.ok) return project;
+    value.projectProvided = true;
+    value.project = project.value;
+  }
+  if (r.secret !== undefined) {
+    const secret = checkRequiredField(r.secret, "secret");
+    if (!secret.ok) return secret;
+    value.secretProvided = true;
+    value.secret = secret.value;
+  }
+  if (r.is_enabled !== undefined) {
+    if (typeof r.is_enabled !== "boolean") return fail("is_enabled must be a boolean");
+    value.isEnabledProvided = true;
+    value.isEnabled = r.is_enabled;
+  }
+
+  if (!value.projectProvided && !value.secretProvided && !value.isEnabledProvided) {
+    return fail("Request body must set at least one of: project, secret, is_enabled");
+  }
+  return { ok: true, value };
+}

--- a/src/utils/webhooks/providers.ts
+++ b/src/utils/webhooks/providers.ts
@@ -1,0 +1,166 @@
+/**
+ * Per-provider webhook adapters (Issue #146, specs/146-git-webhook-adapter/).
+ * Pure — no D1, no `Context` — so the delivery logic unit-tests without a
+ * database: event detection, signature verification, repository extraction, and
+ * payload → `CommitInput` mapping, isolated per git host (research D-2..D-5).
+ *
+ * GitHub authenticates with an HMAC-SHA256 of the *raw* request body keyed by
+ * the registration secret (`X-Hub-Signature-256`); GitLab compares the
+ * `X-Gitlab-Token` header to the secret. Both are constant-time (research D-3).
+ */
+import type { ValidatedCommit } from "../commit-input";
+import { normalizeOptionalDate } from "../datetime";
+import { INPUT_LIMITS, truncateTo } from "../input-limits";
+import { timingSafeEqual } from "../crypto";
+
+export type Provider = "github" | "gitlab";
+
+/** True when `p` is a supported git host — any other `{provider}` is a 404. */
+export function isSupportedProvider(p: unknown): p is Provider {
+  return p === "github" || p === "gitlab";
+}
+
+/** The header carrying the event name for each provider. */
+const EVENT_HEADER: Record<Provider, string> = {
+  github: "X-GitHub-Event",
+  gitlab: "X-Gitlab-Event",
+};
+
+/** The provider's push event name (mapped to commit ingestion). */
+const PUSH_EVENT: Record<Provider, string> = {
+  github: "push",
+  gitlab: "Push Hook",
+};
+
+/**
+ * Read the delivery's event name from the provider header. Returns null when the
+ * header is missing or empty — the route treats that as a 400 (the delivery
+ * names no event). A present, non-empty value (e.g. `ping`, `Push Hook`) is
+ * returned verbatim for {@link isPushEvent} to classify.
+ */
+export function detectEvent(provider: Provider, headers: Headers): string | null {
+  const value = headers.get(EVENT_HEADER[provider]);
+  return value !== null && value.length > 0 ? value : null;
+}
+
+/** True when the detected event is the provider's push event. */
+export function isPushEvent(provider: Provider, event: string): boolean {
+  return event === PUSH_EVENT[provider];
+}
+
+function nonEmptyString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+  return typeof v === "object" && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+/** A non-empty string clamped to `cap`, else null (best-effort omit; research D-5). */
+function clampString(v: unknown, cap: number): string | null {
+  const s = nonEmptyString(v);
+  return s === null ? null : truncateTo(s, cap);
+}
+
+/**
+ * The repository identity a delivery targets, read from the payload: GitHub
+ * `repository.full_name`, GitLab `project.path_with_namespace`. Null when the
+ * body carries no such field — the route maps that to a 400 (FR-007).
+ */
+export function extractRepo(provider: Provider, payload: unknown): string | null {
+  const body = asObject(payload);
+  if (body === null) return null;
+  if (provider === "github") {
+    const repository = asObject(body.repository);
+    return repository ? nonEmptyString(repository.full_name) : null;
+  }
+  const project = asObject(body.project);
+  return project ? nonEmptyString(project.path_with_namespace) : null;
+}
+
+async function hmacSha256Hex(rawBody: ArrayBuffer, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, rawBody);
+  return Array.from(new Uint8Array(signature), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Verify the delivery's authenticity against the registration secret, over the
+ * *raw* request bytes (never a re-serialized body — JSON round-tripping would
+ * change the signed bytes). GitHub: `HMAC-SHA256(rawBody, secret)` compared
+ * constant-time to `X-Hub-Signature-256`. GitLab: `X-Gitlab-Token` compared
+ * constant-time to the secret. A missing header fails closed.
+ */
+export async function verify(
+  provider: Provider,
+  rawBody: ArrayBuffer,
+  headers: Headers,
+  secret: string,
+): Promise<boolean> {
+  if (provider === "github") {
+    const signature = headers.get("X-Hub-Signature-256");
+    if (signature === null) return false;
+    const expected = `sha256=${await hmacSha256Hex(rawBody, secret)}`;
+    return timingSafeEqual(signature, expected);
+  }
+  const token = headers.get("X-Gitlab-Token");
+  if (token === null) return false;
+  return timingSafeEqual(token, secret);
+}
+
+/** A push payload mapped to commit-ingestion inputs, plus the raw commit count. */
+export interface MappedPush {
+  /** Commit objects present in the payload (`received` in the ack). */
+  received: number;
+  /** Successfully mapped commits (usable hash), before the 100-per-delivery cap. */
+  commits: ValidatedCommit[];
+}
+
+/**
+ * Map a provider `push` payload to `CommitInput`s (research D-5). Uses only
+ * documented public fields, parsed originally; clamps each field to its
+ * `CommitInput` length cap and omits any it cannot normalize (an unparseable
+ * `timestamp` → no `author_date`, which the read path backfills). A commit
+ * object without a usable `id`/`hash` is dropped and shows up in the ack's
+ * `skipped` (received − ingested). `total_seconds` is always absent — git
+ * payloads carry no coding time. GitLab payloads have no committer, so those
+ * fields are omitted for GitLab.
+ */
+export function mapCommits(provider: Provider, payload: unknown): MappedPush {
+  const body = asObject(payload);
+  const rawCommits = body && Array.isArray(body.commits) ? body.commits : [];
+  const ref = clampString(body?.ref, INPUT_LIMITS.name);
+
+  const commits: ValidatedCommit[] = [];
+  for (const item of rawCommits) {
+    const co = asObject(item);
+    if (co === null) continue;
+    const hash = nonEmptyString(co.id);
+    if (hash === null) continue; // no usable hash → dropped (counted in skipped)
+
+    const author = asObject(co.author);
+    const committer = provider === "github" ? asObject(co.committer) : null;
+    const authorDate = normalizeOptionalDate(co.timestamp);
+
+    commits.push({
+      hash: truncateTo(hash, INPUT_LIMITS.commitHash),
+      message: clampString(co.message, INPUT_LIMITS.commitMessage),
+      author_name: author ? clampString(author.name, INPUT_LIMITS.name) : null,
+      author_email: author ? clampString(author.email, INPUT_LIMITS.email) : null,
+      author_date: authorDate.ok ? authorDate.value : null,
+      committer_name: committer ? clampString(committer.name, INPUT_LIMITS.name) : null,
+      committer_email: committer ? clampString(committer.email, INPUT_LIMITS.email) : null,
+      committer_date: null,
+      total_seconds: null,
+      ref,
+      url: clampString(co.url, INPUT_LIMITS.url),
+    });
+  }
+  return { received: rawCommits.length, commits };
+}

--- a/src/utils/webhooks/store.ts
+++ b/src/utils/webhooks/store.ts
@@ -1,0 +1,170 @@
+/**
+ * Webhook-registration persistence service (Issue #146,
+ * specs/146-git-webhook-adapter/). D1-facing; owns the queries, the
+ * `(user_id, provider, repo)` uniqueness rule, and the secret-at-rest
+ * encryption. Field-level request validation lives in `input.ts` (pure); this
+ * module owns everything that needs the database.
+ *
+ * The secret is stored AES-256-GCM encrypted (recoverable) via the existing
+ * `encryptToken`/`decryptToken` OAuth-token helpers with a per-row AAD
+ * `webhook:<id>`, because GitHub HMAC verification must recompute the signature
+ * from the raw secret — a one-way hash would not work (research D-4).
+ */
+import { encryptToken } from "../crypto";
+import type { CreateEndpointValue, UpdateEndpointValue } from "./input";
+import type { Provider } from "./providers";
+
+export interface WebhookEndpointRow {
+  id: string;
+  user_id: string;
+  provider: string;
+  repo: string;
+  project: string;
+  secret_encrypted: string;
+  is_enabled: number;
+  created_at: string;
+  modified_at: string;
+}
+
+const SELECT_COLUMNS =
+  "id, user_id, provider, repo, project, secret_encrypted, is_enabled, created_at, modified_at";
+
+/** Result of a create: the persisted row, or a duplicate the route maps to 409. */
+export type EndpointCreateResult =
+  | { ok: true; row: WebhookEndpointRow }
+  | { ok: false; status: 409; error: string };
+
+/** Read one owner-scoped registration by id, or null (unknown / cross-user). */
+export async function getEndpoint(
+  db: D1Database,
+  userId: string,
+  id: string,
+): Promise<WebhookEndpointRow | null> {
+  return db
+    .prepare(`SELECT ${SELECT_COLUMNS} FROM webhook_endpoints WHERE id = ? AND user_id = ?`)
+    .bind(id, userId)
+    .first<WebhookEndpointRow>();
+}
+
+/** List the owner's registrations, ordered by the immutable natural key. */
+export async function listEndpoints(
+  db: D1Database,
+  userId: string,
+): Promise<WebhookEndpointRow[]> {
+  const { results } = await db
+    .prepare(`SELECT ${SELECT_COLUMNS} FROM webhook_endpoints WHERE user_id = ? ORDER BY provider, repo`)
+    .bind(userId)
+    .all<WebhookEndpointRow>();
+  return results;
+}
+
+/**
+ * Resolve the enabled registration a public delivery targets, matched by
+ * `(provider, repo)` read from the payload (research D-9). In single-user mode
+ * this resolves to exactly one row; disabled and unregistered repos return null,
+ * which the receiver maps to 404. Carries `secret_encrypted` for verification.
+ */
+export async function lookupEndpoint(
+  db: D1Database,
+  provider: Provider,
+  repo: string,
+): Promise<WebhookEndpointRow | null> {
+  return db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM webhook_endpoints WHERE provider = ? AND repo = ? AND is_enabled = 1`,
+    )
+    .bind(provider, repo)
+    .first<WebhookEndpointRow>();
+}
+
+/**
+ * Insert a validated owner-scoped registration. Rejects a duplicate
+ * `(user_id, provider, repo)` with a 409-worthy result (FR-010). The secret is
+ * encrypted with the freshly generated id as AAD before it is written — never
+ * stored in plaintext.
+ */
+export async function insertEndpoint(
+  db: D1Database,
+  userId: string,
+  encryptionKey: string,
+  v: CreateEndpointValue,
+): Promise<EndpointCreateResult> {
+  const existing = await db
+    .prepare("SELECT id FROM webhook_endpoints WHERE user_id = ? AND provider = ? AND repo = ?")
+    .bind(userId, v.provider, v.repo)
+    .first<{ id: string }>();
+  if (existing) {
+    return { ok: false, status: 409, error: "a registration for this provider and repo already exists" };
+  }
+
+  const id = crypto.randomUUID();
+  const secretEncrypted = await encryptToken(v.secret, encryptionKey, `webhook:${id}`);
+  await db
+    .prepare(
+      `INSERT INTO webhook_endpoints
+         (id, user_id, provider, repo, project, secret_encrypted, is_enabled, created_at, modified_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    )
+    .bind(id, userId, v.provider, v.repo, v.project, secretEncrypted, v.is_enabled ? 1 : 0)
+    .run();
+
+  const row = await getEndpoint(db, userId, id);
+  if (!row) throw new Error("webhook endpoint vanished after insert");
+  return { ok: true, row };
+}
+
+/**
+ * Apply a validated partial update to an owner row. The caller has already
+ * resolved existence/ownership (404) and rejected immutable `provider`/`repo`
+ * changes (400). A replacement secret is re-encrypted with the row's id AAD.
+ * Bumps `modified_at`.
+ */
+export async function updateEndpoint(
+  db: D1Database,
+  userId: string,
+  encryptionKey: string,
+  row: WebhookEndpointRow,
+  v: UpdateEndpointValue,
+): Promise<WebhookEndpointRow> {
+  const columns: string[] = [];
+  const values: (string | number)[] = [];
+  if (v.projectProvided) {
+    columns.push("project = ?");
+    values.push(v.project!);
+  }
+  if (v.secretProvided) {
+    columns.push("secret_encrypted = ?");
+    values.push(await encryptToken(v.secret!, encryptionKey, `webhook:${row.id}`));
+  }
+  if (v.isEnabledProvided) {
+    columns.push("is_enabled = ?");
+    values.push(v.isEnabled ? 1 : 0);
+  }
+  columns.push("modified_at = datetime('now')");
+
+  await db
+    .prepare(`UPDATE webhook_endpoints SET ${columns.join(", ")} WHERE id = ? AND user_id = ?`)
+    .bind(...values, row.id, userId)
+    .run();
+
+  const updated = await getEndpoint(db, userId, row.id);
+  if (!updated) throw new Error("webhook endpoint vanished after update");
+  return updated;
+}
+
+/**
+ * Delete an owner-created registration. Unknown and cross-user ids match zero
+ * rows and return false, so id existence is never leaked. Returns true only when
+ * a row was removed.
+ */
+export async function deleteEndpoint(
+  db: D1Database,
+  userId: string,
+  id: string,
+): Promise<boolean> {
+  const res = await db
+    .prepare("DELETE FROM webhook_endpoints WHERE id = ? AND user_id = ?")
+    .bind(id, userId)
+    .run();
+  return res.meta.changes > 0;
+}

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests for the git-host webhook adapter (Issue #146,
+ * specs/146-git-webhook-adapter/) against a real in-memory D1.
+ *
+ * Receiver (POST /webhooks/git/{provider}): a verified GitHub/GitLab push
+ * ingests commits under the registration's project with NO heartbeat
+ * correlation (read-back "0 secs"), idempotent redelivery, the 401/404/400/202
+ * response matrix, the 100-commit cap, project-from-registration, cross-user
+ * isolation, and untouched aggregates. CRUD (/users/current/webhooks): the
+ * create→list→read→patch→delete round-trip, the write-only secret, immutable
+ * provider/repo, duplicate 409, unknown/cross-user 404, and owner-only 401.
+ */
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUser, truncate, type SeededUser } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+const CRUD = "/api/v1/users/current/webhooks";
+
+let user: SeededUser;
+let other: SeededUser;
+
+beforeEach(async () => {
+  user = await seedUser({ username: "alice", timezone: "UTC" });
+  other = await seedUser({ username: "bob", timezone: "UTC" });
+});
+
+afterEach(async () => {
+  await truncate("webhook_endpoints", "commits", "heartbeats", "summaries", "hourly_summaries", "user_projects", "users");
+  await env.KV.delete(`apikey:${user.apiKeyHash}`);
+  await env.KV.delete(`apikey:${other.apiKeyHash}`);
+});
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`${BASE}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function bearer(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+function jsonHeaders(apiKey: string): Record<string, string> {
+  return { "Content-Type": "application/json", ...bearer(apiKey) };
+}
+
+async function githubSignature(rawBody: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(rawBody));
+  return `sha256=${Array.from(new Uint8Array(sig), (b) => b.toString(16).padStart(2, "0")).join("")}`;
+}
+
+/** Register a webhook via the owner CRUD; returns the parsed response. */
+async function register(
+  apiKey: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  const res = await call(CRUD, { method: "POST", headers: jsonHeaders(apiKey), body: JSON.stringify(body) });
+  return { status: res.status, data: ((await res.json()) as { data?: Record<string, unknown> }).data ?? {} };
+}
+
+/** Sign and POST a GitHub delivery. */
+async function postGithub(
+  payload: unknown,
+  secret: string,
+  opts: { event?: string; signature?: string } = {},
+): Promise<Response> {
+  const raw = JSON.stringify(payload);
+  const signature = opts.signature ?? (await githubSignature(raw, secret));
+  return call("/api/v1/webhooks/git/github", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-GitHub-Event": opts.event ?? "push", "X-Hub-Signature-256": signature },
+    body: raw,
+  });
+}
+
+function githubPush(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ref: "refs/heads/main",
+    repository: { full_name: "octo/hello" },
+    commits: [
+      {
+        id: "a".repeat(40),
+        message: "first commit",
+        author: { name: "Ada", email: "ada@example.test" },
+        committer: { name: "Grace", email: "grace@example.test" },
+        timestamp: "2026-07-01T12:00:00Z",
+        url: "https://github.test/octo/hello/commit/aaa",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function listCommits(apiKey: string, project: string): Promise<{ status: number; commits: { hash: string; total_seconds?: number; human_readable_total: string }[] }> {
+  const res = await call(`/api/v1/users/current/projects/${project}/commits`, { headers: bearer(apiKey) });
+  const body = (await res.json()) as { data?: { hash: string; total_seconds?: number; human_readable_total: string }[] };
+  return { status: res.status, commits: body.data ?? [] };
+}
+
+async function countRows(table: string): Promise<number> {
+  const row = await env.DB.prepare(`SELECT COUNT(*) AS n FROM ${table}`).first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+// ─── Receiver ────────────────────────────────────────────────────────────────
+
+describe("POST /webhooks/git/:provider — receiver", () => {
+  const SECRET = "owner-secret";
+
+  it("ingests a verified GitHub push under the registration project with no correlation", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+
+    // Heartbeats around the commit that WOULD correlate on the single-commit
+    // endpoint — the receiver must ignore them (total_seconds stays absent).
+    const epoch = Date.parse("2026-07-01T12:00:00Z") / 1000;
+    for (const t of [epoch, epoch + 120]) {
+      await env.DB.prepare(
+        "INSERT INTO heartbeats (id, user_id, entity, time, project, category) VALUES (?, ?, ?, ?, 'backend', 'coding')",
+      )
+        .bind(crypto.randomUUID(), user.userId, "src/app.ts", t)
+        .run();
+    }
+
+    const res = await postGithub(githubPush(), SECRET);
+    expect(res.status).toBe(202);
+    expect((await res.json()) as unknown).toEqual({
+      data: { received: 1, ingested: 1, skipped: 0, project: "backend" },
+    });
+
+    const { commits } = await listCommits(user.apiKey, "backend");
+    expect(commits).toHaveLength(1);
+    expect(commits[0].hash).toBe("a".repeat(40));
+    expect(commits[0].total_seconds).toBeUndefined();
+    expect(commits[0].human_readable_total).toBe("0 secs");
+  });
+
+  it("ingests a verified GitLab push (token header)", async () => {
+    const token = "gitlab-token";
+    await register(user.apiKey, { provider: "gitlab", repo: "grp/proj", project: "gl", secret: token });
+
+    const payload = {
+      ref: "refs/heads/main",
+      project: { path_with_namespace: "grp/proj" },
+      commits: [{ id: "b".repeat(40), message: "gl commit", timestamp: "2026-07-02T09:30:00Z" }],
+    };
+    const res = await call("/api/v1/webhooks/git/gitlab", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Gitlab-Event": "Push Hook", "X-Gitlab-Token": token },
+      body: JSON.stringify(payload),
+    });
+    expect(res.status).toBe(202);
+    expect(((await res.json()) as { data: { ingested: number } }).data.ingested).toBe(1);
+    expect((await listCommits(user.apiKey, "gl")).commits).toHaveLength(1);
+  });
+
+  it("is idempotent on redelivery (one row per hash)", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    await postGithub(githubPush(), SECRET);
+    const second = await postGithub(githubPush(), SECRET);
+    expect(second.status).toBe(202);
+    expect((await listCommits(user.apiKey, "backend")).commits).toHaveLength(1);
+  });
+
+  it("rejects a wrong signature with 401 and writes nothing", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    const res = await postGithub(githubPush(), SECRET, { signature: "sha256=deadbeef" });
+    expect(res.status).toBe(401);
+    expect((await listCommits(user.apiKey, "backend")).commits).toHaveLength(0);
+    expect(await countRows("commits")).toBe(0);
+  });
+
+  it("returns 404 for an unregistered repo", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    const res = await postGithub(githubPush({ repository: { full_name: "octo/other" } }), SECRET);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an unsupported provider", async () => {
+    const res = await call("/api/v1/webhooks/git/bitbucket", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-GitHub-Event": "push" },
+      body: JSON.stringify(githubPush()),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a disabled registration", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET, is_enabled: false });
+    const res = await postGithub(githubPush(), SECRET);
+    expect(res.status).toBe(404);
+    expect(await countRows("commits")).toBe(0);
+  });
+
+  it("acknowledges a ping / non-push event with 202 and zero counts", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    const res = await postGithub({}, SECRET, { event: "ping" });
+    expect(res.status).toBe(202);
+    expect((await res.json()) as unknown).toEqual({ data: { received: 0, ingested: 0, skipped: 0 } });
+    expect(await countRows("commits")).toBe(0);
+  });
+
+  it("returns 400 for an unparseable body", async () => {
+    const res = await call("/api/v1/webhooks/git/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-GitHub-Event": "push", "X-Hub-Signature-256": "sha256=x" },
+      body: "{ not json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the event header is missing", async () => {
+    const raw = JSON.stringify(githubPush());
+    const res = await call("/api/v1/webhooks/git/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Hub-Signature-256": await githubSignature(raw, SECRET) },
+      body: raw,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a push that identifies no repository", async () => {
+    const res = await postGithub({ ref: "refs/heads/main", commits: [{ id: "c".repeat(40) }] }, SECRET);
+    expect(res.status).toBe(400);
+  });
+
+  it("caps at 100 commits and reports the remainder in skipped", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    const commits = Array.from({ length: 101 }, (_, i) => ({
+      id: i.toString(16).padStart(40, "0"),
+      message: `commit ${i}`,
+      timestamp: "2026-07-01T12:00:00Z",
+    }));
+    const res = await postGithub(githubPush({ commits }), SECRET);
+    expect(res.status).toBe(202);
+    expect((await res.json()) as unknown).toEqual({
+      data: { received: 101, ingested: 100, skipped: 1, project: "backend" },
+    });
+  });
+
+  it("ingests under the registration project, not any payload field", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    // A misleading top-level `project` in the payload must be ignored.
+    const res = await postGithub(githubPush({ project: "payload-project" }), SECRET);
+    expect(((await res.json()) as { data: { project: string } }).data.project).toBe("backend");
+    expect((await listCommits(user.apiKey, "backend")).commits).toHaveLength(1);
+    expect((await listCommits(user.apiKey, "payload-project")).commits).toHaveLength(0);
+  });
+
+  it("resolves the delivery to the registering user (cross-user isolation)", async () => {
+    await register(user.apiKey, { provider: "github", repo: "alice/repo", project: "aliceproj", secret: "alice-secret" });
+    await register(other.apiKey, { provider: "github", repo: "bob/repo", project: "bobproj", secret: "bob-secret" });
+
+    const res = await postGithub(githubPush({ repository: { full_name: "bob/repo" } }), "bob-secret");
+    expect(res.status).toBe(202);
+
+    expect((await listCommits(other.apiKey, "bobproj")).commits).toHaveLength(1);
+    expect((await listCommits(user.apiKey, "aliceproj")).commits).toHaveLength(0);
+  });
+
+  it("does not touch the aggregate tables", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: SECRET });
+    await postGithub(githubPush(), SECRET);
+    expect(await countRows("summaries")).toBe(0);
+    expect(await countRows("hourly_summaries")).toBe(0);
+    expect(await countRows("user_projects")).toBe(0);
+  });
+});
+
+// ─── Owner CRUD ──────────────────────────────────────────────────────────────
+
+describe("/users/current/webhooks — owner CRUD", () => {
+  it("round-trips create → list → read → patch → delete, never exposing the secret", async () => {
+    const created = await register(user.apiKey, {
+      provider: "github",
+      repo: "octo/hello",
+      project: "backend",
+      secret: "s3cr3t",
+    });
+    expect(created.status).toBe(201);
+    expect(created.data.id).toBeTruthy();
+    expect(created.data.provider).toBe("github");
+    expect(created.data.repo).toBe("octo/hello");
+    expect(created.data.is_enabled).toBe(true);
+    expect(created.data).not.toHaveProperty("secret");
+    const id = created.data.id as string;
+
+    const list = await call(CRUD, { headers: bearer(user.apiKey) });
+    const listBody = (await list.json()) as { data: Record<string, unknown>[] };
+    expect(listBody.data).toHaveLength(1);
+    expect(listBody.data[0]).not.toHaveProperty("secret");
+
+    const read = await call(`${CRUD}/${id}`, { headers: bearer(user.apiKey) });
+    expect(read.status).toBe(200);
+    expect(((await read.json()) as { data: Record<string, unknown> }).data).not.toHaveProperty("secret");
+
+    const patch = await call(`${CRUD}/${id}`, {
+      method: "PATCH",
+      headers: jsonHeaders(user.apiKey),
+      body: JSON.stringify({ project: "frontend", secret: "rotated", is_enabled: false }),
+    });
+    expect(patch.status).toBe(200);
+    const patched = (await patch.json()) as { data: Record<string, unknown> };
+    expect(patched.data.project).toBe("frontend");
+    expect(patched.data.is_enabled).toBe(false);
+    expect(patched.data).not.toHaveProperty("secret");
+
+    const del = await call(`${CRUD}/${id}`, { method: "DELETE", headers: bearer(user.apiKey) });
+    expect(del.status).toBe(204);
+    expect((await call(`${CRUD}/${id}`, { headers: bearer(user.apiKey) })).status).toBe(404);
+  });
+
+  it("rejects immutable provider/repo changes and an empty patch with 400", async () => {
+    const created = await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: "s" });
+    const id = created.data.id as string;
+
+    for (const patch of [{ provider: "gitlab" }, { repo: "octo/other" }, {}]) {
+      const res = await call(`${CRUD}/${id}`, {
+        method: "PATCH",
+        headers: jsonHeaders(user.apiKey),
+        body: JSON.stringify(patch),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("rejects a duplicate (provider, repo) with 409", async () => {
+    await register(user.apiKey, { provider: "github", repo: "octo/hello", project: "backend", secret: "s" });
+    const dup = await call(CRUD, {
+      method: "POST",
+      headers: jsonHeaders(user.apiKey),
+      body: JSON.stringify({ provider: "github", repo: "octo/hello", project: "other", secret: "s2" }),
+    });
+    expect(dup.status).toBe(409);
+  });
+
+  it.each([
+    ["missing provider", { repo: "octo/hello", project: "backend", secret: "s" }],
+    ["unsupported provider", { provider: "bitbucket", repo: "octo/hello", project: "backend", secret: "s" }],
+    ["empty repo", { provider: "github", repo: "", project: "backend", secret: "s" }],
+    ["missing secret", { provider: "github", repo: "octo/hello", project: "backend" }],
+  ])("rejects create with %s (400)", async (_label, body) => {
+    const res = await call(CRUD, { method: "POST", headers: jsonHeaders(user.apiKey), body: JSON.stringify(body) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown and cross-user ids", async () => {
+    const bob = await register(other.apiKey, { provider: "github", repo: "bob/repo", project: "bobproj", secret: "s" });
+    const bobId = bob.data.id as string;
+
+    expect((await call(`${CRUD}/nope`, { headers: bearer(user.apiKey) })).status).toBe(404);
+    expect((await call(`${CRUD}/${bobId}`, { headers: bearer(user.apiKey) })).status).toBe(404);
+    expect(
+      (await call(`${CRUD}/${bobId}`, { method: "PATCH", headers: jsonHeaders(user.apiKey), body: JSON.stringify({ project: "x" }) })).status,
+    ).toBe(404);
+    expect((await call(`${CRUD}/${bobId}`, { method: "DELETE", headers: bearer(user.apiKey) })).status).toBe(404);
+
+    // Bob's row is untouched by Alice's failed cross-user calls.
+    expect((await call(`${CRUD}/${bobId}`, { headers: bearer(other.apiKey) })).status).toBe(200);
+  });
+
+  it("returns 401 without authentication", async () => {
+    expect((await call(CRUD)).status).toBe(401);
+    expect(
+      (await call(CRUD, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ provider: "github", repo: "r", project: "p", secret: "s" }) })).status,
+    ).toBe(401);
+  });
+});

--- a/tests/security/webhook-providers.test.ts
+++ b/tests/security/webhook-providers.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the pure webhook provider adapters (Issue #146,
+ * specs/146-git-webhook-adapter/): signature verification (GitHub HMAC over the
+ * raw body, GitLab token — both constant-time) and payload → CommitInput
+ * mapping. No D1 — these exercise the adapter logic in isolation.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  detectEvent,
+  extractRepo,
+  isPushEvent,
+  isSupportedProvider,
+  mapCommits,
+  verify,
+} from "../../src/utils/webhooks/providers";
+
+const SECRET = "It is a secret to everybody";
+
+/** Raw UTF-8 bytes of a string, as an ArrayBuffer (what the receiver HMACs). */
+function toBuffer(s: string): ArrayBuffer {
+  const u8 = new TextEncoder().encode(s);
+  return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength) as ArrayBuffer;
+}
+
+/** Compute a GitHub `sha256=<hex>` signature over the raw body (reference impl). */
+async function githubSignature(rawBody: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(rawBody));
+  return `sha256=${Array.from(new Uint8Array(sig), (b) => b.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function githubPush(): Record<string, unknown> {
+  return {
+    ref: "refs/heads/main",
+    repository: { full_name: "octo/hello" },
+    commits: [
+      {
+        id: "a".repeat(40),
+        message: "first commit",
+        author: { name: "Ada", email: "ada@example.test" },
+        committer: { name: "Grace", email: "grace@example.test" },
+        timestamp: "2026-07-01T12:00:00Z",
+        url: "https://github.test/octo/hello/commit/aaa",
+      },
+    ],
+  };
+}
+
+describe("isSupportedProvider", () => {
+  it("accepts github and gitlab, rejects anything else", () => {
+    expect(isSupportedProvider("github")).toBe(true);
+    expect(isSupportedProvider("gitlab")).toBe(true);
+    expect(isSupportedProvider("bitbucket")).toBe(false);
+    expect(isSupportedProvider("")).toBe(false);
+    expect(isSupportedProvider(undefined)).toBe(false);
+  });
+});
+
+describe("detectEvent / isPushEvent", () => {
+  it("reads the provider event header; missing/empty → null", () => {
+    expect(detectEvent("github", new Headers({ "X-GitHub-Event": "push" }))).toBe("push");
+    expect(detectEvent("gitlab", new Headers({ "X-Gitlab-Event": "Push Hook" }))).toBe("Push Hook");
+    expect(detectEvent("github", new Headers())).toBeNull();
+    expect(detectEvent("github", new Headers({ "X-GitHub-Event": "" }))).toBeNull();
+    // A GitLab header does not satisfy a GitHub delivery.
+    expect(detectEvent("github", new Headers({ "X-Gitlab-Event": "Push Hook" }))).toBeNull();
+  });
+
+  it("classifies only the provider's push event as a push", () => {
+    expect(isPushEvent("github", "push")).toBe(true);
+    expect(isPushEvent("github", "ping")).toBe(false);
+    expect(isPushEvent("gitlab", "Push Hook")).toBe(true);
+    expect(isPushEvent("gitlab", "Tag Push Hook")).toBe(false);
+    // Cross-provider event names do not count.
+    expect(isPushEvent("github", "Push Hook")).toBe(false);
+  });
+});
+
+describe("extractRepo", () => {
+  it("reads the provider repository identity from the payload", () => {
+    expect(extractRepo("github", { repository: { full_name: "octo/hello" } })).toBe("octo/hello");
+    expect(extractRepo("gitlab", { project: { path_with_namespace: "grp/proj" } })).toBe("grp/proj");
+  });
+
+  it("returns null when the repository field is absent or empty", () => {
+    expect(extractRepo("github", { repository: {} })).toBeNull();
+    expect(extractRepo("github", { repository: { full_name: "" } })).toBeNull();
+    expect(extractRepo("github", {})).toBeNull();
+    expect(extractRepo("gitlab", { project: null })).toBeNull();
+    expect(extractRepo("github", "not-an-object")).toBeNull();
+  });
+});
+
+describe("verify — GitHub HMAC over the raw body", () => {
+  it("accepts a valid signature over the exact raw bytes", async () => {
+    const raw = JSON.stringify(githubPush());
+    const sig = await githubSignature(raw, SECRET);
+    const headers = new Headers({ "X-Hub-Signature-256": sig });
+    expect(await verify("github", toBuffer(raw), headers, SECRET)).toBe(true);
+  });
+
+  it("rejects a tampered body, wrong secret, and missing signature", async () => {
+    const raw = JSON.stringify(githubPush());
+    const sig = await githubSignature(raw, SECRET);
+
+    // Same signature, but a different body → HMAC of the sent bytes differs.
+    const tampered = raw.replace("first commit", "evil commit");
+    expect(
+      await verify("github", toBuffer(tampered), new Headers({ "X-Hub-Signature-256": sig }), SECRET),
+    ).toBe(false);
+
+    // Right body, wrong secret.
+    expect(
+      await verify("github", toBuffer(raw), new Headers({ "X-Hub-Signature-256": sig }), "wrong-secret"),
+    ).toBe(false);
+
+    // No signature header at all.
+    expect(await verify("github", toBuffer(raw), new Headers(), SECRET)).toBe(false);
+  });
+
+  it("fails when even one whitespace byte differs from the signed body", async () => {
+    // Signature computed over `raw`, verification run over `raw + " "` — a
+    // re-serialized body would drift like this and must NOT verify.
+    const raw = JSON.stringify(githubPush());
+    const sig = await githubSignature(raw, SECRET);
+    expect(
+      await verify("github", toBuffer(`${raw} `), new Headers({ "X-Hub-Signature-256": sig }), SECRET),
+    ).toBe(false);
+  });
+});
+
+describe("verify — GitLab token header", () => {
+  it("accepts a matching token and rejects a wrong or missing one", async () => {
+    const raw = JSON.stringify({ project: { path_with_namespace: "grp/proj" }, commits: [] });
+    expect(
+      await verify("gitlab", toBuffer(raw), new Headers({ "X-Gitlab-Token": SECRET }), SECRET),
+    ).toBe(true);
+    expect(
+      await verify("gitlab", toBuffer(raw), new Headers({ "X-Gitlab-Token": "nope" }), SECRET),
+    ).toBe(false);
+    expect(await verify("gitlab", toBuffer(raw), new Headers(), SECRET)).toBe(false);
+  });
+});
+
+describe("mapCommits", () => {
+  it("maps a GitHub push with ref from the top level and committer fields", () => {
+    const { received, commits } = mapCommits("github", githubPush());
+    expect(received).toBe(1);
+    expect(commits).toHaveLength(1);
+    const c = commits[0];
+    expect(c.hash).toBe("a".repeat(40));
+    expect(c.message).toBe("first commit");
+    expect(c.author_name).toBe("Ada");
+    expect(c.author_email).toBe("ada@example.test");
+    expect(c.committer_name).toBe("Grace");
+    expect(c.ref).toBe("refs/heads/main");
+    expect(c.author_date).toBe("2026-07-01 12:00:00");
+    expect(c.total_seconds).toBeNull();
+  });
+
+  it("omits committer fields for GitLab (not present in the payload)", () => {
+    const payload = {
+      ref: "refs/heads/dev",
+      project: { path_with_namespace: "grp/proj" },
+      commits: [
+        {
+          id: "b".repeat(40),
+          message: "gitlab commit",
+          author: { name: "Lin", email: "lin@example.test" },
+          committer: { name: "ShouldBeIgnored", email: "nope@example.test" },
+          timestamp: "2026-07-02T09:30:00Z",
+          url: "https://gitlab.test/grp/proj/-/commit/bbb",
+        },
+      ],
+    };
+    const { commits } = mapCommits("gitlab", payload);
+    expect(commits[0].committer_name).toBeNull();
+    expect(commits[0].committer_email).toBeNull();
+    expect(commits[0].author_name).toBe("Lin");
+    expect(commits[0].ref).toBe("refs/heads/dev");
+  });
+
+  it("clamps an over-long message, omits an unparseable date, drops a no-id object", () => {
+    const payload = {
+      ref: "refs/heads/main",
+      repository: { full_name: "octo/hello" },
+      commits: [
+        { id: "c".repeat(40), message: "x".repeat(5000), timestamp: "not-a-date" },
+        { message: "no id here" }, // dropped — no usable hash
+      ],
+    };
+    const { received, commits } = mapCommits("github", payload);
+    expect(received).toBe(2); // both objects counted
+    expect(commits).toHaveLength(1); // only the one with an id maps
+    expect(commits[0].message).toHaveLength(4096); // clamped to the CommitInput cap
+    expect(commits[0].author_date).toBeNull(); // unparseable timestamp omitted
+  });
+
+  it("returns zero commits for a payload with none", () => {
+    const { received, commits } = mapCommits("github", { repository: { full_name: "octo/hello" } });
+    expect(received).toBe(0);
+    expect(commits).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

PR2 (implementation) of #146 — the git-host webhook adapter. Adds a public
push-webhook receiver and an owner-authenticated registration CRUD, built on the
spec merged in #210. Implements T-101..T-108 of
`specs/146-git-webhook-adapter/tasks.md`.

## What's included

- **DB** — `migrations/0008_git_webhook_endpoints.sql` + `src/db/schema.sql`
  mirror: `webhook_endpoints` (secret AES-256-GCM encrypted at rest,
  `UNIQUE(user_id, provider, repo)`, `idx_user` + `idx_lookup(provider, repo)`).
- **Registration store** (`src/utils/webhooks/store.ts`) — owner-scoped CRUD +
  `lookupEndpoint` (enabled-only, for delivery); encrypt-on-write /
  decrypt-on-verify via the existing OAuth-token helpers (AAD `webhook:<id>`);
  duplicate `(provider, repo)` -> 409.
- **Pure adapters** (`src/utils/webhooks/providers.ts`) — GitHub HMAC-SHA256 over
  the **raw** body vs `X-Hub-Signature-256`, GitLab `X-Gitlab-Token`, both
  constant-time; event detection; repo extraction; payload -> `CommitInput`
  mapping (clamp + best-effort, drop no-hash). No D1, unit-testable.
- **Routes** (`src/routes/webhooks.ts`) — owner CRUD mirroring `/ai/prices`
  (404-not-403, secret write-only, immutable provider/repo -> 400) + the public
  receiver (`security: []`): provider -> raw body + parse -> event -> repo ->
  verify -> map (cap 100) -> one `db.batch()` of the shared `commitUpsertStmt`.
  **No heartbeat correlation** (reuses the `commits.bulk` write path);
  `total_seconds` stored absent, the read path renders "0 secs".
- **Wiring** (`src/index.ts`) — mount both sub-apps + CSRF-exempt the receiver.
- Export `commitUpsertStmt` / `CommitRow` from `commits.ts` (behavior-preserving).
- **Tests** — provider unit tests + receiver/CRUD integration tests.

## Key decisions (from the merged spec)

- Public receiver, repo read from the payload; the URL carries no secret (D-1).
- Secret encrypted (recoverable), not hashed, because the HMAC must recompute it (D-4).
- `401` (bad signature) vs `404` (unregistered/disabled) — the ratified narrow
  oracle; repo names are public and single-user is the default (D-7).
- 100-commit cap, correlation-free single `db.batch()` — the `commits.bulk`
  path, within the Workers per-request budget (D-6).
- Receiver handling order follows data-model.md (provider -> parse -> event ->
  repo -> verify -> map -> write); nothing is written until the signature verifies.

## Gates

- `npm run lint:api` -> valid (7 pre-existing ignores)
- `npm run generate` -> no content drift (EOL-only; PR2 makes no schema change)
- `npm run typecheck` -> clean (project + tests)
- `npm test` -> **707/707** passing (37 new: 13 unit + 24 integration)

## Operator action at deploy

Apply migration `0008_git_webhook_endpoints.sql` to the remote D1
(`wrangler d1 migrations apply <DB>`). Relies on the existing `ENCRYPTION_KEY`;
no new binding.

Closes #146
