### PR TITLE
feat: derive OpenAI model from the User-Agent for AI heartbeats

### DIFF
--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -41,6 +41,43 @@ token field (any of the six token classes above). Presence, not value, decides
 this: a heartbeat with `ai_input_tokens: 0` contributes, while a heartbeat that
 carries only `ai_prompt_length` does not.
 
+### Deriving provider and model from the User-Agent
+
+`ai_provider` and `ai_model` are optional. When an `ai coding` heartbeat omits
+them, CloudTime fills them best-effort from the client User-Agent so per-provider
+and per-model breakdowns work without the client changing its request body. An
+explicit `ai_provider`/`ai_model` in the body always wins and is never
+overwritten.
+
+A compatible AI CLI composes a User-Agent whose tail lists the emitting plugin
+and, where available, the active model, for example:
+
+```
+wakatime/<cli-ver> (<os>) <runtime> opus/4-8 claude-code/2.1.205 claude-code-wakatime/4.1.0
+wakatime/<cli-ver> (<os>) <runtime> gpt-5.5/xhigh codex-cli/2.2.0 codex-cli-wakatime/1.1.0
+```
+
+CloudTime reads two things from it:
+
+- **Provider** — from the `<tool>-wakatime` plugin token that identifies which
+  tool emitted the heartbeat: `claude-code-wakatime` → `anthropic`,
+  `codex-cli-wakatime` → `openai`.
+- **Model** — from a recognized model token: an Anthropic `family/version`
+  (`opus/4-8` → `claude-opus-4-8`) or an OpenAI model id
+  (`gpt-5.5/xhigh` → `gpt-5.5`; the effort/detail after the slash is dropped).
+
+The model is attributed **only for the resolved provider**, so a co-running
+tool's token is never cross-attributed. A Codex heartbeat's User-Agent can still
+carry Anthropic's `opus/4-8` because another assistant runs alongside; that token
+is ignored, and the codex heartbeat resolves to `openai` with an OpenAI model
+only if an OpenAI id such as `gpt-5.5/xhigh` is present.
+
+**If your client does not send the model**, `ai_model` stays `null` and that
+usage rolls up under an `unknown` model bucket (still attributed to the
+provider). To get per-model breakdowns and cost, either send `ai_model`
+explicitly in the heartbeat body, or have the client include the model as a
+`<model>/<detail>` token in its plugin User-Agent as shown above.
+
 ## Usage summary
 
 `GET /api/v1/users/current/ai/usage` returns an owner-only `AIUsageSummary` over

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -90,6 +90,16 @@ const AI_TOOL_PROVIDER: Record<string, string> = {
   "codex-cli": "openai",
 };
 
+/**
+ * A UA token name that denotes a genuine OpenAI model id (e.g. `gpt-5.5`,
+ * `gpt-5.5-codex`, `o3`, `chatgpt-*`, `codex-mini-*`), used to attribute the
+ * model for `openai` heartbeats. Deliberately excludes the emitting-tool tokens
+ * (`codex-cli`, `codex-cli-wakatime`) and every Anthropic family (`opus`,
+ * `sonnet`, …) that can bleed into a co-running Codex UA, so a co-running
+ * model is never cross-attributed.
+ */
+const OPENAI_MODEL_NAME = /^(?:gpt[-.\d]|o[1-9](?:[-.\d]|$)|chatgpt|codex-mini)/;
+
 export interface AiIdentity {
   /** LLM provider (e.g. "anthropic", "openai"). Null when unrecognised. */
   provider: string | null;
@@ -143,8 +153,11 @@ export function deriveAiIdentity(value: string): AiIdentity {
   }
   const provider = tool ? (AI_TOOL_PROVIDER[tool] ?? null) : null;
 
-  // Model: the `<family>/<ver>` token, attributed only when the provider is
-  // Anthropic (never cross-attributed to a codex/other heartbeat).
+  // Model: attributed from a `<name>/<ver>` token, but only for the resolved
+  // provider so a co-running tool's model token is never cross-attributed
+  // (a Codex heartbeat's UA can still carry Anthropic's `opus/4-8`, and vice
+  // versa). Anthropic uses a known family whitelist; OpenAI matches a genuine
+  // model-id shape.
   let model: string | null = null;
   if (provider === "anthropic") {
     for (const t of tokens) {
@@ -153,6 +166,21 @@ export function deriveAiIdentity(value: string): AiIdentity {
       const family = t.slice(0, slash).toLowerCase();
       if (ANTHROPIC_MODEL_FAMILIES.has(family)) {
         model = `claude-${family}-${t.slice(slash + 1)}`;
+        break;
+      }
+    }
+  } else if (provider === "openai") {
+    // Compatible OpenAI tools (e.g. codex-cli) may carry the model as an
+    // `<model>/<effort>` token such as `gpt-5.5/xhigh`; keep the model id only
+    // (the effort/detail after the slash is dropped). The whole `<name>` before
+    // the slash is the canonical id — OpenAI ids are already full, unlike the
+    // Anthropic `family/ver` shape.
+    for (const t of tokens) {
+      const slash = t.indexOf("/");
+      if (slash <= 0) continue;
+      const name = t.slice(0, slash).toLowerCase();
+      if (OPENAI_MODEL_NAME.test(name)) {
+        model = name;
         break;
       }
     }

--- a/tests/integration/ai-heartbeats.test.ts
+++ b/tests/integration/ai-heartbeats.test.ts
@@ -272,6 +272,23 @@ describe("AI provider/model derived from the User-Agent (Issue #200)", () => {
     expect(hb.ai_model).toBeNull();
   });
 
+  it("fills ai_model from a codex UA that forwards the model token (gpt-5.5)", async () => {
+    // A model-forwarding client appends `gpt-5.5/xhigh`; the co-running
+    // `opus/4-8` must not be mistaken for the codex heartbeat's model.
+    const codexWithModel =
+      "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 gpt-5.5/xhigh codex-cli/unknown codex-cli-wakatime/1.0.0";
+    const res = await callWorker("/api/v1/users/current/heartbeats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": codexWithModel, ...authHeader(user.apiKey) },
+      body: JSON.stringify(aiHeartbeat({ ai_provider: undefined, ai_model: undefined })),
+    });
+    expect(res.status).toBe(201);
+
+    const hb = await firstStored();
+    expect(hb.ai_provider).toBe("openai");
+    expect(hb.ai_model).toBe("gpt-5.5");
+  });
+
   it("never overrides an explicit ai_provider/ai_model sent by the client", async () => {
     const res = await callWorker("/api/v1/users/current/heartbeats", {
       method: "POST",

--- a/tests/security/user-agent.test.ts
+++ b/tests/security/user-agent.test.ts
@@ -75,6 +75,32 @@ describe("deriveAiIdentity (AI provider/model from a compatible AI-tool UA)", ()
     expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: null });
   });
 
+  it("derives openai + gpt-5.5 from a codex UA that carries the model token, ignoring co-running opus/4-8", () => {
+    // A client that forwards the active model appends `gpt-5.5/xhigh`; the
+    // `opus/4-8` is Claude bleed and must NOT be attributed to the codex heartbeat.
+    const ua =
+      "wakatime/v2.22.0 (windows-10.0.26200.8655-x86_64) go1.26.5 opus/4-8 claude-code/2.1.205 gpt-5.5/xhigh codex-cli/unknown codex-cli-wakatime/1.0.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("keeps a suffixed OpenAI model id (gpt-5.6-codex) and drops the effort detail", () => {
+    const ua =
+      "wakatime/v2.22.0 (windows-10-amd64) go1.26.5 gpt-5.6-codex/high codex-cli/2.2.0 codex-cli-wakatime/1.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: "gpt-5.6-codex" });
+  });
+
+  it("matches an o-series OpenAI id with no version slot (o3)", () => {
+    const ua = "wakatime/v2.22.0 (linux-6.5.0-amd64) go1.26.5 o3/medium codex-cli/2.2.0 codex-cli-wakatime/1.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: "o3" });
+  });
+
+  it("does not mistake the codex-cli tool token for an OpenAI model", () => {
+    // Regression: `codex-cli/<ver>` must never be read as the model; with no
+    // genuine model token the model stays null.
+    const ua = "wakatime/v2.22.0 (windows-10-amd64) go1.26.5 codex-cli/2.2.0 codex-cli-wakatime/1.1.0";
+    expect(deriveAiIdentity(ua)).toEqual({ provider: "openai", model: null });
+  });
+
   it("resolves a single tool from a bare token when no -wakatime plugin token is present", () => {
     const ua =
       "wakatime/v2.21.4 (windows-10.0.26200.8655-x86_64) go1.26.4 opus/4-8 claude-code/2.1.198";


### PR DESCRIPTION
## Summary
Extends `deriveAiIdentity` to attribute an **OpenAI model id** (e.g. `gpt-5.5`) from the client User-Agent on `openai` heartbeats, mirroring the existing Anthropic `family/version` derivation. Previously codex/openai heartbeats resolved to `openai` with a `null` model (bucketed as `unknown`), because only Anthropic models were parsed from the UA.

## Why
`ai coding` heartbeats carry the model in the User-Agent, not the body. Anthropic tokens (`opus/4-8` → `claude-opus-4-8`) were already derived; OpenAI ones were not. When a compatible client forwards the active model as a `<model>/<detail>` token (e.g. `gpt-5.5/xhigh`), CloudTime can now attribute it — so per-model token/cost breakdowns work for Codex, not just Claude.

## No cross-attribution
A Codex heartbeat's UA can still carry a co-running assistant's `opus/4-8` (Claude bleed). The new OpenAI branch matches only genuine OpenAI ids via `^(gpt[-.\d]|o[1-9](...)|chatgpt|codex-mini)`, so:
- the emitting-tool tokens (`codex-cli`, `codex-cli-wakatime`) are never read as the model, and
- a co-running Anthropic family token is never attributed to the openai heartbeat.

Model is attributed **only for the resolved provider** (openai), preserving the existing guarantee.

## Changes
- `src/utils/user-agent.ts` — `OPENAI_MODEL_NAME` id-shape regex + an `openai` branch in `deriveAiIdentity` (drops the effort/detail after the slash; keeps the model id).
- `tests/security/user-agent.test.ts` — 4 unit tests (gpt-5.5 with opus bleed ignored, suffixed `gpt-5.6-codex`, bare `o3`, tool-token-not-a-model regression).
- `tests/integration/ai-heartbeats.test.ts` — 1 ingestion test (patched codex UA → stored `openai`/`gpt-5.5`).
- `docs/ai-usage.md` — documents the UA provider/model derivation convention and how a client should forward the model.

## Testing
- `npm test` → 725 passed (was 720; +5).
- `npm run typecheck` → clean.
- **Impl-only, no spec change**: `ai_provider`/`ai_model` are already free-form strings in the OpenAPI schema; `npm run generate` produces no content diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)