### PR TITLE
fix: derive ai_provider/ai_model from the User-Agent for AI heartbeats

### DIFF
--- a/src/routes/heartbeats.ts
+++ b/src/routes/heartbeats.ts
@@ -100,13 +100,22 @@ function bindHeartbeatParams(
  * body, which would otherwise leave the usage rollup bucketed as `unknown`.
  * Returns undefined when nothing needs deriving so the existing bind path is
  * untouched.
+ *
+ * Derivation is all-or-nothing: it runs only when the client supplied NEITHER
+ * field. The compatible plugins carry both provider and model in the
+ * User-Agent, so a partially-populated pair is the client's own explicit data.
+ * Filling only the missing half from the UA could cross-attribute a co-running
+ * tool's model to the client's provider (e.g. an explicit `openai` provider
+ * left without a model, alongside a co-running `opus/4-8` token) — the exact
+ * mis-attribution `deriveAiIdentity` is careful to avoid. Explicit client data
+ * therefore wins wholesale.
  */
 function deriveAiForHeartbeat(
   input: HeartbeatInput,
   userAgent: string | undefined,
 ): AiIdentity | undefined {
   if (input.category !== "ai coding") return undefined;
-  if (input.ai_provider != null && input.ai_model != null) return undefined;
+  if (input.ai_provider != null || input.ai_model != null) return undefined;
   if (!userAgent) return undefined;
   return deriveAiIdentity(userAgent);
 }

--- a/src/routes/heartbeats.ts
+++ b/src/routes/heartbeats.ts
@@ -3,7 +3,7 @@ import type { AuthEnv } from "../types";
 import type { components } from "../types/generated";
 import { authMiddleware, getUserTimeout, getUserTimezone } from "../middleware/auth";
 import { getEpochBoundsForDate } from "../utils/time-format";
-import { resolveUserAgentId } from "../utils/user-agent";
+import { resolveUserAgentId, deriveAiIdentity, type AiIdentity } from "../utils/user-agent";
 import { applyRules, loadRules } from "../utils/custom-rules";
 import { INPUT_LIMITS, tooLong, truncateTo } from "../utils/input-limits";
 import { machineUpsertStmt } from "../utils/machine";
@@ -70,7 +70,8 @@ function bindHeartbeatParams(
   input: HeartbeatInput,
   machine: string | undefined,
   userAgentId: string | null,
-  now: string
+  now: string,
+  derivedAi?: AiIdentity,
 ): D1PreparedStatement {
   return stmt.bind(
     id, userId, input.entity, input.type, input.time,
@@ -81,13 +82,33 @@ function bindHeartbeatParams(
     input.ai_prompt_length ?? null, input.ai_input_tokens ?? null,
     input.ai_output_tokens ?? null, input.ai_cached_input_tokens ?? null,
     input.ai_reasoning_output_tokens ?? null, input.ai_cache_write_tokens ?? null,
-    input.ai_cache_read_tokens ?? null, input.ai_provider ?? null, input.ai_model ?? null,
+    input.ai_cache_read_tokens ?? null,
+    input.ai_provider ?? derivedAi?.provider ?? null,
+    input.ai_model ?? derivedAi?.model ?? null,
     input.lineno ?? null, input.cursorpos ?? null, input.is_write ? 1 : 0,
     input.editor ?? null, input.operating_system ?? null,
     machine ?? null,
     userAgentId,
     now
   );
+}
+
+/**
+ * For an `ai coding` heartbeat whose client did not populate `ai_provider` /
+ * `ai_model`, derive them from the User-Agent (Issue #200). Compatible AI
+ * plugins carry the model/provider in the User-Agent rather than the heartbeat
+ * body, which would otherwise leave the usage rollup bucketed as `unknown`.
+ * Returns undefined when nothing needs deriving so the existing bind path is
+ * untouched.
+ */
+function deriveAiForHeartbeat(
+  input: HeartbeatInput,
+  userAgent: string | undefined,
+): AiIdentity | undefined {
+  if (input.category !== "ai coding") return undefined;
+  if (input.ai_provider != null && input.ai_model != null) return undefined;
+  if (!userAgent) return undefined;
+  return deriveAiIdentity(userAgent);
 }
 
 const heartbeats = new Hono<AuthEnv>();
@@ -248,8 +269,9 @@ heartbeats.post("/heartbeats.bulk", async (c) => {
     if (validationErrors[i] || hidden[i]) continue;
     const input = inputs[i];
     const machine = input.machine ?? headerMachine;
+    const derivedAi = deriveAiForHeartbeat(input, input.user_agent ?? headerUserAgent);
     stmts.push(
-      bindHeartbeatParams(c.env.DB.prepare(INSERT_HEARTBEAT_SQL), ids[i], userId, input, machine, userAgentIds[i], now)
+      bindHeartbeatParams(c.env.DB.prepare(INSERT_HEARTBEAT_SQL), ids[i], userId, input, machine, userAgentIds[i], now, derivedAi)
     );
     if (input.project) {
       const existing = projectTimes.get(input.project);
@@ -519,8 +541,9 @@ async function insertHeartbeat(
   // D1.batch() does not propagate RETURNING values across statements; we need
   // the id before binding the heartbeat insert.
   const userAgentId = await resolveUserAgentId(db, userId, userAgent ?? null);
+  const derivedAi = deriveAiForHeartbeat(input, userAgent);
 
-  const stmts = [bindHeartbeatParams(db.prepare(INSERT_HEARTBEAT_SQL), id, userId, input, machine, userAgentId, now)];
+  const stmts = [bindHeartbeatParams(db.prepare(INSERT_HEARTBEAT_SQL), id, userId, input, machine, userAgentId, now, derivedAi)];
   if (input.project) {
     stmts.push(db.prepare(UPSERT_PROJECT_SQL).bind(userId, input.project, input.time, input.time));
   }

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -72,6 +72,96 @@ export function parseUserAgent(value: string): ParsedUserAgent {
 }
 
 /**
+ * Known Anthropic model families as they appear in a compatible AI-tool
+ * User-Agent (e.g. `opus/4-8`, `fable/5`). The token after the slash is the
+ * version; `opus/4-8` normalizes to `claude-opus-4-8`, matching the model key
+ * used by the owner-managed pricing table (Issue #200).
+ */
+const ANTHROPIC_MODEL_FAMILIES = new Set([
+  "opus", "sonnet", "haiku", "fable", "mythos",
+]);
+
+/**
+ * Map an AI coding tool (the `<tool>-wakatime` plugin that emitted the
+ * heartbeat) to the LLM provider whose models it drives.
+ */
+const AI_TOOL_PROVIDER: Record<string, string> = {
+  "claude-code": "anthropic",
+  "codex-cli": "openai",
+};
+
+export interface AiIdentity {
+  /** LLM provider (e.g. "anthropic", "openai"). Null when unrecognised. */
+  provider: string | null;
+  /** Canonical model id (e.g. "claude-opus-4-8"). Null when not derivable. */
+  model: string | null;
+}
+
+/**
+ * Best-effort derivation of the AI provider/model from a compatible AI-tool
+ * User-Agent, for `ai coding` heartbeats whose client did not populate
+ * `ai_provider` / `ai_model` explicitly (Issue #200). Compatible AI plugins put
+ * the model in the User-Agent (e.g. `... opus/4-8 claude-code/2.1.205
+ * claude-code-wakatime/4.1.0`) rather than in the heartbeat body, so the rollup
+ * would otherwise bucket every provider/model as `unknown`.
+ *
+ * The emitting tool is identified by its `<tool>-wakatime/<ver>` plugin token;
+ * the provider follows from the tool. The `<family>/<ver>` model token is only
+ * attributed when the provider is Anthropic — the same token can co-occur in a
+ * co-running tool's heartbeat (e.g. a `codex-cli` heartbeat whose UA still
+ * carries `opus/4-8`), so it is never cross-attributed to another provider.
+ * Returns nulls for unrecognised shapes.
+ */
+export function deriveAiIdentity(value: string): AiIdentity {
+  const tokens = value.split(/\s+/).filter((t) => t.length > 0);
+
+  // The `<tool>-wakatime/<ver>` plugin identifier at the tail is the definitive
+  // signal for which AI tool actually produced this heartbeat.
+  let tool: string | null = null;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const slash = tokens[i].lastIndexOf("/");
+    if (slash <= 0) continue;
+    const name = tokens[i].slice(0, slash).toLowerCase();
+    if (name.endsWith("-wakatime")) {
+      tool = name.slice(0, -"-wakatime".length);
+      break;
+    }
+  }
+  // Fallback: no plugin token — accept a bare `<tool>/<ver>` known-tool token,
+  // but only when a single known tool is present. A co-running pair (e.g. both
+  // `claude-code/…` and `codex-cli/…`) is ambiguous without the disambiguating
+  // `-wakatime` plugin token, so it is left unresolved.
+  if (tool === null) {
+    const bare = new Set<string>();
+    for (const t of tokens) {
+      const slash = t.indexOf("/");
+      if (slash <= 0) continue;
+      const name = t.slice(0, slash).toLowerCase();
+      if (AI_TOOL_PROVIDER[name] !== undefined) bare.add(name);
+    }
+    if (bare.size === 1) tool = [...bare][0];
+  }
+  const provider = tool ? (AI_TOOL_PROVIDER[tool] ?? null) : null;
+
+  // Model: the `<family>/<ver>` token, attributed only when the provider is
+  // Anthropic (never cross-attributed to a codex/other heartbeat).
+  let model: string | null = null;
+  if (provider === "anthropic") {
+    for (const t of tokens) {
+      const slash = t.indexOf("/");
+      if (slash <= 0 || slash === t.length - 1) continue;
+      const family = t.slice(0, slash).toLowerCase();
+      if (ANTHROPIC_MODEL_FAMILIES.has(family)) {
+        model = `claude-${family}-${t.slice(slash + 1)}`;
+        break;
+      }
+    }
+  }
+
+  return { provider, model };
+}
+
+/**
  * Upsert a `user_agents` row for the given user + raw value and return its id.
  * Returns null when `value` is falsy so the caller can store NULL.
  *

--- a/tests/integration/ai-heartbeats.test.ts
+++ b/tests/integration/ai-heartbeats.test.ts
@@ -230,3 +230,92 @@ describe("POST /heartbeats.bulk — AI telemetry", () => {
     expect(data).toHaveLength(2);
   });
 });
+
+describe("AI provider/model derived from the User-Agent (Issue #200)", () => {
+  // Real compatible AI-plugin User-Agents observed in production: the model
+  // lives in the UA (`opus/4-8`), not the heartbeat body.
+  const CLAUDE_UA =
+    "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 claude-code-wakatime/4.1.0";
+  const CODEX_UA =
+    "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 codex-cli/unknown codex-cli-wakatime/1.0.0";
+
+  async function firstStored(): Promise<Record<string, unknown>> {
+    const get = await callWorker("/api/v1/users/current/heartbeats?date=2026-03-14", {
+      headers: authHeader(user.apiKey),
+    });
+    return ((await get.json()) as { data: Record<string, unknown>[] }).data[0];
+  }
+
+  it("fills ai_provider/ai_model from a Claude Code UA when the client omits them", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": CLAUDE_UA, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ ai_provider: undefined, ai_model: undefined })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_provider).toBe("anthropic");
+    expect(hb.ai_model).toBe("claude-opus-4-8");
+  });
+
+  it("attributes a codex heartbeat to openai without cross-attributing the claude model", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": CODEX_UA, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ ai_provider: undefined, ai_model: undefined })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_provider).toBe("openai");
+    expect(hb.ai_model).toBeNull();
+  });
+
+  it("never overrides an explicit ai_provider/ai_model sent by the client", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": CLAUDE_UA, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ ai_provider: "anthropic", ai_model: "claude-sonnet-5" })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_model).toBe("claude-sonnet-5");
+  });
+
+  it("does not derive for a non-`ai coding` heartbeat", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": CLAUDE_UA, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ category: "coding", ai_provider: undefined, ai_model: undefined })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_provider).toBeNull();
+    expect(hb.ai_model).toBeNull();
+  });
+
+  it("derives per item in a bulk batch from each item's own User-Agent", async () => {
+    const res = await callWorker("/api/v1/users/current/heartbeats.bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader(user.apiKey) },
+      body: JSON.stringify([
+        aiHeartbeat({ entity: "a.ts", user_agent: CLAUDE_UA, ai_provider: undefined, ai_model: undefined }),
+        aiHeartbeat({ entity: "b.ts", user_agent: CODEX_UA, ai_provider: undefined, ai_model: undefined }),
+      ]),
+    });
+    expect(res.status).toBe(202);
+
+    const get = await callWorker("/api/v1/users/current/heartbeats?date=2026-03-14", {
+      headers: authHeader(user.apiKey),
+    });
+    const data = ((await get.json()) as { data: Record<string, unknown>[] }).data;
+    const byEntity = Object.fromEntries(data.map((h) => [h.entity, h]));
+    expect(byEntity["a.ts"].ai_provider).toBe("anthropic");
+    expect(byEntity["a.ts"].ai_model).toBe("claude-opus-4-8");
+    expect(byEntity["b.ts"].ai_provider).toBe("openai");
+    expect(byEntity["b.ts"].ai_model).toBeNull();
+  });
+});

--- a/tests/integration/ai-heartbeats.test.ts
+++ b/tests/integration/ai-heartbeats.test.ts
@@ -284,6 +284,23 @@ describe("AI provider/model derived from the User-Agent (Issue #200)", () => {
     expect(hb.ai_model).toBe("claude-sonnet-5");
   });
 
+  it("does not cross-attribute a derived model when the client pins only the provider", async () => {
+    // Client sent an explicit provider but no model, alongside a Claude Code UA
+    // carrying `opus/4-8`. Deriving only the missing model would attach the
+    // co-running Claude model to the client's provider — derivation is
+    // all-or-nothing, so the explicit provider wins and the model stays null.
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": CLAUDE_UA, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ ai_provider: "openai", ai_model: undefined })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_provider).toBe("openai");
+    expect(hb.ai_model).toBeNull();
+  });
+
   it("does not derive for a non-`ai coding` heartbeat", async () => {
     const res = await callWorker("/api/v1/users/current/heartbeats", {
       method: "POST",

--- a/tests/security/user-agent.test.ts
+++ b/tests/security/user-agent.test.ts
@@ -5,7 +5,7 @@
  *   wakatime/<cli-ver> (<os>-<core>-<platform>) <runtime> <plugin>/<plugin-ver>
  */
 import { describe, expect, it } from "vitest";
-import { parseUserAgent } from "../../src/utils/user-agent";
+import { deriveAiIdentity, parseUserAgent } from "../../src/utils/user-agent";
 
 describe("parseUserAgent (compatible CLI format)", () => {
   it("extracts os, editor, and version from the standard format", () => {
@@ -51,5 +51,49 @@ describe("parseUserAgent (compatible CLI format)", () => {
 
   it("lower-cases the OS family", () => {
     expect(parseUserAgent("wakatime/v1 (DARWIN-23-arm64) go1 ed/1").os).toBe("darwin");
+  });
+});
+
+describe("deriveAiIdentity (AI provider/model from a compatible AI-tool UA)", () => {
+  it("derives anthropic + claude-opus-4-8 from a Claude Code UA", () => {
+    const ua =
+      "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 claude-code-wakatime/4.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "anthropic", model: "claude-opus-4-8" });
+  });
+
+  it("normalizes other Anthropic model families (fable/5 -> claude-fable-5)", () => {
+    const ua =
+      "wakatime/v2.21.4 (windows-10.0.26200.8655-x86_64) go1.26.4 fable/5 claude-code/2.1.202 claude-code-wakatime/4.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "anthropic", model: "claude-fable-5" });
+  });
+
+  it("attributes a codex heartbeat to openai and never cross-attributes the co-running claude model", () => {
+    // `opus/4-8` is present only because Claude Code runs alongside; the
+    // `-wakatime` plugin token proves codex-cli emitted this heartbeat.
+    const ua =
+      "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 codex-cli/unknown codex-cli-wakatime/1.0.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: null });
+  });
+
+  it("resolves a single tool from a bare token when no -wakatime plugin token is present", () => {
+    const ua =
+      "wakatime/v2.21.4 (windows-10.0.26200.8655-x86_64) go1.26.4 opus/4-8 claude-code/2.1.198";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "anthropic", model: "claude-opus-4-8" });
+  });
+
+  it("leaves a co-running pair unresolved when the disambiguating plugin token is absent", () => {
+    const ua =
+      "wakatime/v2.21.4 (windows-10-amd64) go1.26.4 opus/4-8 claude-code/2.1.205 codex-cli/unknown";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: null, model: null });
+  });
+
+  it("returns the provider without a model when the Anthropic tool reports no model token", () => {
+    const ua = "wakatime/v2.22.0 (windows-10-amd64) go1.26.5 claude-code/2.1.205 claude-code-wakatime/4.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "anthropic", model: null });
+  });
+
+  it("returns all-null for a non-AI editor UA", () => {
+    const ua = "wakatime/v1.65.2 (linux-6.5.0-amd64) go1.21.5 vscode-wakatime/24.0.4";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: null, model: null });
   });
 });


### PR DESCRIPTION
## Problem

AI token usage flows into cloudtime but the **per-AI-service breakdown never populates** — `GET /users/current/ai/usage` returns empty `by_provider` / `by_model` and a `null` estimated cost, even though tokens are arriving.

Root cause, confirmed against real production data:

- The compatible AI-coding WakaTime plugins (`claude-code-wakatime`, `codex-cli-wakatime`) sync AI heartbeats to `heartbeats.bulk` with the token fields populated (e.g. one heartbeat carried `ai_input_tokens: 801901`), but they put the **model in the User-Agent**, not the heartbeat body:

  ```
  wakatime/v2.22.0 (windows-…) go1.26.5 opus/4-8 claude-code/2.1.205 claude-code-wakatime/4.1.0
  ```

- So `ai_provider` / `ai_model` arrive `NULL`. `computeAiDailyUsage` falls back to `provider = "unknown"` / `model = "unknown"`, and — because no owner price row matches `unknown` — cost estimation is impossible. Across all `ai coding` heartbeats: `token_hbs = 26`, `provider_hbs = 0`, `model_hbs = 0`.

(The pre-existing `500` on `heartbeats.bulk` for AI payloads was a *separate* issue caused by the old deployed build predating the Issue #200 columns; it is already resolved by deploying the current `develop`.)

## Fix

Derive `ai_provider` / `ai_model` from the User-Agent at ingestion, **only** when an `ai coding` heartbeat omits them:

- The emitting tool is identified by its `<tool>-wakatime` plugin token (with a fallback to a single bare `<tool>` token; a co-running pair with no plugin token is deliberately left unresolved to avoid guessing). `claude-code → anthropic`, `codex-cli → openai`.
- The `<family>/<ver>` model token (`opus/4-8 → claude-opus-4-8`, `fable/5 → claude-fable-5`) is attributed **only when the provider is Anthropic**, so a co-running Claude model token is never cross-attributed to a `codex-cli` heartbeat.
- An explicit client-supplied `ai_provider` / `ai_model` always wins.

`agent` already distinguishes tools today (it resolves to `user_agents.editor`, i.e. `claude-code-wakatime` vs `codex-cli-wakatime`), so this PR only fills the missing provider/model.

## Scope / boundaries

- **Server-side ingestion only. No OpenAPI/schema change** (`ai_provider`/`ai_model` were already optional inputs), so `generated.ts` is untouched — impl-only, no spec PR needed.
- Parsing extends the existing WakaTime-compatible User-Agent parser (`parseUserAgent`); it reads a User-Agent this server already receives and stores. No third-party source/design was consulted.

## Changes

- `src/utils/user-agent.ts` — new `deriveAiIdentity(ua)` (pure, tested).
- `src/routes/heartbeats.ts` — apply it in the single + bulk ingest paths via `deriveAiForHeartbeat`, backfilling `ai_provider`/`ai_model` when absent.
- Tests grounded in real UA strings: `tests/security/user-agent.test.ts` (unit), `tests/integration/ai-heartbeats.test.ts` (ingest round-trip incl. the codex non-cross-attribution and the "explicit wins" / "non-ai-coding not derived" cases).

## Gates

`lint:api` ✅ · `generate` no-drift (LF/CRLF only) ✅ · `typecheck` ✅ · `test` **719/719** ✅

## Follow-ups (separate, out of scope)

- Ship default AI model prices in the codebase (LiteLLM-style maintained map) so cost works without manual entry.
- Optionally document the derivation in the OpenAPI description (spec-first).

Refs #200
