### PR TITLE
feat: stopgap patch for Codex model attribution in the User-Agent

### DIFF
--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -78,6 +78,11 @@ provider). To get per-model breakdowns and cost, either send `ai_model`
 explicitly in the heartbeat body, or have the client include the model as a
 `<model>/<detail>` token in its plugin User-Agent as shown above.
 
+> **Codex CLI:** the official `codex-cli-wakatime` plugin (through v1.0.0) does
+> not emit the model, so Codex usage lands under an `unknown` model until patched.
+> See [Codex model attribution](codex-model-attribution.md) for a reversible,
+> version-guarded stopgap patch (`scripts/patch-codex-wakatime.mjs`).
+
 ## Usage summary
 
 `GET /api/v1/users/current/ai/usage` returns an owner-only `AIUsageSummary` over

--- a/docs/codex-model-attribution.md
+++ b/docs/codex-model-attribution.md
@@ -1,0 +1,69 @@
+# Codex model attribution (stopgap plugin patch)
+
+CloudTime derives `ai_provider` / `ai_model` for `ai coding` heartbeats from the
+client User-Agent (see [AI usage → Deriving provider and model](ai-usage.md#deriving-provider-and-model-from-the-user-agent)).
+Anthropic's `claude-code-wakatime` plugin already includes the model in the UA
+(`... opus/4-8 claude-code/2.1.205 claude-code-wakatime/4.1.0`), so Claude Code
+usage attributes to a concrete model with no extra setup.
+
+OpenAI's `codex-cli-wakatime` plugin (through v1.0.0) does **not** put the model
+in the UA — it sends `... codex-cli/<ver> codex-cli-wakatime/<ver>`. CloudTime can
+still tell the heartbeat came from Codex (→ `openai`), but the **model is
+`null`**, so all Codex usage rolls up under `openai` / unknown model and cannot be
+split by `gpt-5.6-sol` vs `gpt-5.6-terra`, etc.
+
+## The stopgap
+
+`scripts/patch-codex-wakatime.mjs` patches the installed plugin to prepend the
+active model as a `<model>/<effort>` token, mirroring how `claude-code-wakatime`
+carries `opus/4-8`. The model is read from the Codex hook `input`, falling back
+to `config.toml` (`$CODEX_HOME/config.toml`, then `~/.codex/config.toml`).
+
+After patching, a Codex heartbeat's User-Agent looks like:
+
+```
+wakatime/<cli-ver> (<os>) <runtime> gpt-5.6-sol/high codex-cli/<ver> codex-cli-wakatime/<ver>
+```
+
+which CloudTime resolves to `openai` / `gpt-5.6-sol`.
+
+### Apply
+
+```sh
+node scripts/patch-codex-wakatime.mjs            # discover the plugin and patch
+node scripts/patch-codex-wakatime.mjs --dry-run  # report what it would do, change nothing
+node scripts/patch-codex-wakatime.mjs --path <bin/codex-cli-wakatime.js>   # target a specific file
+```
+
+The script auto-discovers the plugin under `$CODEX_HOME`, `~/.codex`, and
+`%LOCALAPPDATA%/OpenAI/CodexHome`. Node >= 16, no dependencies. Restart Codex (or
+start a new session) so the patched plugin is loaded.
+
+### Revert
+
+```sh
+node scripts/patch-codex-wakatime.mjs --revert
+```
+
+Restores the `.orig` backup the patch writes on first apply.
+
+## Properties
+
+- **Idempotent** — the patched file is regenerated from the pristine `.orig`
+  backup on every run, so re-running (or upgrading an older patch) is a no-op or a
+  clean re-apply, never a double patch.
+- **Reversible** — `--revert` restores `.orig`; the pristine file is never lost.
+  (If the plugin was patched by hand with no `.orig`, the script refuses rather
+  than guess the pristine source — reinstall the plugin first.)
+- **Version-guarded / upstream-aware** — only the recognized pristine `--plugin`
+  line is patched. If a future plugin release changes that line — including one
+  that adds model passthrough upstream — the anchor no longer matches and the
+  script leaves the file untouched (`SKIP`). Re-run after any plugin update.
+
+## Upstream
+
+This is a stopgap, not a fork. The proper fix is for the plugin to include the
+model itself; track or request it at
+<https://github.com/wakatime/codex-cli-wakatime>. Once a release ships model
+passthrough, revert the patch (or let the version guard skip it) and drop this
+step.

--- a/scripts/patch-codex-wakatime.mjs
+++ b/scripts/patch-codex-wakatime.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Stopgap patch for the official `codex-cli-wakatime` plugin so its AI heartbeats
+ * carry the active model in the User-Agent — letting a WakaTime-compatible server
+ * (e.g. CloudTime) attribute `openai` + a concrete model instead of bucketing every
+ * Codex heartbeat as `openai`/unknown. See docs/codex-model-attribution.md.
+ *
+ * Why this is needed: `claude-code-wakatime` already puts the model in the UA
+ * (`... opus/4-8 claude-code/...`), but `codex-cli-wakatime` (<= 1.0.0) does not.
+ * This patch prepends a `<model>/<effort>` token to the plugin's `--plugin` value,
+ * read from the codex hook `input` (falling back to `config.toml`).
+ *
+ * Properties:
+ *   - Idempotent: the patched file is always regenerated from a pristine `.orig`
+ *     backup, so re-running (or upgrading an older patch) yields the same result.
+ *   - Reversible: `--revert` restores the `.orig` backup.
+ *   - Version-guarded / upstream-aware: only a recognized pristine `--plugin`
+ *     line is patched. If the vendor changes that line (e.g. adds model support
+ *     upstream), the anchor no longer matches and the script refuses to patch —
+ *     so a future fixed release is left untouched.
+ *
+ * Usage:
+ *   node scripts/patch-codex-wakatime.mjs            # discover + apply
+ *   node scripts/patch-codex-wakatime.mjs --dry-run  # report, change nothing
+ *   node scripts/patch-codex-wakatime.mjs --revert   # restore from .orig
+ *   node scripts/patch-codex-wakatime.mjs --path <file>   # target a specific file
+ *
+ * No dependencies; Node >= 16. Exit 0 on success/no-op, 1 on error.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const MARKER = "cloudtime-model-passthrough";
+
+// Exact pristine line to anchor the injection (codex-cli-wakatime bin, <= 1.0.0).
+const ANCHOR = "const plugin = `codex-cli/${codexVersion || 'unknown'} ${PLUGIN_NAME}/${VERSION}`;";
+const PATCHED =
+  "const plugin = `${cloudtimeResolveModelToken(input)}codex-cli/${codexVersion || 'unknown'} ${PLUGIN_NAME}/${VERSION}`; // " +
+  MARKER;
+
+// Injected helpers. NOTE: regex character classes are written with `\\s` so the
+// emitted file contains `\s` — a bare `\s` inside a JS string collapses to `s`
+// (which is the very bug this catalog of escapes avoids).
+const HELPERS = [
+  "",
+  "",
+  `// --- ${MARKER} (local patch by scripts/patch-codex-wakatime.mjs; reversible via .orig backup) ---`,
+  "// Prepend the active model as a `<model>/<effort>` token so a WakaTime-compatible",
+  "// server can attribute provider/model (mirrors how claude-code UAs carry opus/4-8).",
+  "function cloudtimeResolveModelToken(input) {",
+  "  try {",
+  "    let model = input && typeof input.model === 'string' ? input.model.trim() : '';",
+  "    let effort = input && typeof input.model_reasoning_effort === 'string' ? input.model_reasoning_effort.trim() : '';",
+  "    if (!model || !effort) {",
+  "      const cfg = cloudtimeReadCodexConfig();",
+  "      if (!model) model = cfg.model;",
+  "      if (!effort) effort = cfg.effort;",
+  "    }",
+  "    if (!model) return '';",
+  "    model = model.replace(/[\\s/]+/g, '-');",
+  "    effort = (effort || 'unknown').replace(/[\\s/]+/g, '-');",
+  "    return `${model}/${effort} `;",
+  "  } catch (_) { return ''; }",
+  "}",
+  "function cloudtimeReadCodexConfig() {",
+  "  const candidates = [];",
+  "  if (process.env.CODEX_HOME) candidates.push(path.join(process.env.CODEX_HOME, 'config.toml'));",
+  "  candidates.push(path.join(os.homedir(), '.codex', 'config.toml'));",
+  "  for (const cfgPath of candidates) {",
+  "    try {",
+  "      const txt = fs.readFileSync(cfgPath, 'utf8');",
+  '      const m = txt.match(/^\\s*model\\s*=\\s*"([^"]+)"/m);',
+  '      const e = txt.match(/^\\s*model_reasoning_effort\\s*=\\s*"([^"]+)"/m);',
+  "      if (m || e) return { model: m ? m[1].trim() : '', effort: e ? e[1].trim() : '' };",
+  "    } catch (_) { /* try next candidate */ }",
+  "  }",
+  "  return { model: '', effort: '' };",
+  "}",
+  "",
+].join("\n");
+
+function fail(msg) {
+  console.error(`[patch-codex-wakatime] ERROR: ${msg}`);
+  process.exit(1);
+}
+
+/** Candidate CODEX_HOME roots, most specific first. */
+function codexHomes() {
+  const homes = [];
+  if (process.env.CODEX_HOME) homes.push(process.env.CODEX_HOME);
+  homes.push(path.join(os.homedir(), ".codex"));
+  homes.push(path.join(os.homedir(), "AppData", "Local", "OpenAI", "CodexHome")); // Windows
+  homes.push(path.join(os.homedir(), ".local", "share", "codex")); // possible XDG
+  return [...new Set(homes)];
+}
+
+/** Discover every installed codex-cli-wakatime plugin bin under known homes. */
+function discover() {
+  const found = [];
+  for (const home of codexHomes()) {
+    const base = path.join(home, "plugins", "cache", "wakatime", "codex-cli-wakatime");
+    let versions;
+    try {
+      versions = fs.readdirSync(base);
+    } catch {
+      continue;
+    }
+    for (const ver of versions) {
+      const f = path.join(base, ver, "bin", "codex-cli-wakatime.js");
+      if (fs.existsSync(f)) found.push(f);
+    }
+  }
+  return [...new Set(found)];
+}
+
+function revert(target) {
+  const orig = `${target}.orig`;
+  if (!fs.existsSync(orig)) {
+    console.log(`[patch-codex-wakatime] no backup at ${orig}; nothing to revert: ${target}`);
+    return;
+  }
+  fs.copyFileSync(orig, target);
+  console.log(`[patch-codex-wakatime] reverted ${target} from ${orig}`);
+}
+
+function apply(target, dryRun) {
+  const orig = `${target}.orig`;
+  const current = fs.readFileSync(target, "utf8");
+
+  // Establish a trustworthy pristine source.
+  let pristine;
+  if (fs.existsSync(orig)) {
+    pristine = fs.readFileSync(orig, "utf8");
+    if (pristine.includes(MARKER)) {
+      return fail(`${orig} is not pristine (contains the patch marker). Remove it and reinstall the plugin.`);
+    }
+  } else if (current.includes(MARKER)) {
+    return fail(
+      `${target} is already patched but has no ${path.basename(orig)} backup, so the pristine ` +
+        `source cannot be recovered. Reinstall the plugin, then re-run.`,
+    );
+  } else {
+    pristine = current;
+  }
+
+  // Version guard: only patch a recognized pristine structure. A mismatch means
+  // the vendor changed the plugin (possibly adding model support upstream) — skip.
+  if (!pristine.includes(ANCHOR)) {
+    console.log(
+      `[patch-codex-wakatime] SKIP ${target}: the plugin's --plugin line was not found ` +
+        `(vendor structure changed; upstream may already emit the model). Left untouched.`,
+    );
+    return;
+  }
+
+  let patched = pristine.replace(ANCHOR, PATCHED);
+  if (!patched.includes("function cloudtimeResolveModelToken")) patched += HELPERS;
+
+  if (patched === current) {
+    console.log(`[patch-codex-wakatime] already up to date: ${target}`);
+    return;
+  }
+  if (dryRun) {
+    console.log(`[patch-codex-wakatime] DRY-RUN would patch ${target} (backup: ${orig})`);
+    return;
+  }
+
+  if (!fs.existsSync(orig)) fs.writeFileSync(orig, pristine);
+  fs.writeFileSync(target, patched);
+  console.log(`[patch-codex-wakatime] patched ${target} (backup: ${orig})`);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const doRevert = args.includes("--revert");
+  const pathIdx = args.indexOf("--path");
+  const explicit = pathIdx >= 0 ? args[pathIdx + 1] : null;
+
+  const targets = explicit ? [explicit] : discover();
+  if (targets.length === 0) {
+    return fail(
+      "no codex-cli-wakatime plugin found under CODEX_HOME / ~/.codex / %LOCALAPPDATA%/OpenAI/CodexHome. " +
+        "Pass --path <bin/codex-cli-wakatime.js>.",
+    );
+  }
+  for (const t of targets) {
+    if (!fs.existsSync(t)) fail(`target not found: ${t}`);
+    if (doRevert) revert(t);
+    else apply(t, dryRun);
+  }
+}
+
+main();


### PR DESCRIPTION
Follow-up to #213 / #214. Makes Codex usage attribute to a concrete model instead of `openai` / unknown.

## Problem
CloudTime derives provider/model from the client User-Agent. `claude-code-wakatime` already carries the model (`... opus/4-8 claude-code/...`), but the official `codex-cli-wakatime` plugin (<= v1.0.0) does not — so every Codex heartbeat resolves to `openai` with a `null` model and rolls up under "unknown". The model can only come from the client, so this is a client-side stopgap until the plugin adds it upstream.

## What
- **`scripts/patch-codex-wakatime.mjs`** — prepends a `<model>/<effort>` token to the plugin's `--plugin` value (read from the Codex hook `input`, falling back to `$CODEX_HOME/config.toml` → `~/.codex/config.toml`). After patching, a Codex UA carries e.g. `gpt-5.6-sol/high codex-cli/... codex-cli-wakatime/...`, which the existing derivation (#213) resolves to `openai` / `gpt-5.6-sol` and the default catalog (#214) prices.
- **`docs/codex-model-attribution.md`** — rationale, apply/revert, and design guarantees; cross-linked from `docs/ai-usage.md`.

## Design (per the "think about the approach" ask)
- **Idempotent** — regenerates the patched file from a pristine `.orig` backup each run (clean re-apply / upgrade, never a double patch).
- **Reversible** — `--revert` restores `.orig`; refuses rather than guess if a hand-patched file has no backup.
- **Version-guarded / upstream-aware** — patches only the recognized pristine `--plugin` line. If the vendor changes it (including adding model passthrough upstream), the anchor mismatches and the script `SKIP`s. Re-run after plugin updates.

## Verification
Exercised against a copy of the pristine plugin and the live install:
- apply → syntax valid, correct token output (`gpt-5.6-sol` → `gpt-5.6-sol/high`, no `s`-corruption), both hook-input and `config.toml` paths;
- idempotent re-run (`already up to date`);
- `--revert` restores a byte-identical pristine file;
- version guard `SKIP`s a changed `--plugin` line.

Dev tooling + docs only — no worker/runtime change, no deploy. `typecheck` clean; test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)