### PR TITLE
feat: ship default AI model prices (family-based, no stale hardcoding)

### DIFF
--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -123,6 +123,29 @@ excluded from every `estimated_cost`, counted in `missing_price_count`, and the
 summary sets `mixed_currency: true` to warn that some priced usage is not
 reflected in the totals.
 
+## Shipped default prices
+
+So a fresh instance estimates cost before anyone configures anything, CloudTime
+ships a small **default price catalog** exposed as read-only `is_default` rows.
+Defaults resolve by the *shape* of a model id rather than pinning every release,
+so a steady stream of new models does not immediately go stale:
+
+- **Anthropic** rates are flat within a family generation, so a default resolves
+  from the family: `claude-opus-*` → $5/$25, `claude-sonnet-*` → $3/$15,
+  `claude-haiku-*` → $1/$5, `claude-fable-*` / `claude-mythos-*` → $10/$50. A
+  future `claude-opus-4-9` is priced with no code change; the price list shows
+  these as family entries (`claude-opus-*`).
+- **OpenAI** is priced per version, so its models are listed explicitly: `gpt-5`,
+  `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`, and the three `gpt-5.6` tiers (Sol /
+  Terra / Luna). An OpenAI model not in the list is left unpriced.
+
+An owner price row always outranks the shipped default for the same
+`(provider, model)`. A model no default covers stays unpriced and surfaces in
+`missing_price_count` — never a silent zero — so you can add a row for it. The
+catalog is code-maintained (no per-instance seeding or migration); its synthetic
+`default:<provider>:<model>` ids are not individually addressable, so the
+single-row price endpoints `404` on them.
+
 ## Owner-managed pricing table
 
 Estimated cost is only as good as the prices you configure. Price rows are

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -18,6 +18,7 @@ import {
   toMs,
   validateCreatePrice,
   validateUpdatePrice,
+  type AiModelPriceRow,
 } from "../utils/ai/pricing";
 import {
   applyPriceUpdate,
@@ -27,6 +28,7 @@ import {
   listEnabledPrices,
   listPrices,
 } from "../utils/ai/price-store";
+import { resolveDefaultPrice } from "../utils/ai/default-prices";
 import {
   AI_DAILY_USAGE_SELECT_COLUMNS,
   buildUsageSummary,
@@ -200,8 +202,20 @@ ai.get("/ai/usage", async (c) => {
       .bind(...binds)
       .all<AiDailyUsageRow>();
 
-    // Only enabled price rows participate in cost estimation.
+    // Only enabled owner price rows participate in cost estimation.
     const prices = await listEnabledPrices(c.env.DB, userId);
+    // Resolve a shipped default for each (provider, model) actually used, so cost
+    // estimation covers models the owner has not priced. Owner rows still win in
+    // selectEffectivePrice; an unresolved model stays unpriced (missing_price_count).
+    const resolved = new Set<string>();
+    const defaults: AiModelPriceRow[] = [];
+    for (const r of rows) {
+      const key = `${r.provider} ${r.model}`;
+      if (resolved.has(key)) continue;
+      resolved.add(key);
+      const d = resolveDefaultPrice(userId, r.provider, r.model);
+      if (d) defaults.push(d);
+    }
 
     const summary = buildUsageSummary({
       start: range.start,
@@ -209,7 +223,7 @@ ai.get("/ai/usage", async (c) => {
       timezone: requestTz,
       aggregationTz,
       rows,
-      prices,
+      prices: [...prices, ...defaults],
     });
 
     return c.json({ data: summary });

--- a/src/utils/ai/default-prices.ts
+++ b/src/utils/ai/default-prices.ts
@@ -1,0 +1,150 @@
+/**
+ * Shipped default AI model prices (Issue #200 follow-up). A code-maintained
+ * catalog of API-equivalent list rates so a fresh CloudTime instance estimates
+ * cost out of the box, before an owner configures anything. Values are per
+ * 1,000,000 tokens in USD.
+ *
+ * Design: resolve prices by the *shape* of a model id rather than pinning every
+ * version, so a steady stream of new models does not go stale immediately.
+ *   - **Anthropic** prices are flat within a family generation (every
+ *     `claude-opus-*` is $5/$25, `claude-sonnet-*` $3/$15, …), so a default is
+ *     resolved from the family — a future `claude-opus-4-9` is priced with no
+ *     code change.
+ *   - **OpenAI** prices per version with no flat family rate, so its models are
+ *     listed explicitly. An OpenAI model not in the list resolves to `null`.
+ * An unresolved model stays unpriced and surfaces in `missing_price_count`
+ * (never a silent zero); the owner can add a row for it.
+ *
+ * Defaults materialize as read-only `is_default = 1` rows merged into price
+ * reads, not stored in D1 — nothing to seed or migrate. `selectEffectivePrice`
+ * ranks any owner row ahead of a default, so overrides win; the synthetic
+ * `default:<provider>:<model>` ids never exist in D1, so the single-row price
+ * endpoints 404 on them (id existence is not leaked). Model ids match what
+ * `deriveAiIdentity` produces (`opus/4-8` → `claude-opus-4-8`).
+ *
+ * Rate conventions: `cached_input` (cache-hit input) = 0.1× input; `reasoning_output`
+ * is billed at the output rate; Anthropic also sets `cache_write` = 1.25× input
+ * (5-minute write) and `cache_read` = 0.1× input, which OpenAI leaves null (it
+ * reports cache reads as `cached_input`). Unused token classes never affect a
+ * bucket, so over-specifying a rate is harmless.
+ */
+import type { AiModelPriceRow } from "./pricing";
+
+/** Effective-from for every shipped default: a broad past window, open-ended. */
+export const DEFAULT_PRICE_EFFECTIVE_FROM = "2020-01-01 00:00:00";
+
+const ANTHROPIC_SRC = "https://platform.claude.com/docs/en/about-claude/pricing";
+const OPENAI_SRC = "https://developers.openai.com/api/docs/pricing";
+
+/**
+ * Anthropic family → [input, output] per-MTok USD. Flat within a family
+ * generation, so any version resolves from its family (verified 2026-07).
+ */
+const ANTHROPIC_FAMILY_RATES: Record<string, readonly [number, number]> = {
+  opus: [5, 25],
+  sonnet: [3, 15],
+  haiku: [1, 5],
+  fable: [10, 50],
+  mythos: [10, 50],
+};
+
+/**
+ * OpenAI is priced per version, so each model id is listed explicitly (verified
+ * 2026-07). gpt-5.6 ships three tiers; the bare `gpt-5.6` slug maps to Sol.
+ */
+const OPENAI_MODEL_RATES: Record<string, readonly [number, number]> = {
+  "gpt-5": [1.25, 10],
+  "gpt-5.3-codex": [1.75, 14],
+  "gpt-5.4": [2.5, 15],
+  "gpt-5.5": [5, 30],
+  "gpt-5.6": [5, 30], // bare slug → Sol tier
+  "gpt-5.6-sol": [5, 30],
+  "gpt-5.6-terra": [2.5, 15],
+  "gpt-5.6-luna": [1, 6],
+};
+
+/** Avoid binary-float noise in derived rates (e.g. 1.25 * 0.1). */
+function round(n: number): number {
+  return Math.round(n * 1e6) / 1e6;
+}
+
+/** Build a synthetic `is_default = 1` row for one (provider, model). */
+function makeRow(
+  userId: string,
+  provider: string,
+  model: string,
+  input: number,
+  output: number,
+  source: string,
+  anthropicCache: boolean,
+): AiModelPriceRow {
+  const ts = DEFAULT_PRICE_EFFECTIVE_FROM;
+  return {
+    id: `default:${provider}:${model}`,
+    user_id: userId,
+    provider,
+    model,
+    currency: "USD",
+    input_cost_per_mtok: input,
+    cached_input_cost_per_mtok: round(input * 0.1),
+    output_cost_per_mtok: output,
+    reasoning_output_cost_per_mtok: output,
+    cache_write_cost_per_mtok: anthropicCache ? round(input * 1.25) : null,
+    cache_read_cost_per_mtok: anthropicCache ? round(input * 0.1) : null,
+    effective_from: ts,
+    effective_to: null,
+    source_url: source,
+    is_default: 1,
+    is_enabled: 1,
+    created_at: ts,
+    updated_at: ts,
+  };
+}
+
+/** The family in a derived Anthropic id (`claude-opus-4-8` → `opus`), else null. */
+function anthropicFamily(model: string): string | null {
+  const m = /^claude-([a-z]+)-/.exec(model);
+  return m ? m[1] : null;
+}
+
+/**
+ * Resolve the shipped default price for a concrete (provider, model), or null
+ * when none applies (the model stays unpriced → `missing_price_count`). Anthropic
+ * resolves by family (new versions covered without a code change); OpenAI resolves
+ * from the explicit per-version list. Used by cost estimation for exactly the
+ * models that appear in a usage summary.
+ */
+export function resolveDefaultPrice(
+  userId: string,
+  provider: string,
+  model: string,
+): AiModelPriceRow | null {
+  if (provider === "anthropic") {
+    const fam = anthropicFamily(model);
+    const rate = fam ? ANTHROPIC_FAMILY_RATES[fam] : undefined;
+    return rate ? makeRow(userId, provider, model, rate[0], rate[1], ANTHROPIC_SRC, true) : null;
+  }
+  if (provider === "openai") {
+    const rate = OPENAI_MODEL_RATES[model];
+    return rate ? makeRow(userId, provider, model, rate[0], rate[1], OPENAI_SRC, false) : null;
+  }
+  return null;
+}
+
+/**
+ * Representative default rows for the price-list UI (`GET /ai/prices`). Anthropic
+ * entries are family-level (`claude-opus-*`), signalling they apply to every
+ * version; OpenAI entries are the explicit per-version models. Cost estimation
+ * uses {@link resolveDefaultPrice} per concrete model, so a version absent from
+ * this list is still priced by its family.
+ */
+export function defaultPriceRows(userId: string): AiModelPriceRow[] {
+  const rows: AiModelPriceRow[] = [];
+  for (const [fam, [input, output]] of Object.entries(ANTHROPIC_FAMILY_RATES)) {
+    rows.push(makeRow(userId, "anthropic", `claude-${fam}-*`, input, output, ANTHROPIC_SRC, true));
+  }
+  for (const [model, [input, output]] of Object.entries(OPENAI_MODEL_RATES)) {
+    rows.push(makeRow(userId, "openai", model, input, output, OPENAI_SRC, false));
+  }
+  return rows;
+}

--- a/src/utils/ai/price-store.ts
+++ b/src/utils/ai/price-store.ts
@@ -16,6 +16,7 @@ import {
   type CreatePriceValue,
   type UpdatePriceValue,
 } from "./pricing";
+import { defaultPriceRows } from "./default-prices";
 
 /** Only the two window columns, read for the overlap invariant. */
 interface WindowRow {
@@ -74,7 +75,12 @@ export async function fetchPriceRow(
     .first<AiModelPriceRow>();
 }
 
-/** All enabled owner + default price rows for the user (used by cost estimation). */
+/**
+ * All enabled owner price rows for the user (used by cost estimation). Shipped
+ * defaults are NOT merged here: they are resolved per used (provider, model) at
+ * the call site (see `resolveDefaultPrice`) so family-based defaults cover any
+ * concrete version, which a fixed list cannot.
+ */
 export async function listEnabledPrices(
   db: D1Database,
   userId: string,
@@ -111,7 +117,15 @@ export async function listPrices(
 
   const { results } = await db.prepare(sql).bind(...binds).all<AiModelPriceRow>();
 
-  let rows = results;
+  // Merge the shipped default catalog (is_default = 1). Defaults are enabled and
+  // open-ended, so `include_disabled` never excludes them; apply the same
+  // provider/model filters, then the shared `active_on` filter and ordering below
+  // treat owner and default rows uniformly.
+  let defaults = defaultPriceRows(userId);
+  if (opts.provider !== undefined) defaults = defaults.filter((r) => r.provider === opts.provider);
+  if (opts.model !== undefined) defaults = defaults.filter((r) => r.model === opts.model);
+
+  let rows = [...results, ...defaults];
   if (opts.activeOnMs !== undefined) {
     const at = opts.activeOnMs;
     rows = rows.filter((r) => {

--- a/tests/aggregation/ai-default-prices.test.ts
+++ b/tests/aggregation/ai-default-prices.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the shipped default AI price catalog (src/utils/ai/default-prices.ts).
+ * Pure: prices resolve by model-id shape (Anthropic by family, OpenAI per version)
+ * and rank behind owner rows via the same selectEffectivePrice the cost path uses.
+ */
+import { describe, expect, it } from "vitest";
+import { defaultPriceRows, resolveDefaultPrice } from "../../src/utils/ai/default-prices";
+import { selectEffectivePrice } from "../../src/utils/ai/pricing";
+
+describe("resolveDefaultPrice — Anthropic by family (new versions covered)", () => {
+  it("prices any claude-opus version from the opus family rate", () => {
+    for (const model of ["claude-opus-4-8", "claude-opus-4-9", "claude-opus-5-0"]) {
+      expect(resolveDefaultPrice("u", "anthropic", model)).toMatchObject({
+        provider: "anthropic",
+        model,
+        is_default: 1,
+        is_enabled: 1,
+        currency: "USD",
+        input_cost_per_mtok: 5,
+        output_cost_per_mtok: 25,
+        cached_input_cost_per_mtok: 0.5,
+        cache_write_cost_per_mtok: 6.25,
+        cache_read_cost_per_mtok: 0.5,
+      });
+    }
+  });
+
+  it("prices the sonnet / haiku / fable / mythos families", () => {
+    expect(resolveDefaultPrice("u", "anthropic", "claude-sonnet-5")).toMatchObject({ input_cost_per_mtok: 3, output_cost_per_mtok: 15 });
+    expect(resolveDefaultPrice("u", "anthropic", "claude-haiku-4-5")).toMatchObject({ input_cost_per_mtok: 1, output_cost_per_mtok: 5 });
+    expect(resolveDefaultPrice("u", "anthropic", "claude-fable-5")).toMatchObject({ input_cost_per_mtok: 10, output_cost_per_mtok: 50 });
+    expect(resolveDefaultPrice("u", "anthropic", "claude-mythos-5")).toMatchObject({ input_cost_per_mtok: 10, output_cost_per_mtok: 50 });
+  });
+
+  it("returns null for an unknown Anthropic family or a non-claude id", () => {
+    expect(resolveDefaultPrice("u", "anthropic", "claude-nova-1")).toBeNull();
+    expect(resolveDefaultPrice("u", "anthropic", "not-a-claude-id")).toBeNull();
+  });
+});
+
+describe("resolveDefaultPrice — OpenAI per version (incl. codex 5.6 tiers)", () => {
+  it("prices the gpt-5.6 tiers and the bare slug", () => {
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.6")).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-sol")).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-terra")).toMatchObject({ input_cost_per_mtok: 2.5, output_cost_per_mtok: 15 });
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-luna")).toMatchObject({ input_cost_per_mtok: 1, output_cost_per_mtok: 6 });
+  });
+
+  it("prices gpt-5.5 and leaves OpenAI cache-write/read null (reported as cached_input)", () => {
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.5")).toMatchObject({
+      input_cost_per_mtok: 5,
+      output_cost_per_mtok: 30,
+      cached_input_cost_per_mtok: 0.5,
+      cache_write_cost_per_mtok: null,
+      cache_read_cost_per_mtok: null,
+    });
+  });
+
+  it("returns null for an OpenAI model not in the list (stays unpriced → missing_price_count)", () => {
+    expect(resolveDefaultPrice("u", "openai", "gpt-5.7")).toBeNull();
+    expect(resolveDefaultPrice("u", "openai", "o5")).toBeNull();
+  });
+});
+
+describe("default price catalog — cross-cutting", () => {
+  it("returns null for an unknown provider", () => {
+    expect(resolveDefaultPrice("u", "acme", "whatever")).toBeNull();
+  });
+
+  it("bills reasoning output at the output rate and scopes the row to the user", () => {
+    const r = resolveDefaultPrice("user-42", "anthropic", "claude-opus-4-8")!;
+    expect(r.reasoning_output_cost_per_mtok).toBe(r.output_cost_per_mtok);
+    expect(r.user_id).toBe("user-42");
+    expect(r.id).toBe("default:anthropic:claude-opus-4-8");
+    expect(r.effective_to).toBeNull();
+  });
+
+  it("lets an enabled owner row outrank the shipped default", () => {
+    const dflt = resolveDefaultPrice("u", "openai", "gpt-5.5")!;
+    const owner = { ...dflt, id: "owner-1", is_default: 0, input_cost_per_mtok: 99 };
+    const picked = selectEffectivePrice([dflt, owner], Date.parse("2026-07-01T00:00:00Z"));
+    expect(picked?.is_default).toBe(0);
+    expect(picked?.id).toBe("owner-1");
+  });
+});
+
+describe("defaultPriceRows — representative rows for the price list UI", () => {
+  const rows = defaultPriceRows("u");
+
+  it("lists Anthropic families as globs and OpenAI models explicitly", () => {
+    const ids = rows.map((r) => `${r.provider}/${r.model}`);
+    expect(ids).toContain("anthropic/claude-opus-*");
+    expect(ids).toContain("anthropic/claude-sonnet-*");
+    expect(ids).toContain("openai/gpt-5.6-luna");
+    expect(ids).toContain("openai/gpt-5.5");
+  });
+
+  it("ships enabled, read-only rows with unique synthetic ids", () => {
+    expect(new Set(rows.map((r) => r.id)).size).toBe(rows.length);
+    for (const r of rows) {
+      expect(r.is_default).toBe(1);
+      expect(r.is_enabled).toBe(1);
+      expect(r.currency).toBe("USD");
+    }
+  });
+});

--- a/tests/integration/ai-prices.test.ts
+++ b/tests/integration/ai-prices.test.ts
@@ -176,13 +176,14 @@ describe("GET /ai/prices", () => {
       body: JSON.stringify(validPrice({ model: "gpt-4o-mini", is_enabled: false })),
     });
 
+    // Owner rows only (shipped is_default rows are always present alongside them).
     const enabled = await callWorker(PRICES, { headers: authHeader(user.apiKey) });
-    const enabledBody = (await enabled.json()) as { data: unknown[] };
-    expect(enabledBody.data).toHaveLength(1);
+    const enabledBody = (await enabled.json()) as { data: { is_default: boolean }[] };
+    expect(enabledBody.data.filter((r) => !r.is_default)).toHaveLength(1);
 
     const all = await callWorker(`${PRICES}?include_disabled=true`, { headers: authHeader(user.apiKey) });
-    const allBody = (await all.json()) as { data: unknown[] };
-    expect(allBody.data).toHaveLength(2);
+    const allBody = (await all.json()) as { data: { is_default: boolean }[] };
+    expect(allBody.data.filter((r) => !r.is_default)).toHaveLength(2);
   });
 
   it("filters by active_on window and by provider", async () => {
@@ -198,14 +199,42 @@ describe("GET /ai/prices", () => {
     });
 
     const active = await callWorker(`${PRICES}?active_on=2026-01-15T00:00:00Z`, { headers: authHeader(user.apiKey) });
-    const activeBody = (await active.json()) as { data: { provider: string }[] };
-    expect(activeBody.data).toHaveLength(1);
-    expect(activeBody.data[0].provider).toBe("openai");
+    const activeBody = (await active.json()) as { data: { provider: string; is_default: boolean }[] };
+    const activeOwner = activeBody.data.filter((r) => !r.is_default);
+    expect(activeOwner).toHaveLength(1);
+    expect(activeOwner[0].provider).toBe("openai");
 
     const byProvider = await callWorker(`${PRICES}?provider=anthropic`, { headers: authHeader(user.apiKey) });
-    const byProviderBody = (await byProvider.json()) as { data: { provider: string }[] };
-    expect(byProviderBody.data).toHaveLength(1);
-    expect(byProviderBody.data[0].provider).toBe("anthropic");
+    const byProviderBody = (await byProvider.json()) as { data: { provider: string; is_default: boolean }[] };
+    const byProviderOwner = byProviderBody.data.filter((r) => !r.is_default);
+    expect(byProviderOwner).toHaveLength(1);
+    expect(byProviderOwner[0].provider).toBe("anthropic");
+  });
+
+  it("lists shipped default prices (is_default) even with no owner rows configured", async () => {
+    const res = await callWorker(`${PRICES}?provider=openai`, { headers: authHeader(user.apiKey) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { model: string; is_default: boolean; input_cost_per_mtok?: number; output_cost_per_mtok?: number }[];
+    };
+    const defaults = body.data.filter((r) => r.is_default);
+    expect(defaults.length).toBeGreaterThan(0);
+    // gpt-5.6 tiers (codex 5.6) ship out of the box.
+    expect(defaults.find((r) => r.model === "gpt-5.6-luna")).toMatchObject({
+      is_default: true,
+      input_cost_per_mtok: 1,
+      output_cost_per_mtok: 6,
+    });
+  });
+
+  it("does not expose a shipped default as an addressable row (single-row endpoints 404)", async () => {
+    // Synthetic default ids never exist in D1, so id existence is not leaked and
+    // defaults cannot be fetched, edited, or deleted individually.
+    const id = "default:openai:gpt-5.6";
+    const get = await callWorker(`${PRICES}/${id}`, { headers: authHeader(user.apiKey) });
+    expect(get.status).toBe(404);
+    const del = await callWorker(`${PRICES}/${id}`, { method: "DELETE", headers: authHeader(user.apiKey) });
+    expect(del.status).toBe(404);
   });
 
   it("rejects a malformed active_on with 400", async () => {

--- a/tests/integration/ai-usage.test.ts
+++ b/tests/integration/ai-usage.test.ts
@@ -167,6 +167,66 @@ describe("GET /ai/usage — token trends + cost", () => {
     expect(data.totals.missing_price_count).toBe(3);
   });
 
+  it("prices a NEW Anthropic version from its family default, with no owner row", async () => {
+    // A claude-opus version that did not exist when the code shipped still
+    // resolves via the opus family, so defaults do not go stale on point releases.
+    await insertUsage(user.userId, {
+      provider: "anthropic",
+      model: "claude-opus-4-9",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+
+    const { data } = await getUsage(RANGE);
+    expect(data.currency).toBe("USD");
+    expect(data.totals.estimated_cost).toBeCloseTo(30, 6); // $5/M in + $25/M out
+    expect(data.totals.missing_price_count).toBe(0);
+    expect(data.by_model.find((m) => m.model === "claude-opus-4-9")?.estimated_cost).toBeCloseTo(30, 6);
+  });
+
+  it("prices a codex gpt-5.6 tier from the shipped default, with no owner row", async () => {
+    await insertUsage(user.userId, {
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+
+    const { data } = await getUsage(RANGE);
+    expect(data.totals.estimated_cost).toBeCloseTo(7, 6); // $1/M in + $6/M out
+  });
+
+  it("keeps an unknown model unpriced even with defaults shipped (missing_price_count)", async () => {
+    await insertUsage(user.userId, {
+      provider: "openai",
+      model: "gpt-5.7",
+      input_tokens: 1_000_000,
+      heartbeat_count: 4,
+    });
+
+    const { data } = await getUsage(RANGE);
+    expect(data.totals.estimated_cost).toBeNull();
+    expect(data.totals.missing_price_count).toBe(4);
+  });
+
+  it("lets an owner price override the shipped family default", async () => {
+    await insertUsage(user.userId, {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+    });
+    await insertPrice(user.userId, {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      input_cost_per_mtok: 1,
+      output_cost_per_mtok: 1,
+    });
+
+    const { data } = await getUsage(RANGE);
+    expect(data.totals.estimated_cost).toBeCloseTo(1, 6); // owner $1/M, not the $5/M opus default
+  });
+
   it("selects one currency and flags mixed_currency, excluding off-currency cost", async () => {
     await insertUsage(user.userId, { provider: "openai", model: "gpt-4o", input_tokens: 1_000_000, heartbeat_count: 3 });
     await insertUsage(user.userId, { provider: "anthropic", model: "claude", input_tokens: 1_000_000, heartbeat_count: 1 });


### PR DESCRIPTION
## Summary
Ships a code-maintained **default AI price catalog** so a fresh CloudTime instance estimates cost out of the box — no per-instance seeding, no migration. Exposed as read-only `is_default` rows and merged into the existing price reads; `selectEffectivePrice` already ranks owner rows ahead of defaults.

## Why family-based (not a fixed model list)
New models ship constantly, so a hardcoded per-model list goes stale immediately. Instead defaults resolve by the **shape** of a model id:

- **Anthropic** rates are flat within a family generation, so a default resolves **by family**: `claude-opus-*` → \$5/\$25, `claude-sonnet-*` → \$3/\$15, `claude-haiku-*` → \$1/\$5, `claude-fable-*` / `claude-mythos-*` → \$10/\$50. A future `claude-opus-4-9` is priced with **no code change**.
- **OpenAI** is priced per version (no flat family rate), so its models are listed explicitly: `gpt-5`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`, and the three `gpt-5.6` tiers **Sol / Terra / Luna**.
- A model no default covers stays **unpriced** → `missing_price_count` (never a silent zero); the owner adds a row.

## How it wires in
- `resolveDefaultPrice(userId, provider, model)` resolves a default for exactly the `(provider, model)`s a usage summary uses (so any concrete version is covered), merged into `GET /ai/usage` cost estimation. `buildUsageSummary` stays pure/unchanged.
- `defaultPriceRows(userId)` exposes representative rows in `GET /ai/prices` — Anthropic as family globs (`claude-opus-*`), OpenAI per version.
- Owner rows always win (`selectEffectivePrice` owner-over-default); owner overlap checks and edit/delete protection are unaffected.
- Synthetic `default:<provider>:<model>` ids are never stored, so the single-row price endpoints `404` on them (id existence not leaked).

## Rates
Verified 2026-07 against provider pricing pages (linked as each default's `source_url`). `cached_input` = 0.1× input; `reasoning_output` billed at the output rate; Anthropic also sets `cache_write` (1.25×) and `cache_read` (0.1×), OpenAI leaves them null.

## Testing
- `npm test` → **742 pass** (+ `ai-default-prices` units; family-coverage, gpt-5.6-tier, unknown-stays-unpriced, and owner-override cases in `ai-usage`).
- `npm run typecheck` clean. **Impl-only** — the OpenAPI already documents `is_default` rows; `npm run generate` yields no content diff.

## Docs
`docs/ai-usage.md` gains a **Shipped default prices** section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)