### PR TITLE
fix: correct default AI prices (sonnet intro window, gpt-5.6 cache-write)

### DIFF
--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -131,13 +131,17 @@ Defaults resolve by the *shape* of a model id rather than pinning every release,
 so a steady stream of new models does not immediately go stale:
 
 - **Anthropic** rates are flat within a family generation, so a default resolves
-  from the family: `claude-opus-*` → $5/$25, `claude-sonnet-*` → $3/$15,
-  `claude-haiku-*` → $1/$5, `claude-fable-*` / `claude-mythos-*` → $10/$50. A
+  from the family: `claude-opus-*` → $5/$25, `claude-haiku-*` → $1/$5,
+  `claude-fable-*` / `claude-mythos-*` → $10/$50. `claude-sonnet-*` carries an
+  introductory $2/$10 through 2026-08-31, then its standard $3/$15 — shipped as
+  two time windows so each usage day prices from the rate then in effect. A
   future `claude-opus-4-9` is priced with no code change; the price list shows
   these as family entries (`claude-opus-*`).
 - **OpenAI** is priced per version, so its models are listed explicitly: `gpt-5`,
   `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`, and the three `gpt-5.6` tiers (Sol /
-  Terra / Luna). An OpenAI model not in the list is left unpriced.
+  Terra / Luna). `gpt-5.6` and later bill cache writes at 1.25× input (earlier
+  versions do not); cache reads take the 90% cached-input discount for all. An
+  OpenAI model not in the list is left unpriced.
 
 An owner price row always outranks the shipped default for the same
 `(provider, model)`. A model no default covers stays unpriced and surfaces in

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -28,7 +28,7 @@ import {
   listEnabledPrices,
   listPrices,
 } from "../utils/ai/price-store";
-import { resolveDefaultPrice } from "../utils/ai/default-prices";
+import { resolveDefaultPrices } from "../utils/ai/default-prices";
 import {
   AI_DAILY_USAGE_SELECT_COLUMNS,
   buildUsageSummary,
@@ -213,8 +213,7 @@ ai.get("/ai/usage", async (c) => {
       const key = `${r.provider} ${r.model}`;
       if (resolved.has(key)) continue;
       resolved.add(key);
-      const d = resolveDefaultPrice(userId, r.provider, r.model);
-      if (d) defaults.push(d);
+      defaults.push(...resolveDefaultPrices(userId, r.provider, r.model));
     }
 
     const summary = buildUsageSummary({

--- a/src/utils/ai/default-prices.ts
+++ b/src/utils/ai/default-prices.ts
@@ -7,13 +7,19 @@
  * Design: resolve prices by the *shape* of a model id rather than pinning every
  * version, so a steady stream of new models does not go stale immediately.
  *   - **Anthropic** prices are flat within a family generation (every
- *     `claude-opus-*` is $5/$25, `claude-sonnet-*` $3/$15, …), so a default is
+ *     `claude-opus-*` is $5/$25, `claude-haiku-*` $1/$5, …), so a default is
  *     resolved from the family — a future `claude-opus-4-9` is priced with no
  *     code change.
  *   - **OpenAI** prices per version with no flat family rate, so its models are
- *     listed explicitly. An OpenAI model not in the list resolves to `null`.
+ *     listed explicitly. An OpenAI model not in the list resolves to nothing.
  * An unresolved model stays unpriced and surfaces in `missing_price_count`
  * (never a silent zero); the owner can add a row for it.
+ *
+ * A family/model may carry more than one time window when a list rate changes
+ * on a known date (e.g. Sonnet 5's introductory rate through 2026-08-31). Each
+ * window becomes its own default row; `selectEffectivePrice` picks the one whose
+ * `[effective_from, effective_to)` contains the usage day, so cost is accurate
+ * across the boundary. `resolveDefaultPrices` therefore returns 0..n rows.
  *
  * Defaults materialize as read-only `is_default = 1` rows merged into price
  * reads, not stored in D1 — nothing to seed or migrate. `selectEffectivePrice`
@@ -23,29 +29,43 @@
  * `deriveAiIdentity` produces (`opus/4-8` → `claude-opus-4-8`).
  *
  * Rate conventions: `cached_input` (cache-hit input) = 0.1× input; `reasoning_output`
- * is billed at the output rate; Anthropic also sets `cache_write` = 1.25× input
- * (5-minute write) and `cache_read` = 0.1× input, which OpenAI leaves null (it
- * reports cache reads as `cached_input`). Unused token classes never affect a
- * bucket, so over-specifying a rate is harmless.
+ * is billed at the output rate. `cache_write` = 1.25× input (5-minute write) is set
+ * for Anthropic and for OpenAI's gpt-5.6+ tiers, which adopted the same cache-write
+ * surcharge; earlier OpenAI versions leave it null. `cache_read` = 0.1× input is set
+ * for Anthropic; OpenAI leaves it null and reports cache reads as `cached_input`.
+ * Unused token classes never affect a bucket, so over-specifying a rate is harmless.
  */
 import type { AiModelPriceRow } from "./pricing";
 
-/** Effective-from for every shipped default: a broad past window, open-ended. */
+/** Effective-from for every open-ended shipped default: a broad past window. */
 export const DEFAULT_PRICE_EFFECTIVE_FROM = "2020-01-01 00:00:00";
 
 const ANTHROPIC_SRC = "https://platform.claude.com/docs/en/about-claude/pricing";
 const OPENAI_SRC = "https://developers.openai.com/api/docs/pricing";
 
+/** One time-windowed list rate. `to = null` is open-ended. Per-MTok USD. */
+interface RateWindow {
+  readonly from: string;
+  readonly to: string | null;
+  readonly input: number;
+  readonly output: number;
+}
+
 /**
- * Anthropic family → [input, output] per-MTok USD. Flat within a family
- * generation, so any version resolves from its family (verified 2026-07).
+ * Anthropic family → time-windowed [input, output] per-MTok USD. Flat within a
+ * family generation, so any version resolves from its family (verified 2026-07).
+ * Sonnet 5 ships an introductory rate ($2/$10) through 2026-08-31, then its
+ * standard $3/$15 — expressed as two windows so each usage day prices correctly.
  */
-const ANTHROPIC_FAMILY_RATES: Record<string, readonly [number, number]> = {
-  opus: [5, 25],
-  sonnet: [3, 15],
-  haiku: [1, 5],
-  fable: [10, 50],
-  mythos: [10, 50],
+const ANTHROPIC_FAMILY_RATES: Record<string, readonly RateWindow[]> = {
+  opus: [{ from: DEFAULT_PRICE_EFFECTIVE_FROM, to: null, input: 5, output: 25 }],
+  sonnet: [
+    { from: DEFAULT_PRICE_EFFECTIVE_FROM, to: "2026-09-01 00:00:00", input: 2, output: 10 },
+    { from: "2026-09-01 00:00:00", to: null, input: 3, output: 15 },
+  ],
+  haiku: [{ from: DEFAULT_PRICE_EFFECTIVE_FROM, to: null, input: 1, output: 5 }],
+  fable: [{ from: DEFAULT_PRICE_EFFECTIVE_FROM, to: null, input: 10, output: 50 }],
+  mythos: [{ from: DEFAULT_PRICE_EFFECTIVE_FROM, to: null, input: 10, output: 50 }],
 };
 
 /**
@@ -63,41 +83,56 @@ const OPENAI_MODEL_RATES: Record<string, readonly [number, number]> = {
   "gpt-5.6-luna": [1, 6],
 };
 
+/**
+ * OpenAI models that bill cache writes at 1.25× input, matching Anthropic's
+ * 5-minute cache-write surcharge. Introduced with gpt-5.6; earlier versions
+ * leave `cache_write` null (verified 2026-07).
+ */
+const OPENAI_CACHE_WRITE_MODELS = new Set(["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+
 /** Avoid binary-float noise in derived rates (e.g. 1.25 * 0.1). */
 function round(n: number): number {
   return Math.round(n * 1e6) / 1e6;
 }
 
-/** Build a synthetic `is_default = 1` row for one (provider, model). */
-function makeRow(
-  userId: string,
-  provider: string,
-  model: string,
-  input: number,
-  output: number,
-  source: string,
-  anthropicCache: boolean,
-): AiModelPriceRow {
-  const ts = DEFAULT_PRICE_EFFECTIVE_FROM;
+/** Inputs for one synthetic default row. */
+interface RowSpec {
+  provider: string;
+  model: string;
+  input: number;
+  output: number;
+  from: string;
+  to: string | null;
+  source: string;
+  /** Set `cache_write` = 1.25× input (Anthropic; OpenAI gpt-5.6+). */
+  cacheWrite: boolean;
+  /** Set `cache_read` = 0.1× input (Anthropic only; OpenAI uses `cached_input`). */
+  cacheRead: boolean;
+  /** Disambiguates the synthetic id when a model has more than one window. */
+  idSuffix?: string;
+}
+
+/** Build a synthetic `is_default = 1` row from a spec. */
+function makeRow(userId: string, s: RowSpec): AiModelPriceRow {
   return {
-    id: `default:${provider}:${model}`,
+    id: `default:${s.provider}:${s.model}${s.idSuffix ? `:${s.idSuffix}` : ""}`,
     user_id: userId,
-    provider,
-    model,
+    provider: s.provider,
+    model: s.model,
     currency: "USD",
-    input_cost_per_mtok: input,
-    cached_input_cost_per_mtok: round(input * 0.1),
-    output_cost_per_mtok: output,
-    reasoning_output_cost_per_mtok: output,
-    cache_write_cost_per_mtok: anthropicCache ? round(input * 1.25) : null,
-    cache_read_cost_per_mtok: anthropicCache ? round(input * 0.1) : null,
-    effective_from: ts,
-    effective_to: null,
-    source_url: source,
+    input_cost_per_mtok: s.input,
+    cached_input_cost_per_mtok: round(s.input * 0.1),
+    output_cost_per_mtok: s.output,
+    reasoning_output_cost_per_mtok: s.output,
+    cache_write_cost_per_mtok: s.cacheWrite ? round(s.input * 1.25) : null,
+    cache_read_cost_per_mtok: s.cacheRead ? round(s.input * 0.1) : null,
+    effective_from: s.from,
+    effective_to: s.to,
+    source_url: s.source,
     is_default: 1,
     is_enabled: 1,
-    created_at: ts,
-    updated_at: ts,
+    created_at: s.from,
+    updated_at: s.from,
   };
 }
 
@@ -107,44 +142,107 @@ function anthropicFamily(model: string): string | null {
   return m ? m[1] : null;
 }
 
+/** Date portion of an effective-from timestamp, for a unique multi-window id. */
+function windowKey(from: string): string {
+  return from.slice(0, 10);
+}
+
 /**
- * Resolve the shipped default price for a concrete (provider, model), or null
- * when none applies (the model stays unpriced → `missing_price_count`). Anthropic
- * resolves by family (new versions covered without a code change); OpenAI resolves
- * from the explicit per-version list. Used by cost estimation for exactly the
- * models that appear in a usage summary.
+ * Resolve the shipped default price row(s) for a concrete (provider, model): one
+ * per time window, or an empty array when none applies (the model stays unpriced
+ * → `missing_price_count`). Anthropic resolves by family (new versions covered
+ * without a code change); OpenAI resolves from the explicit per-version list.
+ * The cost path pushes every returned row into the candidate set and lets
+ * `selectEffectivePrice` pick the one effective on each usage day.
  */
-export function resolveDefaultPrice(
+export function resolveDefaultPrices(
   userId: string,
   provider: string,
   model: string,
-): AiModelPriceRow | null {
+): AiModelPriceRow[] {
   if (provider === "anthropic") {
     const fam = anthropicFamily(model);
-    const rate = fam ? ANTHROPIC_FAMILY_RATES[fam] : undefined;
-    return rate ? makeRow(userId, provider, model, rate[0], rate[1], ANTHROPIC_SRC, true) : null;
+    const windows = fam ? ANTHROPIC_FAMILY_RATES[fam] : undefined;
+    if (!windows) return [];
+    const multi = windows.length > 1;
+    return windows.map((w) =>
+      makeRow(userId, {
+        provider,
+        model,
+        input: w.input,
+        output: w.output,
+        from: w.from,
+        to: w.to,
+        source: ANTHROPIC_SRC,
+        cacheWrite: true,
+        cacheRead: true,
+        idSuffix: multi ? windowKey(w.from) : undefined,
+      }),
+    );
   }
   if (provider === "openai") {
     const rate = OPENAI_MODEL_RATES[model];
-    return rate ? makeRow(userId, provider, model, rate[0], rate[1], OPENAI_SRC, false) : null;
+    if (!rate) return [];
+    return [
+      makeRow(userId, {
+        provider,
+        model,
+        input: rate[0],
+        output: rate[1],
+        from: DEFAULT_PRICE_EFFECTIVE_FROM,
+        to: null,
+        source: OPENAI_SRC,
+        cacheWrite: OPENAI_CACHE_WRITE_MODELS.has(model),
+        cacheRead: false,
+      }),
+    ];
   }
-  return null;
+  return [];
 }
 
 /**
  * Representative default rows for the price-list UI (`GET /ai/prices`). Anthropic
  * entries are family-level (`claude-opus-*`), signalling they apply to every
- * version; OpenAI entries are the explicit per-version models. Cost estimation
- * uses {@link resolveDefaultPrice} per concrete model, so a version absent from
+ * version; OpenAI entries are the explicit per-version models. A family/model
+ * with more than one time window contributes one row per window. Cost estimation
+ * uses {@link resolveDefaultPrices} per concrete model, so a version absent from
  * this list is still priced by its family.
  */
 export function defaultPriceRows(userId: string): AiModelPriceRow[] {
   const rows: AiModelPriceRow[] = [];
-  for (const [fam, [input, output]] of Object.entries(ANTHROPIC_FAMILY_RATES)) {
-    rows.push(makeRow(userId, "anthropic", `claude-${fam}-*`, input, output, ANTHROPIC_SRC, true));
+  for (const [fam, windows] of Object.entries(ANTHROPIC_FAMILY_RATES)) {
+    const multi = windows.length > 1;
+    for (const w of windows) {
+      rows.push(
+        makeRow(userId, {
+          provider: "anthropic",
+          model: `claude-${fam}-*`,
+          input: w.input,
+          output: w.output,
+          from: w.from,
+          to: w.to,
+          source: ANTHROPIC_SRC,
+          cacheWrite: true,
+          cacheRead: true,
+          idSuffix: multi ? windowKey(w.from) : undefined,
+        }),
+      );
+    }
   }
   for (const [model, [input, output]] of Object.entries(OPENAI_MODEL_RATES)) {
-    rows.push(makeRow(userId, "openai", model, input, output, OPENAI_SRC, false));
+    rows.push(
+      makeRow(userId, {
+        provider: "openai",
+        model,
+        input,
+        output,
+        from: DEFAULT_PRICE_EFFECTIVE_FROM,
+        to: null,
+        source: OPENAI_SRC,
+        cacheWrite: OPENAI_CACHE_WRITE_MODELS.has(model),
+        cacheRead: false,
+      }),
+    );
   }
   return rows;
 }

--- a/src/utils/ai/price-store.ts
+++ b/src/utils/ai/price-store.ts
@@ -78,7 +78,7 @@ export async function fetchPriceRow(
 /**
  * All enabled owner price rows for the user (used by cost estimation). Shipped
  * defaults are NOT merged here: they are resolved per used (provider, model) at
- * the call site (see `resolveDefaultPrice`) so family-based defaults cover any
+ * the call site (see `resolveDefaultPrices`) so family-based defaults cover any
  * concrete version, which a fixed list cannot.
  */
 export async function listEnabledPrices(

--- a/tests/aggregation/ai-default-prices.test.ts
+++ b/tests/aggregation/ai-default-prices.test.ts
@@ -1,16 +1,19 @@
 /**
  * Unit tests for the shipped default AI price catalog (src/utils/ai/default-prices.ts).
- * Pure: prices resolve by model-id shape (Anthropic by family, OpenAI per version)
- * and rank behind owner rows via the same selectEffectivePrice the cost path uses.
+ * Pure: prices resolve by model-id shape (Anthropic by family, OpenAI per version),
+ * carry time windows when a list rate changes on a known date, and rank behind
+ * owner rows via the same selectEffectivePrice the cost path uses.
  */
 import { describe, expect, it } from "vitest";
-import { defaultPriceRows, resolveDefaultPrice } from "../../src/utils/ai/default-prices";
+import { defaultPriceRows, resolveDefaultPrices } from "../../src/utils/ai/default-prices";
 import { selectEffectivePrice } from "../../src/utils/ai/pricing";
 
-describe("resolveDefaultPrice — Anthropic by family (new versions covered)", () => {
+describe("resolveDefaultPrices — Anthropic by family (new versions covered)", () => {
   it("prices any claude-opus version from the opus family rate", () => {
     for (const model of ["claude-opus-4-8", "claude-opus-4-9", "claude-opus-5-0"]) {
-      expect(resolveDefaultPrice("u", "anthropic", model)).toMatchObject({
+      const rows = resolveDefaultPrices("u", "anthropic", model);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
         provider: "anthropic",
         model,
         is_default: 1,
@@ -21,33 +24,63 @@ describe("resolveDefaultPrice — Anthropic by family (new versions covered)", (
         cached_input_cost_per_mtok: 0.5,
         cache_write_cost_per_mtok: 6.25,
         cache_read_cost_per_mtok: 0.5,
+        effective_to: null,
       });
     }
   });
 
-  it("prices the sonnet / haiku / fable / mythos families", () => {
-    expect(resolveDefaultPrice("u", "anthropic", "claude-sonnet-5")).toMatchObject({ input_cost_per_mtok: 3, output_cost_per_mtok: 15 });
-    expect(resolveDefaultPrice("u", "anthropic", "claude-haiku-4-5")).toMatchObject({ input_cost_per_mtok: 1, output_cost_per_mtok: 5 });
-    expect(resolveDefaultPrice("u", "anthropic", "claude-fable-5")).toMatchObject({ input_cost_per_mtok: 10, output_cost_per_mtok: 50 });
-    expect(resolveDefaultPrice("u", "anthropic", "claude-mythos-5")).toMatchObject({ input_cost_per_mtok: 10, output_cost_per_mtok: 50 });
+  it("prices the haiku / fable / mythos families as a single open-ended window", () => {
+    expect(resolveDefaultPrices("u", "anthropic", "claude-haiku-4-5")).toMatchObject([
+      { input_cost_per_mtok: 1, output_cost_per_mtok: 5, effective_to: null },
+    ]);
+    expect(resolveDefaultPrices("u", "anthropic", "claude-fable-5")).toMatchObject([
+      { input_cost_per_mtok: 10, output_cost_per_mtok: 50, effective_to: null },
+    ]);
+    expect(resolveDefaultPrices("u", "anthropic", "claude-mythos-5")).toMatchObject([
+      { input_cost_per_mtok: 10, output_cost_per_mtok: 50, effective_to: null },
+    ]);
   });
 
-  it("returns null for an unknown Anthropic family or a non-claude id", () => {
-    expect(resolveDefaultPrice("u", "anthropic", "claude-nova-1")).toBeNull();
-    expect(resolveDefaultPrice("u", "anthropic", "not-a-claude-id")).toBeNull();
+  it("prices sonnet as two windows: introductory $2/$10 through 2026-08-31, then $3/$15", () => {
+    const rows = resolveDefaultPrices("u", "anthropic", "claude-sonnet-5");
+    expect(rows).toHaveLength(2);
+    // Two enabled windows must not overlap and must carry unique synthetic ids.
+    expect(new Set(rows.map((r) => r.id)).size).toBe(2);
+    // Effective-row selection prices each usage day from the right window.
+    const intro = selectEffectivePrice(rows, Date.parse("2026-07-15T00:00:00Z"));
+    const standard = selectEffectivePrice(rows, Date.parse("2026-09-15T00:00:00Z"));
+    expect(intro).toMatchObject({ input_cost_per_mtok: 2, output_cost_per_mtok: 10 });
+    expect(standard).toMatchObject({ input_cost_per_mtok: 3, output_cost_per_mtok: 15 });
+  });
+
+  it("returns an empty array for an unknown Anthropic family or a non-claude id", () => {
+    expect(resolveDefaultPrices("u", "anthropic", "claude-nova-1")).toEqual([]);
+    expect(resolveDefaultPrices("u", "anthropic", "not-a-claude-id")).toEqual([]);
   });
 });
 
-describe("resolveDefaultPrice — OpenAI per version (incl. codex 5.6 tiers)", () => {
+describe("resolveDefaultPrices — OpenAI per version (incl. codex 5.6 tiers)", () => {
   it("prices the gpt-5.6 tiers and the bare slug", () => {
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.6")).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-sol")).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-terra")).toMatchObject({ input_cost_per_mtok: 2.5, output_cost_per_mtok: 15 });
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.6-luna")).toMatchObject({ input_cost_per_mtok: 1, output_cost_per_mtok: 6 });
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6")[0]).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6-sol")[0]).toMatchObject({ input_cost_per_mtok: 5, output_cost_per_mtok: 30 });
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6-terra")[0]).toMatchObject({ input_cost_per_mtok: 2.5, output_cost_per_mtok: 15 });
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6-luna")[0]).toMatchObject({ input_cost_per_mtok: 1, output_cost_per_mtok: 6 });
   });
 
-  it("prices gpt-5.5 and leaves OpenAI cache-write/read null (reported as cached_input)", () => {
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.5")).toMatchObject({
+  it("bills gpt-5.6+ cache writes at 1.25x input, cache-read null (reported as cached_input)", () => {
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6-sol")[0]).toMatchObject({
+      cached_input_cost_per_mtok: 0.5,
+      cache_write_cost_per_mtok: 6.25,
+      cache_read_cost_per_mtok: null,
+    });
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.6-luna")[0]).toMatchObject({
+      cache_write_cost_per_mtok: 1.25,
+      cache_read_cost_per_mtok: null,
+    });
+  });
+
+  it("leaves pre-5.6 OpenAI cache-write null (gpt-5.5)", () => {
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.5")[0]).toMatchObject({
       input_cost_per_mtok: 5,
       output_cost_per_mtok: 30,
       cached_input_cost_per_mtok: 0.5,
@@ -56,19 +89,19 @@ describe("resolveDefaultPrice — OpenAI per version (incl. codex 5.6 tiers)", (
     });
   });
 
-  it("returns null for an OpenAI model not in the list (stays unpriced → missing_price_count)", () => {
-    expect(resolveDefaultPrice("u", "openai", "gpt-5.7")).toBeNull();
-    expect(resolveDefaultPrice("u", "openai", "o5")).toBeNull();
+  it("returns an empty array for an OpenAI model not in the list (stays unpriced → missing_price_count)", () => {
+    expect(resolveDefaultPrices("u", "openai", "gpt-5.7")).toEqual([]);
+    expect(resolveDefaultPrices("u", "openai", "o5")).toEqual([]);
   });
 });
 
 describe("default price catalog — cross-cutting", () => {
-  it("returns null for an unknown provider", () => {
-    expect(resolveDefaultPrice("u", "acme", "whatever")).toBeNull();
+  it("returns an empty array for an unknown provider", () => {
+    expect(resolveDefaultPrices("u", "acme", "whatever")).toEqual([]);
   });
 
   it("bills reasoning output at the output rate and scopes the row to the user", () => {
-    const r = resolveDefaultPrice("user-42", "anthropic", "claude-opus-4-8")!;
+    const r = resolveDefaultPrices("user-42", "anthropic", "claude-opus-4-8")[0];
     expect(r.reasoning_output_cost_per_mtok).toBe(r.output_cost_per_mtok);
     expect(r.user_id).toBe("user-42");
     expect(r.id).toBe("default:anthropic:claude-opus-4-8");
@@ -76,7 +109,7 @@ describe("default price catalog — cross-cutting", () => {
   });
 
   it("lets an enabled owner row outrank the shipped default", () => {
-    const dflt = resolveDefaultPrice("u", "openai", "gpt-5.5")!;
+    const dflt = resolveDefaultPrices("u", "openai", "gpt-5.5")[0];
     const owner = { ...dflt, id: "owner-1", is_default: 0, input_cost_per_mtok: 99 };
     const picked = selectEffectivePrice([dflt, owner], Date.parse("2026-07-01T00:00:00Z"));
     expect(picked?.is_default).toBe(0);
@@ -95,8 +128,10 @@ describe("defaultPriceRows — representative rows for the price list UI", () =>
     expect(ids).toContain("openai/gpt-5.5");
   });
 
-  it("ships enabled, read-only rows with unique synthetic ids", () => {
+  it("ships enabled, read-only rows with unique synthetic ids (incl. sonnet's two windows)", () => {
     expect(new Set(rows.map((r) => r.id)).size).toBe(rows.length);
+    // Sonnet contributes one glob row per time window.
+    expect(rows.filter((r) => r.model === "claude-sonnet-*")).toHaveLength(2);
     for (const r of rows) {
       expect(r.is_default).toBe(1);
       expect(r.is_enabled).toBe(1);


### PR DESCRIPTION
Follow-up to #214. Corrects two default-price inaccuracies found while verifying against published 2026-07 list rates. **No OpenAPI / response-shape change** (impl + tests + docs only).

## Fixes
- **Sonnet 5 introductory pricing.** Anthropic lists Sonnet 5 at **$2/$10 through 2026-08-31**, then **$3/$15**. #214 shipped a flat $3/$15, overcharging the intro period by 50%. Now shipped as two time windows; `selectEffectivePrice` (already used by the cost path) picks the rate effective on each usage day.
- **gpt-5.6+ cache-write.** OpenAI adopted a 1.25× input cache-write surcharge starting with the gpt-5.6 family (Sol/Terra/Luna). #214 left OpenAI `cache_write` null. Now set for gpt-5.6+; pre-5.6 versions keep it null. Cache reads remain the 90% cached-input discount for all.

## Mechanism
- `resolveDefaultPrice` → **`resolveDefaultPrices`**, returning `0..n` windowed rows for a `(provider, model)`. The `/ai/usage` cost path spreads them into the candidate set and lets `selectEffectivePrice` match per day.
- `defaultPriceRows` (price-list UI) emits one family-glob row per window with unique synthetic ids (`default:anthropic:claude-sonnet-*:2020-01-01` / `:2026-09-01`).
- Anthropic family-flat resolution (opus/haiku/fable/mythos) and the "unknown model → `missing_price_count`, never silent zero" invariant are unchanged.

## Sources
- Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
- OpenAI: https://developers.openai.com/api/docs/pricing

## Tests
- `tests/aggregation/ai-default-prices.test.ts` updated for array returns; adds sonnet two-window selection (July→$2/$10, September→$3/$15) and gpt-5.6 cache-write assertions.
- Full suite green locally (744 passed), `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)