### PR TITLE
fix: resolve shipped default AI prices on the owner dashboard

### DIFF
--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -18,7 +18,6 @@ import {
   toMs,
   validateCreatePrice,
   validateUpdatePrice,
-  type AiModelPriceRow,
 } from "../utils/ai/pricing";
 import {
   applyPriceUpdate,
@@ -28,7 +27,7 @@ import {
   listEnabledPrices,
   listPrices,
 } from "../utils/ai/price-store";
-import { resolveDefaultPrices } from "../utils/ai/default-prices";
+import { resolveUsageDefaultPrices } from "../utils/ai/default-prices";
 import {
   AI_DAILY_USAGE_SELECT_COLUMNS,
   buildUsageSummary,
@@ -202,19 +201,13 @@ ai.get("/ai/usage", async (c) => {
       .bind(...binds)
       .all<AiDailyUsageRow>();
 
-    // Only enabled owner price rows participate in cost estimation.
+    // Enabled owner rows plus a shipped default for each (provider, model) the
+    // rollup actually used, so cost estimation covers models the owner has not
+    // priced. Owner rows still win in selectEffectivePrice; a model with no
+    // default stays unpriced (missing_price_count). The owner dashboard resolves
+    // defaults through the same helper (loadAiUsageSummary) — one path, no drift.
     const prices = await listEnabledPrices(c.env.DB, userId);
-    // Resolve a shipped default for each (provider, model) actually used, so cost
-    // estimation covers models the owner has not priced. Owner rows still win in
-    // selectEffectivePrice; an unresolved model stays unpriced (missing_price_count).
-    const resolved = new Set<string>();
-    const defaults: AiModelPriceRow[] = [];
-    for (const r of rows) {
-      const key = `${r.provider} ${r.model}`;
-      if (resolved.has(key)) continue;
-      resolved.add(key);
-      defaults.push(...resolveDefaultPrices(userId, r.provider, r.model));
-    }
+    const defaults = resolveUsageDefaultPrices(userId, rows);
 
     const summary = buildUsageSummary({
       start: range.start,

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -58,6 +58,7 @@ import {
   resolveUsageRange,
   type AiDailyUsageRow,
 } from "../utils/ai/usage";
+import { resolveUsageDefaultPrices } from "../utils/ai/default-prices";
 
 type WebEnv = {
   Bindings: Env;
@@ -496,7 +497,7 @@ async function loadAiUsageSummary(
   // The all-default range never errors; guard only to satisfy the type.
   const { start, end } = range.ok ? range : { start: "", end: "" };
 
-  const [usageRows, prices] = await Promise.all([
+  const [usageRows, ownerPrices] = await Promise.all([
     db
       .prepare(
         `SELECT ${AI_DAILY_USAGE_SELECT_COLUMNS} FROM ai_daily_usage
@@ -506,6 +507,11 @@ async function loadAiUsageSummary(
       .all<AiDailyUsageRow>(),
     listEnabledPrices(db, userId),
   ]);
+
+  // Merge a shipped default for each (provider, model) the rollup used so the
+  // dashboard estimates cost out of the box, before the owner prices anything —
+  // the same resolution the `/ai/usage` API applies (one shared helper, no drift).
+  const prices = [...ownerPrices, ...resolveUsageDefaultPrices(userId, usageRows.results)];
 
   return buildUsageSummary({
     start,

--- a/src/utils/ai/default-prices.ts
+++ b/src/utils/ai/default-prices.ts
@@ -201,6 +201,37 @@ export function resolveDefaultPrices(
 }
 
 /**
+ * Resolve the shipped default rows for every distinct (provider, model) that
+ * appears in `rows` (rollup buckets), deduplicated. Callers merge the result
+ * AFTER the owner's enabled rows — `[...ownerPrices, ...resolveUsageDefaultPrices(...)]`
+ * — so cost estimation covers models the owner has never priced while an owner
+ * row still outranks its default in `selectEffectivePrice`. A model with no
+ * shipped default contributes nothing and stays unpriced (`missing_price_count`),
+ * never a silent zero.
+ *
+ * Both cost surfaces price the same rollup rows, so this is their one shared
+ * default-resolution step: the `/ai/usage` API (`src/routes/ai.ts`) and the owner
+ * dashboard (`loadAiUsageSummary` in `src/routes/app.tsx`). It is a single helper
+ * on purpose — the dashboard once merged owner rows only and showed no estimated
+ * cost until an owner configured pricing, a drift a shared call site prevents.
+ */
+export function resolveUsageDefaultPrices(
+  userId: string,
+  rows: readonly { provider: string; model: string }[],
+): AiModelPriceRow[] {
+  const seen = new Set<string>();
+  const out: AiModelPriceRow[] = [];
+  for (const r of rows) {
+    // Collision-safe composite key: provider/model are unrestricted user text.
+    const key = JSON.stringify([r.provider, r.model]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(...resolveDefaultPrices(userId, r.provider, r.model));
+  }
+  return out;
+}
+
+/**
  * Representative default rows for the price-list UI (`GET /ai/prices`). Anthropic
  * entries are family-level (`claude-opus-*`), signalling they apply to every
  * version; OpenAI entries are the explicit per-version models. A family/model

--- a/tests/aggregation/ai-default-prices.test.ts
+++ b/tests/aggregation/ai-default-prices.test.ts
@@ -5,7 +5,11 @@
  * owner rows via the same selectEffectivePrice the cost path uses.
  */
 import { describe, expect, it } from "vitest";
-import { defaultPriceRows, resolveDefaultPrices } from "../../src/utils/ai/default-prices";
+import {
+  defaultPriceRows,
+  resolveDefaultPrices,
+  resolveUsageDefaultPrices,
+} from "../../src/utils/ai/default-prices";
 import { selectEffectivePrice } from "../../src/utils/ai/pricing";
 
 describe("resolveDefaultPrices — Anthropic by family (new versions covered)", () => {
@@ -137,5 +141,45 @@ describe("defaultPriceRows — representative rows for the price list UI", () =>
       expect(r.is_enabled).toBe(1);
       expect(r.currency).toBe("USD");
     }
+  });
+});
+
+describe("resolveUsageDefaultPrices — shared default resolution for used rollup rows", () => {
+  it("resolves one default set per distinct (provider, model), deduplicated", () => {
+    // Duplicate anthropic pair + a two-window sonnet + a priced OpenAI model.
+    const usage = [
+      { provider: "anthropic", model: "claude-opus-4-8" },
+      { provider: "anthropic", model: "claude-opus-4-8" },
+      { provider: "anthropic", model: "claude-sonnet-5" },
+      { provider: "openai", model: "gpt-5.5" },
+    ];
+    const out = resolveUsageDefaultPrices("u", usage);
+    // opus (1 window, once despite the dup) + sonnet (2 windows) + gpt-5.5 (1) = 4.
+    expect(out).toHaveLength(4);
+    expect(out.filter((r) => r.model === "claude-opus-4-8")).toHaveLength(1);
+    expect(out.filter((r) => r.model === "claude-sonnet-5")).toHaveLength(2);
+    expect(out.filter((r) => r.model === "gpt-5.5")).toHaveLength(1);
+    for (const r of out) expect(r.user_id).toBe("u");
+  });
+
+  it("covers a claude version with no explicit list entry via its family", () => {
+    // A future opus version the catalog never enumerated still prices from opus.
+    const out = resolveUsageDefaultPrices("u", [{ provider: "anthropic", model: "claude-opus-9-9" }]);
+    expect(out).toMatchObject([{ input_cost_per_mtok: 5, output_cost_per_mtok: 25 }]);
+  });
+
+  it("omits models with no shipped default (they stay unpriced → missing_price_count)", () => {
+    const out = resolveUsageDefaultPrices("u", [
+      { provider: "openai", model: "unknown" },
+      { provider: "anthropic", model: "claude-nova-1" },
+      { provider: "openai", model: "gpt-5.5" },
+    ]);
+    // Only gpt-5.5 resolves; the unpriced pairs contribute nothing.
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("returns an empty array for empty usage", () => {
+    expect(resolveUsageDefaultPrices("u", [])).toEqual([]);
   });
 });

--- a/tests/integration/app-ai-pricing.test.ts
+++ b/tests/integration/app-ai-pricing.test.ts
@@ -256,6 +256,40 @@ describe("dashboard AI token/cost summary", () => {
     expect(html).toContain("API-equivalent estimate, not a bill");
   });
 
+  it("prices from a shipped default when the owner has configured no prices", async () => {
+    // Reproduces the out-of-the-box dashboard: a rollup row for a model covered
+    // only by a shipped default (opus family, $5/Mtok input) and zero owner price
+    // rows. The dashboard must resolve the default and show a cost — not the
+    // "no enabled price row" notice. Regression: loadAiUsageSummary once merged
+    // owner rows only, so cost stayed unavailable until an owner priced manually.
+    const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
+    const today = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date());
+
+    await env.DB.prepare(
+      `INSERT INTO ai_daily_usage
+         (user_id, day, provider, model, agent, project, input_tokens, heartbeat_count)
+       VALUES (?, ?, 'anthropic', 'claude-opus-4-8', 'claude-code', 'cloudtime', 1000000, 3)`,
+    )
+      .bind(user.userId, today)
+      .run();
+
+    expect(await priceCount(user.userId)).toBe(0);
+
+    const res = await call("/app", {
+      headers: { Cookie: `__Host-session=${user.sessionToken}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // opus default input rate is $5/Mtok → 1,000,000 input tokens = USD 5.00.
+    expect(html).toContain("USD 5.00");
+    expect(html).not.toContain("No enabled price row matches this usage");
+  });
+
   it("shows an empty state when there is no rollup usage", async () => {
     const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
     const res = await call("/app", {


### PR DESCRIPTION
## Problem

On the owner dashboard, **AI Coding Activity → Estimated cost** shows `—` with the notice *"No enabled price row matches this usage"*, even though the shipped default catalog (opus/sonnet/fable, gpt-5.x) covers the models in use (`claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5`, `gpt-5.5`, `gpt-5.6-sol`).

## Root cause

The default prices (#214) are resolved per used `(provider, model)` at the call site, not merged inside the price store. The `/ai/usage` **JSON API** (`src/routes/ai.ts`) did this correctly, but the **dashboard's** server-side summary (`loadAiUsageSummary` in `src/routes/app.tsx`) passed only owner-created enabled rows to `buildUsageSummary` and never resolved defaults. With no owner-configured prices, every bucket went unmatched → `estimated_cost: null`. The two cost surfaces had drifted; only the dashboard was broken.

## Fix

- Extract the default-resolution step into one shared helper, `resolveUsageDefaultPrices(userId, rows)`, in `src/utils/ai/default-prices.ts`.
- Call it from **both** the dashboard (`loadAiUsageSummary`) and the `/ai/usage` route, so the two surfaces can't drift again.
- Owner rows still outrank defaults in `selectEffectivePrice`; a model with no shipped default stays unpriced (`missing_price_count`), never a silent zero.

## Incidental: NUL byte / EOL normalization in `ai.ts`

The old inline dedup key in `src/routes/ai.ts` contained a **literal NUL byte** (`` `${provider}\0${model}` ``). That made git treat the file as *binary*, so `core.autocrlf` skipped it and it was stored with CRLF while every other source file is LF. The refactor deletes that line, so the file normalizes CRLF → LF.

⚠️ **The `ai.ts` diff looks like a full-file rewrite — it is EOL-only.** The real change is the import plus ~7 lines. Review with **"Hide whitespace"** on GitHub, or locally:

```
git diff --ignore-cr-at-eol b9f2678..HEAD -- src/routes/ai.ts
```

## Tests

- Unit: `resolveUsageDefaultPrices` — dedup, family resolution (covers a version not in the explicit list), unpriced models omitted, empty input.
- Integration: dashboard renders a default-priced cost (`USD 5.00` for opus @ $5/Mtok) with **zero** owner price rows, and no longer shows the "no enabled price row" notice.
- `npm run typecheck` clean; full suite green (749 tests).

## Deploy note

There is no CD; production (`cloudtime.nagahama-91b.workers.dev`) updates via `wrangler deploy`. The dashboard cost will remain `—` until this is merged (`develop` → `master`) and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
