### PR TITLE
feat: guide owners to fix unattributed AI model usage (Codex) — Issue #201 impl

### DIFF
--- a/src/ui/dashboard.tsx
+++ b/src/ui/dashboard.tsx
@@ -2,6 +2,7 @@ import { DataTable, EmptyState, MetricCard, Notice, Panel, ProgressRow } from ".
 import { RankedBarChart, VerticalBarChart, type ChartDatum } from "./charts";
 import type { EmbedSettings } from "../utils/embed-settings";
 import type { components } from "../types/generated";
+import { detectUnattributedTools, type AttributionStatus } from "../utils/ai/attribution";
 
 export type AiUsageSummary = components["schemas"]["AIUsageSummary"];
 export type AiTokenTotals = components["schemas"]["AITokenTotals"];
@@ -424,8 +425,56 @@ function UsageTile({ label, value, detail }: { label: string; value: string; det
   );
 }
 
+/**
+ * Actionable, non-intrusive setup guidance shown when recent AI usage is
+ * attributed to a known provider but an unknown model (Issue #201). It is an
+ * advisory `role="note"` (not an interrupting `alert`): it names the cause, gives
+ * the exact one-time local command for tools with tailored guidance (else generic
+ * troubleshooting), and links to the canonical instructions. It self-resolves —
+ * once no such usage remains in the window, `detectUnattributedTools` returns
+ * nothing and this renders null. It never shows a secret or client configuration.
+ */
+function AttributionGuidance({ status }: { status: AttributionStatus }) {
+  if (!status.hasUnattributed) return null;
+  return (
+    <div role="note" class="alert alert-info flex-col items-start gap-3 rounded-lg text-sm">
+      {status.affected.map((tool) => (
+        <div class="w-full space-y-1">
+          <div class="font-semibold">
+            {tool.tool} usage isn't attributed to a model ({formatHeartbeatCount(tool.heartbeatCount)})
+          </div>
+          {tool.hasTailoredGuidance && tool.command ? (
+            <>
+              <div>
+                {tool.tool} heartbeats currently arrive without the active model, so this usage
+                buckets under "unknown" and is left out of the estimated cost. Run this once on the
+                machine where you use {tool.tool}, then start a new {tool.tool} session:
+              </div>
+              <code class="block w-full overflow-x-auto rounded bg-base-300/60 px-2 py-1 font-mono text-xs">
+                {tool.command}
+              </code>
+            </>
+          ) : (
+            <div>
+              These {tool.provider} heartbeats arrive without a model, so this usage buckets under
+              "unknown" and is left out of the estimated cost.
+            </div>
+          )}
+          <div class="text-xs">
+            <a class="link" href={tool.docUrl} target="_blank" rel="noopener noreferrer">
+              {tool.hasTailoredGuidance ? `${tool.tool} model attribution setup` : "AI attribution troubleshooting"}
+            </a>{" "}
+            — you run this on your own machine; CloudTime only shows the steps.
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function AiUsageSummarySection({ usage }: { usage: AiUsageSummary }) {
   const totals = usage.totals;
+  const attribution = detectUnattributedTools(usage);
   const totalTokens = sumTokenClasses(totals);
   const hasUsage = totals.heartbeat_count > 0 || totalTokens > 0;
 
@@ -485,6 +534,7 @@ function AiUsageSummarySection({ usage }: { usage: AiUsageSummary }) {
               Some priced usage is in a different currency and is excluded from the {usage.currency} total.
             </Notice>
           ) : null}
+          <AttributionGuidance status={attribution} />
 
           <div class="grid gap-6 lg:grid-cols-2">
             <div class="space-y-3">

--- a/src/utils/ai/attribution.ts
+++ b/src/utils/ai/attribution.ts
@@ -1,0 +1,113 @@
+/**
+ * AI coding model-attribution detection (Issue #201, US1/US2). Pure: no D1, no I/O.
+ *
+ * Some AI clients send `ai coding` heartbeats that identify the provider but not
+ * the active model, so the rollup buckets them as `<provider>` / `"unknown"`
+ * (see `src/cron/aggregate.ts`, which coalesces a null `ai_model` to `"unknown"`).
+ * Those buckets cannot be priced and are surfaced to the owner as an actionable
+ * setup step in the dashboard (`src/ui/dashboard.tsx`).
+ *
+ * This module derives that state from the `AIUsageSummary` the dashboard already
+ * computes (`buildUsageSummary` → `by_model`) — no extra query, no stored state.
+ * It only *reads* the summary; pricing, aggregation, and ingestion are untouched.
+ *
+ * The canonical instructions live in the repository docs (CloudTime does not serve
+ * its docs as web pages), so the guidance links to their public URLs.
+ */
+import type { components } from "../../types/generated";
+
+type AIUsageSummary = components["schemas"]["AIUsageSummary"];
+
+/** The rollup's sentinel for a heartbeat whose model could not be derived. */
+const UNKNOWN = "unknown";
+
+/** Public, canonical instructions (the repo is the docs' canonical home). */
+const CODEX_DOC_URL =
+  "https://github.com/sudolifeagain/cloudtime/blob/develop/docs/codex-model-attribution.md";
+const GENERIC_DOC_URL =
+  "https://github.com/sudolifeagain/cloudtime/blob/develop/docs/ai-usage.md#deriving-provider-and-model-from-the-user-agent";
+
+/**
+ * Provider-specific ("tailored") guidance. A provider listed here has a concrete
+ * one-time client-side fix; a provider absent here gets generic troubleshooting
+ * with no command (FR-009). Keyed by the `ai_provider` value the rollup stores.
+ */
+const TAILORED_GUIDANCE: Record<string, { tool: string; command: string; docUrl: string }> = {
+  openai: {
+    tool: "Codex",
+    command: "node scripts/patch-codex-wakatime.mjs",
+    docUrl: CODEX_DOC_URL,
+  },
+};
+
+/** One provider whose recent usage is model-unknown, plus the guidance to show. */
+export interface UnattributedTool {
+  /** The known provider (e.g. `"openai"`); never `"unknown"`. */
+  provider: string;
+  /** Human tool name for copy (e.g. `"Codex"`); the provider itself when unmapped. */
+  tool: string;
+  /** Recent heartbeats (in the summary window) attributed to this provider but no model. */
+  heartbeatCount: number;
+  /** Whether a provider-specific command exists (else generic troubleshooting only). */
+  hasTailoredGuidance: boolean;
+  /** Exact one-time local command for tailored providers, else `null`. */
+  command: string | null;
+  /** Canonical public instructions URL. */
+  docUrl: string;
+}
+
+/** Derived attribution state for the dashboard. Not persisted. */
+export interface AttributionStatus {
+  hasUnattributed: boolean;
+  affected: UnattributedTool[];
+}
+
+/**
+ * Detect providers whose recent usage is "provider-known, model-unknown", folded
+ * to one entry per provider and sorted by provider for a stable render.
+ *
+ * A `by_model` group is affected when `provider !== "unknown"` (the tool is
+ * identifiable) AND `model === "unknown"` (its model is not) AND `heartbeat_count > 0`.
+ * A group whose provider is itself `"unknown"` is skipped: with no identifiable
+ * tool there is nothing actionable to guide.
+ *
+ * Pure and windowed by construction — it reflects only the summary it is given, so
+ * a fixed pile of out-of-window historical unknowns stops surfacing once it ages
+ * out of that summary (FR-006/FR-007). Multiple same-provider groups fold and their
+ * counts sum.
+ */
+export function detectUnattributedTools(summary: AIUsageSummary): AttributionStatus {
+  const counts = new Map<string, number>();
+  for (const group of summary.by_model) {
+    if (group.provider === UNKNOWN || group.model !== UNKNOWN || group.heartbeat_count <= 0) {
+      continue;
+    }
+    counts.set(group.provider, (counts.get(group.provider) ?? 0) + group.heartbeat_count);
+  }
+
+  const affected: UnattributedTool[] = [...counts.entries()]
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .map(([provider, heartbeatCount]) => {
+      const tailored = TAILORED_GUIDANCE[provider];
+      if (tailored) {
+        return {
+          provider,
+          tool: tailored.tool,
+          heartbeatCount,
+          hasTailoredGuidance: true,
+          command: tailored.command,
+          docUrl: tailored.docUrl,
+        };
+      }
+      return {
+        provider,
+        tool: provider,
+        heartbeatCount,
+        hasTailoredGuidance: false,
+        command: null,
+        docUrl: GENERIC_DOC_URL,
+      };
+    });
+
+  return { hasUnattributed: affected.length > 0, affected };
+}

--- a/tests/aggregation/ai-attribution.test.ts
+++ b/tests/aggregation/ai-attribution.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for AI model-attribution detection (Issue #201, US1/US2).
+ *
+ * `detectUnattributedTools` is pure over an `AIUsageSummary`; only the `by_model`
+ * groups matter, so each case crafts a minimal summary with a zeroed totals base.
+ * The rollup coalesces a null `ai_model` to the literal `"unknown"` (the column is
+ * `NOT NULL`), so the "unattributed" sentinel under test is the string `"unknown"`.
+ */
+import { describe, expect, it } from "vitest";
+import { detectUnattributedTools } from "../../src/utils/ai/attribution";
+import type { components } from "../../src/types/generated";
+
+type AIUsageSummary = components["schemas"]["AIUsageSummary"];
+type AITokenTotals = components["schemas"]["AITokenTotals"];
+
+const ZERO_TOTALS: AITokenTotals = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cached_input_tokens: 0,
+  reasoning_output_tokens: 0,
+  cache_write_tokens: 0,
+  cache_read_tokens: 0,
+  prompt_length_total: 0,
+  prompt_length_avg: null,
+  heartbeat_count: 0,
+  estimated_cost: null,
+  missing_price_count: 0,
+};
+
+/** A minimal summary whose only meaningful content is its `by_model` groups. */
+function summaryWith(
+  byModel: Array<{ provider: string; model: string; heartbeat_count?: number }>,
+): AIUsageSummary {
+  return {
+    start: "2026-07-01",
+    end: "2026-07-30",
+    timezone: "UTC",
+    currency: "USD",
+    totals: { ...ZERO_TOTALS },
+    daily: [],
+    by_project: [],
+    by_agent: [],
+    by_provider: [],
+    by_model: byModel.map((m) => ({
+      ...ZERO_TOTALS,
+      provider: m.provider,
+      model: m.model,
+      heartbeat_count: m.heartbeat_count ?? 1,
+    })),
+  };
+}
+
+describe("detectUnattributedTools", () => {
+  it("flags an openai/unknown group with tailored Codex guidance", () => {
+    const status = detectUnattributedTools(
+      summaryWith([{ provider: "openai", model: "unknown", heartbeat_count: 2 }]),
+    );
+    expect(status.hasUnattributed).toBe(true);
+    expect(status.affected).toHaveLength(1);
+    expect(status.affected[0]).toMatchObject({
+      provider: "openai",
+      tool: "Codex",
+      heartbeatCount: 2,
+      hasTailoredGuidance: true,
+      command: "node scripts/patch-codex-wakatime.mjs",
+    });
+    expect(status.affected[0].docUrl).toContain("codex-model-attribution.md");
+  });
+
+  it("does not flag usage that already carries a concrete model", () => {
+    const status = detectUnattributedTools(
+      summaryWith([{ provider: "anthropic", model: "claude-opus-4-8", heartbeat_count: 5 }]),
+    );
+    expect(status.hasUnattributed).toBe(false);
+    expect(status.affected).toEqual([]);
+  });
+
+  it("skips a group whose provider is itself unknown (nothing actionable to guide)", () => {
+    const status = detectUnattributedTools(
+      summaryWith([{ provider: "unknown", model: "unknown", heartbeat_count: 3 }]),
+    );
+    expect(status.hasUnattributed).toBe(false);
+  });
+
+  it("gives generic guidance (no command) for a recognized but unmapped provider", () => {
+    const status = detectUnattributedTools(
+      summaryWith([{ provider: "example-provider", model: "unknown", heartbeat_count: 4 }]),
+    );
+    expect(status.affected).toHaveLength(1);
+    expect(status.affected[0]).toMatchObject({
+      provider: "example-provider",
+      tool: "example-provider",
+      hasTailoredGuidance: false,
+      command: null,
+    });
+    expect(status.affected[0].docUrl).toContain("ai-usage.md");
+  });
+
+  it("folds multiple same-provider unknown groups and sums their counts", () => {
+    const status = detectUnattributedTools(
+      summaryWith([
+        { provider: "openai", model: "unknown", heartbeat_count: 2 },
+        { provider: "openai", model: "unknown", heartbeat_count: 3 },
+      ]),
+    );
+    expect(status.affected).toHaveLength(1);
+    expect(status.affected[0].heartbeatCount).toBe(5);
+  });
+
+  it("ignores a zero-heartbeat unknown group alongside attributed usage", () => {
+    const status = detectUnattributedTools(
+      summaryWith([
+        { provider: "openai", model: "gpt-5.6-sol", heartbeat_count: 10 },
+        { provider: "openai", model: "unknown", heartbeat_count: 0 },
+      ]),
+    );
+    expect(status.hasUnattributed).toBe(false);
+  });
+
+  it("sorts multiple affected providers by provider for a stable render", () => {
+    const status = detectUnattributedTools(
+      summaryWith([
+        { provider: "openai", model: "unknown", heartbeat_count: 1 },
+        { provider: "acme", model: "unknown", heartbeat_count: 1 },
+      ]),
+    );
+    expect(status.affected.map((a) => a.provider)).toEqual(["acme", "openai"]);
+  });
+
+  it("returns nothing for an empty summary", () => {
+    expect(detectUnattributedTools(summaryWith([])).hasUnattributed).toBe(false);
+  });
+});

--- a/tests/integration/app-ai-attribution.test.ts
+++ b/tests/integration/app-ai-attribution.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration tests for the dashboard AI model-attribution guidance (Issue #201,
+ * US1/US2). Renders the real owner dashboard (`GET /app`, session-cookie auth)
+ * against in-memory D1 and asserts the guided setup step shows only when recent
+ * usage is provider-known / model-unknown, and hides otherwise. Mirrors the setup
+ * in `app-ai-pricing.test.ts`.
+ */
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import worker from "../../src/index";
+import { seedUserWithSession, truncate } from "../helpers/fixtures";
+
+const BASE = "https://test.cloudtime.dev";
+/** Unique to the tailored Codex guidance — a reliable present/absent marker. */
+const GUIDANCE_MARKER = "node scripts/patch-codex-wakatime.mjs";
+
+afterEach(async () => {
+  await truncate("ai_daily_usage", "sessions", "users");
+  const keys = await env.KV.list();
+  await Promise.all(keys.keys.map((key) => env.KV.delete(key.name)));
+});
+
+/** `YYYY-MM-DD` in UTC, `offsetDays` from today (negative = past). */
+function utcDay(offsetDays = 0): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(Date.now() + offsetDays * 86_400_000));
+}
+
+async function seedUsage(
+  userId: string,
+  row: { day: string; provider: string; model: string; heartbeats?: number },
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO ai_daily_usage
+       (user_id, day, provider, model, agent, project, input_tokens, heartbeat_count)
+     VALUES (?, ?, ?, ?, 'codex-cli', 'cloudtime', 1000, ?)`,
+  )
+    .bind(userId, row.day, row.provider, row.model, row.heartbeats ?? 2)
+    .run();
+}
+
+async function getDashboard(sessionToken: string): Promise<string> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`${BASE}/app`, { headers: { Cookie: `__Host-session=${sessionToken}` } }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+describe("dashboard AI attribution guidance", () => {
+  it("shows the Codex setup guidance for recent openai/unknown usage", async () => {
+    const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
+    // The rollup stores the literal "unknown" sentinel for a null model.
+    await seedUsage(user.userId, { day: utcDay(0), provider: "openai", model: "unknown", heartbeats: 2 });
+
+    const html = await getDashboard(user.sessionToken);
+    expect(html).toContain(GUIDANCE_MARKER);
+    expect(html).toContain("codex-model-attribution.md");
+    expect(html).toContain("Codex");
+  });
+
+  it("hides the guidance when usage already carries a concrete model", async () => {
+    const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
+    await seedUsage(user.userId, {
+      day: utcDay(0),
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      heartbeats: 5,
+    });
+
+    const html = await getDashboard(user.sessionToken);
+    expect(html).toContain("Token usage"); // AI panel rendered
+    expect(html).not.toContain(GUIDANCE_MARKER);
+  });
+
+  it("does not nag on out-of-window historical unknowns", async () => {
+    const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
+    // In-window attributed usage keeps the AI panel populated...
+    await seedUsage(user.userId, {
+      day: utcDay(0),
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      heartbeats: 5,
+    });
+    // ...while an old openai/unknown row sits outside the trailing ~30-day window.
+    await seedUsage(user.userId, { day: utcDay(-45), provider: "openai", model: "unknown", heartbeats: 9 });
+
+    const html = await getDashboard(user.sessionToken);
+    expect(html).not.toContain(GUIDANCE_MARKER);
+  });
+
+  it("does not show guidance for an owner with no AI usage", async () => {
+    const user = await seedUserWithSession({ username: "owner", timezone: "UTC" });
+    const html = await getDashboard(user.sessionToken);
+    expect(html).not.toContain(GUIDANCE_MARKER);
+  });
+});


### PR DESCRIPTION
## PR2 of 2 — Implementation (Issue #201)

Implements the AI coding **model-attribution onboarding** designed in PR1 (spec + design, merged). This is the **P1/P2 MVP, presentation-only**: no new endpoint, no stored state, **no OpenAPI/generated-types change**.

### What it does

When recent AI coding usage is attributed to a known provider but an **unknown model**, the owner dashboard now shows an actionable, self-resolving setup step in the AI panel.

- **Codex today** (`openai`/unknown, because Codex heartbeats don't carry the model): explains the cause, shows the exact one-time local command `node scripts/patch-codex-wakatime.mjs`, and links to the canonical instructions.
- **Auto-resolves**: the step is derived from the trailing-window summary, so it disappears once no unknown usage remains — and out-of-window historical unknowns never nag (FR-006/FR-007).
- **Generic fallback**: a recognized-but-unmapped provider gets generic troubleshooting with **no** command; a provider-specific command is never cross-shown (FR-009).
- **No client automation**: the copy states plainly the fix runs on the owner's machine; the server only shows steps (FR-003). No secret or client config is ever shown (FR-004).

### How (matches the merged plan)

- `src/utils/ai/attribution.ts` — pure `detectUnattributedTools(summary)` over the `AIUsageSummary` the dashboard already computes (`by_model`). Predicate: `provider !== "unknown" && model === "unknown" && heartbeat_count > 0`, folded per provider. **No new D1 query, no stored state.**
- `src/ui/dashboard.tsx` — renders the guidance near the existing `missing_price_count` notice.

### Accessibility & UX — researched best practices applied

- Rendered as `role="note"` (advisory / ancillary content), **not** `role="alert"` — an informational setup hint shouldn't assertively interrupt the screen-reader (alert = `aria-live="assertive"`; status/note is polite/advisory). It doesn't steal focus or force dismissal. Sources: [MDN `alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role), [MDN `status` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role), [Sara Soueidan — Accessible notifications with ARIA live regions](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/).
- Contextual, actionable, non-intrusive, and self-resolving (progressive disclosure) — surface guidance where/when it's relevant, one clear CTA, dismiss by fixing. Sources: [Appcues — Onboarding UX patterns](https://www.appcues.com/blog/user-onboarding-ui-ux-patterns), [Chameleon — Onboarding UX patterns](https://www.chameleon.io/blog/onboarding-ux-patterns).
- Command in a `<code>` block; descriptive external link with `rel="noopener noreferrer"`.

### Constitution compliance

Presentation-only (Principle V); reuses the already-loaded summary, no request-path D1 query (Principle II); uses generated types (Principle III); copy is original and avoids the WakaTime name entirely (Principle IV); no contract change so nothing to spec-first (Principle I).

### Tests (full suite green — 761)

- **Unit** `tests/aggregation/ai-attribution.test.ts` — tailored (Codex) vs generic vs skip-unknown-provider, fold+sum, zero-heartbeat guard, sort, empty.
- **Integration** `tests/integration/app-ai-attribution.test.ts` — `/app` render: shown for recent `openai`/unknown; hidden for attributed-only, out-of-window historical, and no-usage.

### Out of scope (isolated follow-ups, per design)

Persisted "dismiss forever" (would add storage + an endpoint → spec-first) and the P3 proactive first-run onboarding.

### Verifying live

The canonical instance currently has recent `openai`/unknown usage (the 2 pre-patch Codex heartbeats), so once deployed the step will render on the real dashboard and then clear as that usage ages out of the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
