### PR TITLE
docs: align branch/deploy flow with reality (develop deploy; master = stable release line)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -110,8 +110,13 @@ All work follows the SDD workflow defined in `docs/development-flow.md`:
 
 ### Git Branching
 
-- `master` is production. Only updated via `develop` merge.
 - `develop` is the integration branch. All PRs MUST target `develop`.
+- During active development, the canonical live instance is deployed directly
+  from a `develop` checkout; `develop` is the deploy source, with no
+  `develop`→`master` gate on that path.
+- `master` is the stable release line for self-hosters, advanced only by a
+  deliberate `develop`→`master` merge (optionally tagged) when a release is
+  cut. It lags `develop` by design and is not the maintainer's deploy source.
 - Feature branches: `feat/`, `fix/`, `refactor/`, `spec/`.
 - All code, comments, commit messages, docs, and PR descriptions MUST be in English.
 
@@ -137,4 +142,16 @@ All work follows the SDD workflow defined in `docs/development-flow.md`:
 - All PRs and reviews MUST verify compliance with these principles.
 - Complexity MUST be justified against Principle V (Simplicity First).
 
-**Version**: 1.0.0 | **Ratified**: 2026-03-11 | **Last Amended**: 2026-03-11
+**Version**: 1.1.0 | **Ratified**: 2026-03-11 | **Last Amended**: 2026-07-15
+
+<!--
+Amendment 1.1.0 (2026-07-15) — Git Branching clarified (MINOR: material expansion).
+Rationale: the documented "master is production, updated via develop merge" gate did not
+match practice. During active development the maintainer deploys the canonical live instance
+directly from `develop`; `master` had not been advanced in months. Reframed the model by
+audience: `develop` = integration branch + maintainer deploy source; `master` = stable
+release line for self-hosters, advanced by a deliberate release cut.
+Migration plan: docs-only. No code, CI, or deploy-process change. `master` is left untouched
+(strictly behind `develop`, a clean fast-forward if/when the maintainer chooses to cut a
+release). Aligned CLAUDE.md and docs/development-flow.md in the same change.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,10 @@ Think in English, interact with the user in Japanese.
 
 ## Git Branching
 - PRs always target `develop` (never `master`)
-- `master` is production — only updated via `develop` merge
+- Deploy flow differs by audience (see `docs/development-flow.md` → "Branching & PR Strategy"):
+  - **Maintainer, active development:** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (`docs/deployment-guide.md`); there is no `develop`→`master` gate on this path. Rollback is by Worker version, not by git branch.
+  - **Self-hosters / general users:** `master` is the stable release line to self-host, advanced only by a deliberate `develop`→`master` merge (optionally tagged) when a release is cut — not the maintainer's deploy source.
+- `master` intentionally lags `develop` between releases; cutting a stable release is a maintainer decision (a `develop`→`master` merge/tag, currently a clean fast-forward)
 
 ## Code
 - Framework: Hono >= 4.9.7 on Cloudflare Workers (CVE-2025-58362, CVE-2025-59139)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Think in English, interact with the user in Japanese.
 ## Git Branching
 - PRs always target `develop` (never `master`)
 - Deploy flow differs by audience (see `docs/development-flow.md` → "Branching & PR Strategy"):
-  - **Maintainer, active development:** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (`docs/deployment-guide.md`); there is no `develop`→`master` gate on this path. Rollback is by Worker version, not by git branch.
+  - **Maintainer, active development:** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (`docs/deployment-guide.md`); there is no `develop`→`master` gate on this path. Roll back by Worker version, not by git branch. A Worker rollback does not revert D1, KV, or other resource changes, so deployments and migrations must remain rollback-compatible.
   - **Self-hosters / general users:** `master` is the stable release line to self-host, advanced only by a deliberate `develop`→`master` merge (optionally tagged) when a release is cut — not the maintainer's deploy source.
 - `master` intentionally lags `develop` between releases; cutting a stable release is a maintainer decision (a `develop`→`master` merge/tag, currently a clean fast-forward)
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -32,6 +32,11 @@ npm ci
 > [`development-flow.md`](./development-flow.md) → "Branching & PR Strategy"
 > for the full model.
 
+> **Rollback scope.** Roll back a deployed Worker by Worker version, not by
+> switching a Git branch. Cloudflare does not roll back D1, KV, or other resource
+> changes with the Worker version, so deploy backwards-compatible schema changes
+> and use your data-recovery plan when a rollback crosses a data change.
+
 Authenticate this workstation with Cloudflare:
 
 ```powershell

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -25,6 +25,13 @@ cd cloudtime
 npm ci
 ```
 
+> **Maintainer vs. self-hoster.** The maintainer deploys the canonical
+> instance directly from `develop`. If you self-host your own instance,
+> `master` is the intended stable release line and `develop` carries the
+> latest unreleased changes — check out the ref that fits your needs. See
+> [`development-flow.md`](./development-flow.md) → "Branching & PR Strategy"
+> for the full model.
+
 Authenticate this workstation with Cloudflare:
 
 ```powershell

--- a/docs/development-flow.md
+++ b/docs/development-flow.md
@@ -111,7 +111,7 @@ develop  ── integration branch + maintainer deploy source: all PRs target it
    └── ...
 ```
 
-- **Maintainer (active development).** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (see [`deployment-guide.md`](./deployment-guide.md)); there is no `develop`→`master` gate on this path. Rollback is by Worker version, not by git branch.
+- **Maintainer (active development).** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (see [`deployment-guide.md`](./deployment-guide.md)); there is no `develop`→`master` gate on this path. Roll back by Worker version, not by git branch. A Worker rollback does not revert D1, KV, or other resource changes, so deployments and migrations must remain rollback-compatible.
 - **Self-hosters / general users.** `master` is the stable release line to self-host. It is advanced only by a deliberate `develop`→`master` merge (optionally tagged) when the maintainer cuts a release, so it lags `develop` by design between releases. It is **not** the maintainer's deploy source.
 - **`develop`** is the integration branch. All PRs target `develop`.
 - **`master`** is the stable release line (above). Cutting a release = an intentional `develop`→`master` merge/tag.

--- a/docs/development-flow.md
+++ b/docs/development-flow.md
@@ -94,19 +94,27 @@ This is the critical case. If a reviewer discovers that the spec itself is wrong
 
 ## Branching & PR Strategy
 
+The branch model serves two audiences, and the deploy flow differs between them.
+
 ```
-master (production — deploy target)
-  │
-  └── develop (integration — PR target)
-        │
-        ├── feat/heartbeat-ingestion
-        ├── feat/timezone-support
-        ├── refactor/extract-helper
-        └── ...
+master   ── stable release line (self-hosters): advanced only by a deliberate
+   ▲          develop→master merge (optionally tagged) when a release is cut
+   │
+   │  release cut (maintainer decision; infrequent during active development)
+   │
+develop  ── integration branch + maintainer deploy source: all PRs target it,
+   │          and the canonical live instance ships directly from a develop checkout
+   │
+   ├── feat/heartbeat-ingestion
+   ├── feat/timezone-support
+   ├── refactor/extract-helper
+   └── ...
 ```
 
-- **`master`** is production. Only updated via `develop` merge.
+- **Maintainer (active development).** `develop` is both the integration branch and the deploy source. The canonical live instance is deployed directly from a `develop` checkout (see [`deployment-guide.md`](./deployment-guide.md)); there is no `develop`→`master` gate on this path. Rollback is by Worker version, not by git branch.
+- **Self-hosters / general users.** `master` is the stable release line to self-host. It is advanced only by a deliberate `develop`→`master` merge (optionally tagged) when the maintainer cuts a release, so it lags `develop` by design between releases. It is **not** the maintainer's deploy source.
 - **`develop`** is the integration branch. All PRs target `develop`.
+- **`master`** is the stable release line (above). Cutting a release = an intentional `develop`→`master` merge/tag.
 - **Feature branches** are named by type: `feat/`, `fix/`, `refactor/`, `spec/`.
 - **Spec-only PRs** are allowed when a feature needs spec review before implementation.
 - **One feature per PR** keeps reviews focused and feedback actionable.


### PR DESCRIPTION
## Summary

Reconcile the documented Git branching model with actual practice. The docs
stated "master is production — only updated via `develop` merge," but during
active development the maintainer deploys the canonical live instance directly
from a `develop` checkout, and `master` has been strictly behind `develop`
(0 ahead) with no release cut in months.

Per the owner's decision, this reframes the model **by audience** rather than
switching the deploy source:

- **Maintainer (active development).** `develop` is both the integration branch
  and the deploy source; the live instance ships directly from a `develop`
  checkout. There is no `develop`→`master` gate on this path. Rollback is by
  Worker version, not by git branch.
- **Self-hosters / general users.** `master` is the stable release line,
  advanced only by a deliberate `develop`→`master` merge (optionally tagged) at
  a release cut. It lags `develop` by design and is not the maintainer's deploy
  source.

## Changes

- `CLAUDE.md` — "## Git Branching" rewritten as the two-audience model.
- `docs/development-flow.md` — "Branching & PR Strategy" diagram + bullets updated.
- `docs/deployment-guide.md` — short maintainer-vs-self-hoster note added in the clone step.
- `.specify/memory/constitution.md` — Git Branching clarified; amended **1.0.0 → 1.1.0**
  (MINOR) per the governance protocol, with rationale + migration plan.

## Notes

- **Docs/process only** — no code, schema, CI, or deploy-behavior change.
- `master` is intentionally left untouched (still strictly behind `develop`, a
  clean fast-forward if/when a release is cut).
- The pre-existing working-tree change to `public/assets/app.css` is unrelated
  and excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
